### PR TITLE
Provide Wrapper Types for GDAL handles

### DIFF
--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -1,10 +1,10 @@
 function Base.show(io::IO, drv::Driver)
-    drv.ptr == C_NULL && (print(io, "NULL Driver"); return)
+    drv.ptr == C_NULL && (return print(io, "NULL Driver"))
     print(io, "Driver: $(shortname(drv))/$(longname(drv))")
 end
 
 function Base.show(io::IO, dataset::Dataset)
-    dataset.ptr == C_NULL && (print(io, "NULL Dataset"); return)
+    dataset.ptr == C_NULL && (return print(io, "NULL Dataset"))
     println(io, "GDAL Dataset ($(getdriver(dataset)))")
     println(io, "File(s): ")
     for (i,filename) in enumerate(filelist(dataset))
@@ -47,7 +47,7 @@ function Base.show(io::IO, dataset::Dataset)
 end
 
 function summarize(io::IO, rasterband::RasterBand)
-    rasterband.ptr == C_NULL && (print(io, "NULL RasterBand"); return)
+    rasterband.ptr == C_NULL && (return print(io, "NULL RasterBand"))
     access = getaccess(rasterband)
     color = getname(getcolorinterp(rasterband))
     xsize = width(rasterband)
@@ -58,7 +58,7 @@ function summarize(io::IO, rasterband::RasterBand)
 end
 
 function Base.show(io::IO, rasterband::RasterBand)
-    rasterband.ptr == C_NULL && (print(io, "NULL RasterBand"); return)
+    rasterband.ptr == C_NULL && (return print(io, "NULL RasterBand"))
     summarize(io, rasterband)
     (x,y) = getblocksize(rasterband)
     sc = getscale(rasterband)
@@ -78,7 +78,7 @@ end
 
 # assumes that the layer is reset, and will reset it after display
 function Base.show(io::IO, layer::FeatureLayer)
-    layer.ptr == C_NULL && (println(io, "NULL Layer"); return)
+    layer.ptr == C_NULL && (return println(io, "NULL Layer"))
     layergeomtype = getgeomtype(layer)
     println(io, "Layer: $(getname(layer))")
     featuredefn = getlayerdefn(layer)
@@ -139,7 +139,7 @@ function Base.show(io::IO, layer::FeatureLayer)
 end
 
 function Base.show(io::IO, featuredefn::FeatureDefn)
-    featuredefn.ptr == C_NULL && (print(io, "NULL FeatureDefn"); return)
+    featuredefn.ptr == C_NULL && (return print(io, "NULL FeatureDefn"))
     n = ngeomfield(featuredefn)
     ngeomdisplay = min(n, 3)
     for i in 1:ngeomdisplay
@@ -158,7 +158,7 @@ function Base.show(io::IO, featuredefn::FeatureDefn)
 end
 
 function Base.show(io::IO, fd::FieldDefn)
-    fd.ptr == C_NULL && (print(io, "NULL FieldDefn"); return)
+    fd.ptr == C_NULL && (return print(io, "NULL FieldDefn"))
     print(io, "$(getname(fd)) ($(gettype(fd)))")
 end
 
@@ -168,7 +168,7 @@ function Base.show(io::IO, gfd::GeomFieldDefn)
 end
 
 function Base.show(io::IO, feature::Feature)
-    feature.ptr == C_NULL && (println(io, "NULL Feature"); return)
+    feature.ptr == C_NULL && (return println(io, "NULL Feature"))
     println(io, "Feature")
     n = ngeomfield(feature)
     for i in 1:min(n, 3)

--- a/src/context.jl
+++ b/src/context.jl
@@ -71,7 +71,7 @@ for gdalfunc in (
         :createstyletool, :delaunaytriangulation, :difference, :forceto,
         :fromEPSG, :fromEPSGA, :fromESRI, :fromGML, :fromJSON, :fromPROJ4,
         :fromURL, :fromWKB, :fromWKT, :fromXML, :getcurvegeom, :getfeature,
-        :getlineargeom, :intersection, :newspatialref, :nextfeature,
+        :getlineargeom, :getpart, :intersection, :newspatialref, :nextfeature,
         :pointalongline, :pointonsurface, :polygonfromedges, :polygonize, :read,
         :simplify, :simplifypreservetopology, :symdifference, :union, :update
     )

--- a/src/context.jl
+++ b/src/context.jl
@@ -46,7 +46,7 @@ end
 
 function createfeature(f::Function, layer::FeatureLayer)
     feature = unsafe_createfeature(layer)
-    try f(feature); createfeature(layer, feature) finally destroy(feature) end
+    try f(feature); createfeature!(layer, feature) finally destroy(feature) end
 end
 
 function createfeature(f::Function, featuredefn::FeatureDefn)
@@ -60,21 +60,21 @@ function createfeature(f::Function, featuredefn::FeatureDefn)
     try f(feature) finally destroy(feature); dereference(featuredefn) end
 end
 
-for gdalfunc in (:boundary, :buffer, :centroid, :clone, :convexhull, :create,
-                 :createcolortable, :createcoordtrans, :createcopy,
-                 :createfeaturedefn, :createfielddefn, :creategeom,
-                 :creategeomcollection, :creategeomfieldcollection,
-                 :creategeomfielddefn, :createlinearring, :createlinestring,
-                 :createmultilinestring, :createmultipoint, :createmultipolygon,
-                 :createmultipolygon_noholes, :createpoint, :createpolygon,
-                 :createRAT, :createstylemanager, :createstyletable,
-                 :createstyletool, :delaunaytriangulation, :difference,
-                 :forceto, :fromEPSG, :fromEPSGA, :fromESRI, :fromGML,
-                 :fromJSON, :fromPROJ4, :fromURL, :fromWKB, :fromWKT, :fromXML,
-                 :getcurvegeom, :getfeature, :getlineargeom, :intersection,
-                 :newspatialref, :nextfeature, :pointalongline, :pointonsurface,
-                 :polygonfromedges, :polygonize, :read, :symdifference, :union,
-                 :update)
+for gdalfunc in (
+        :boundary, :buffer, :centroid, :clone, :convexhull, :create,
+        :createcolortable, :createcoordtrans, :createcopy, :createfeaturedefn,
+        :createfielddefn, :creategeom, :creategeomcollection,
+        :creategeomfieldcollection, :creategeomfielddefn, :createlinearring,
+        :createlinestring, :createmultilinestring, :createmultipoint,
+        :createmultipolygon, :createmultipolygon_noholes, :createpoint,
+        :createpolygon, :createRAT, :createstylemanager, :createstyletable,
+        :createstyletool, :delaunaytriangulation, :difference, :forceto,
+        :fromEPSG, :fromEPSGA, :fromESRI, :fromGML, :fromJSON, :fromPROJ4,
+        :fromURL, :fromWKB, :fromWKT, :fromXML, :getcurvegeom, :getfeature,
+        :getlineargeom, :intersection, :newspatialref, :nextfeature,
+        :pointalongline, :pointonsurface, :polygonfromedges, :polygonize, :read,
+        :simplify, :simplifypreservetopology, :symdifference, :union, :update
+    )
     eval(quote
         function $(gdalfunc)(f::Function, args...; kwargs...)
             obj = $(Symbol("unsafe_$gdalfunc"))(args...; kwargs...)

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -1,45 +1,41 @@
 "Fetch driver by index"
-getdriver(i::Integer) = GDAL.getdriver(i)
+getdriver(i::Integer) = Driver(GDAL.getdriver(i))
 
 "Fetch a driver based on the short name (such as `GTiff`)."
-getdriver(name::AbstractString) = GDAL.getdriverbyname(name)
+getdriver(name::AbstractString) = Driver(GDAL.getdriverbyname(name))
 
 """
 Destroy a `GDALDriver`.
 
-This is roughly equivelent to deleting the driver, but is guaranteed to take
+This is roughly equivalent to deleting the driver, but is guaranteed to take
 place in the GDAL heap. It is important this that function not be called on a
 driver that is registered with the `GDALDriverManager`.
 """
-destroy(drv::Driver) = GDAL.destroydriver(drv)
+destroy(drv::Driver) = (GDAL.destroydriver(drv.ptr); drv.ptr = C_NULL)
 
 "Register a driver for use."
-register(drv::Driver) = GDAL.registerdriver(drv)
+register(drv::Driver) = GDAL.registerdriver(drv.ptr)
 
 "Deregister the passed drv."
-deregister(drv::Driver) = GDAL.deregisterdriver(drv)
+deregister(drv::Driver) = GDAL.deregisterdriver(drv.ptr)
 
 "Return the list of creation options of the driver [an XML string]"
-options(drv::Driver) = GDAL.getdrivercreationoptionlist(drv)
-options(name::AbstractString) = options(getdriver(name))
+options(drv::Driver) = GDAL.getdrivercreationoptionlist(drv.ptr)
+driveroptions(name::AbstractString) = options(getdriver(name))
 
 "Return the short name of a driver (e.g. `GTiff`)"
-shortname(drv::Driver) = GDAL.getdrivershortname(drv)
+shortname(drv::Driver) = GDAL.getdrivershortname(drv.ptr)
 
 "Return the long name of a driver (e.g. `GeoTIFF`), or empty string."
-longname(drv::Driver) = GDAL.getdriverlongname(drv)
+longname(drv::Driver) = GDAL.getdriverlongname(drv.ptr)
 
 "Fetch the number of registered drivers."
 ndriver() = GDAL.getdrivercount()
 
 "Returns a listing of all registered drivers"
-function drivers()
-    dlist = Dict{String,String}()
-    for i in 0:(ndriver()-1)
-        dlist[shortname(getdriver(i))] = longname(getdriver(i))
-    end
-    dlist
-end
+listdrivers() = Dict{String,String}([
+    shortname(getdriver(i)) => longname(getdriver(i)) for i in 0:(ndriver()-1)
+])
 
 """
 Identify the driver that can open a raster file.
@@ -49,7 +45,8 @@ by invoking the Identify method of each registered `GDALDriver` in turn. The
 first driver that successful identifies the file name will be returned. If all
 drivers fail then `NULL` is returned.
 """
-identifydriver(filename::AbstractString) = GDAL.identifydriver(filename, C_NULL)
+identifydriver(filename::AbstractString) =
+    Driver(GDAL.identifydriver(filename, C_NULL))
 
 """
 Validate the list of creation options that are handled by a drv.
@@ -65,8 +62,8 @@ validate that the passed in list of creation options is compatible with the
             element is a `NULL` pointer
 
 ### Returns
-`TRUE` if the list of creation options is compatible with the `create()` and
-`createCopy()` method of the driver, `FALSE` otherwise.
+`true` if the list of creation options is compatible with the `create()` and
+`createCopy()` method of the driver, `false` otherwise.
 
 ### Additional Remarks
 See also: `options(drv::Driver)`
@@ -78,18 +75,17 @@ by the `GDAL_DMD_CREATIONOPTIONLIST` metadata item. In case of incompatibility
 a (non fatal) warning will be emited and `FALSE` will be returned.
 """
 validate{T <: AbstractString}(drv::Driver, options::Vector{T}) = 
-    Bool(ccall((:GDALValidateCreationOptions,GDAL.libgdal),Cint,
-               (Driver,StringList),drv,options))
+    Bool(@gdal(GDALValidateCreationOptions::Cint,
+        drv.ptr::GDALDriver,
+        options::StringList
+    ))
 
 "Copy all the files associated with a dataset."
-function copyfiles(drv::Driver,
-                   newname::AbstractString,
-                   oldname::AbstractString)
-    result = GDAL.copydatasetfiles(drv, newname, oldname)
+function copyfiles(drv::Driver, new::AbstractString, old::AbstractString)
+    result = GDAL.copydatasetfiles(drv.ptr, new, old)
     @cplerr result "Failed to copy dataset files"
 end
 
 "Copy all the files associated with a dataset."
-copyfiles(drvname::AbstractString, newname::AbstractString,
-          oldname::AbstractString) =
-    copyfiles(getdriver(drvname), newname, oldname)
+copyfiles(drvname::AbstractString, new::AbstractString, old::AbstractString) =
+    copyfiles(getdriver(drvname), new, old)

--- a/src/gcp.jl
+++ b/src/gcp.jl
@@ -9,7 +9,7 @@ converts the equation from being pixel to geo to being geo to pixel.
 * `gt_out`      Output geotransform (six doubles - updated).
 
 ### Returns
-`TRUE` on success or `FALSE` if the equation is uninvertable.
+`gt_out`
 """
 function invgeotransform!(gt_in::Vector{Cdouble}, gt_out::Vector{Cdouble})
     result = Bool(GDAL.invgeotransform(pointer(gt_in), pointer(gt_out)))
@@ -38,7 +38,7 @@ function applygeotransform(geotransform::Vector{Cdouble},
                            pixel::Cdouble,
                            line::Cdouble)
     geo_xy = Array(Cdouble, 2)
-    geo_x = pointer(geo_xy);
+    geo_x = pointer(geo_xy)
     geo_y = geo_x + sizeof(Cdouble)
     GDAL.applygeotransform(pointer(geotransform), pixel, line, geo_x, geo_y)
     geo_xy

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -252,7 +252,9 @@ the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief.
 """
 asstringlist(feature::Feature, i::Integer) =
-    unsafe_loadstringlist(GDAL.C.OGR_F_GetFieldAsStringList(feature.ptr, i))
+    unsafe_loadstringlist(
+        GDAL.C.OGR_F_GetFieldAsStringList(Ptr{Void}(feature.ptr), Cint(i))
+    )
 
 """
     OGR_F_GetFieldAsBinary(OGRFeatureH hFeat,
@@ -466,7 +468,7 @@ field types may be unaffected.
 * `panValues`: the values to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Vector{GDAL.GIntBig}) =
-    (GDAL.setfieldintegerlist(feature.ptr, i, length(value), value); feature)
+    (GDAL.setfieldinteger64list(feature.ptr, i, length(value), value); feature)
 
 """
 Set field to list of doubles value.

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -4,7 +4,7 @@ Duplicate feature.
 The newly created feature is owned by the caller, and will have it's own
 reference to the OGRFeatureDefn.
 """
-unsafe_clone(feature::Feature) = GDAL.clone(feature)
+unsafe_clone(feature::Feature) = Feature(GDAL.clone(feature.ptr))
 
 """
 Destroy the feature passed in.
@@ -15,7 +15,7 @@ to delete a feature created within the DLL. If the delete is done in the calling
 application the memory will be freed onto the application heap which is
 inappropriate.
 """
-destroy(feature::Feature) = GDAL.destroy(feature)
+destroy(feature::Feature) = (GDAL.destroy(feature.ptr); feature.ptr = C_NULL)
 
 """
 Set feature geometry.
@@ -29,7 +29,7 @@ OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry
 type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function setgeomdirectly!(feature::Feature, geom::Geometry)
-    result = GDAL.setgeometrydirectly(feature, geom)
+    result = GDAL.setgeometrydirectly(feature.ptr, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry."
 end
 
@@ -49,19 +49,19 @@ OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry
 type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function setgeom!(feature::Feature, geom::Geometry)
-    result = GDAL.setgeometry(feature, geom)
+    result = GDAL.setgeometry(feature.ptr, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry."
 end
 
 "Fetch an handle to internal feature geometry. It should not be modified."
-getgeom(feature::Feature) = GDAL.getgeometryref(feature)
+getgeom(feature::Feature) = Geometry(GDAL.getgeometryref(feature.ptr))
 
 """
 Fetch number of fields on this feature.
 
 This will always be the same as the field count for the OGRFeatureDefn.
 """
-nfield(feature::Feature) = GDAL.getfieldcount(feature)
+nfield(feature::Feature) = GDAL.getfieldcount(feature.ptr)
 
 """
 Fetch definition for this field.
@@ -75,7 +75,7 @@ an handle to the field definition (from the OGRFeatureDefn). This is an
 internal reference, and should not be deleted or modified.
 """
 getfielddefn(feature::Feature, i::Integer) =
-    GDAL.getfielddefnref(feature, i)
+    FieldDefn(GDAL.getfielddefnref(feature.ptr, i))
 
 # fetchfields(feature::Feature) =
 #     Dict(getname(borrowfieldefn(feature, i-1)) => fetchfield(feature, i-1)
@@ -111,7 +111,7 @@ This is a cover for the OGRFeatureDefn::GetFieldIndex() method.
 the field index, or -1 if no matching field is found.
 """
 getfieldindex(feature::Feature, name::AbstractString) =
-    GDAL.getfieldindex(feature, name)
+    GDAL.getfieldindex(feature.ptr, name)
 
 """Test if a field has ever been assigned a value or not.
 
@@ -119,7 +119,7 @@ getfieldindex(feature::Feature, name::AbstractString) =
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-isfieldset(feature::Feature, i::Integer) = Bool(GDAL.isfieldset(feature, i))
+isfieldset(feature::Feature, i::Integer) = Bool(GDAL.isfieldset(feature.ptr, i))
 
 """
 Clear a field, marking it as unset.
@@ -128,7 +128,8 @@ Clear a field, marking it as unset.
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-unsetfield!(feature::Feature, i::Integer) = GDAL.unsetfield(feature, i)
+unsetfield!(feature::Feature, i::Integer) =
+    (GDAL.unsetfield(feature.ptr, i); feature)
 
 # """
 #     OGR_F_GetRawFieldRef(OGRFeatureH hFeat,
@@ -152,7 +153,7 @@ unsetfield!(feature::Feature, i::Integer) = GDAL.unsetfield(feature, i)
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-asint(feature::Feature, i::Integer) = GDAL.getfieldasinteger(feature, i)
+asint(feature::Feature, i::Integer) = GDAL.getfieldasinteger(feature.ptr, i)
 
 """Fetch field value as integer 64 bit.
 
@@ -160,7 +161,7 @@ asint(feature::Feature, i::Integer) = GDAL.getfieldasinteger(feature, i)
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-asint64(feature::Feature, i::Integer) = GDAL.getfieldasinteger64(feature, i)
+asint64(feature::Feature, i::Integer) = GDAL.getfieldasinteger64(feature.ptr, i)
 
 """Fetch field value as a double.
 
@@ -168,7 +169,7 @@ asint64(feature::Feature, i::Integer) = GDAL.getfieldasinteger64(feature, i)
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-asdouble(feature::Feature, i::Integer) = GDAL.getfieldasdouble(feature, i)
+asdouble(feature::Feature, i::Integer) = GDAL.getfieldasdouble(feature.ptr, i)
 
 """
 Fetch field value as a string.
@@ -177,7 +178,7 @@ Fetch field value as a string.
 * `feature`: the feature that owned the field.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
-asstring(feature::Feature, i::Integer) = GDAL.getfieldasstring(feature, i)
+asstring(feature::Feature, i::Integer) = GDAL.getfieldasstring(feature.ptr, i)
 
 """
     OGR_F_GetFieldAsIntegerList(OGRFeatureH hFeat,
@@ -195,8 +196,7 @@ pointer may be NULL or non-NULL.
 """
 function asintlist(feature::Feature, i::Integer)
     n = Ref{Cint}()
-    ptr = GDAL.getfieldasintegerlist(feature, i, n)
-    GDAL.checknull(ptr)
+    ptr = GDAL.checknull(GDAL.getfieldasintegerlist(feature.ptr, i, n))
     pointer_to_array(ptr, n[], false)
 end
 
@@ -216,8 +216,7 @@ pointer may be NULL or non-NULL.
 """
 function asint64list(feature::Feature, i::Integer)
     n = Ref{Cint}()
-    ptr = GDAL.getfieldasinteger64list(feature, i, n)
-    GDAL.checknull(ptr)
+    ptr = GDAL.checknull(GDAL.getfieldasinteger64list(feature.ptr, i, n))
     pointer_to_array(ptr, n[], false)
 end
 
@@ -237,8 +236,7 @@ pointer may be NULL or non-NULL.
 """
 function asdoublelist(feature::Feature, i::Integer)
     n = Ref{Cint}()
-    ptr = GDAL.getfieldasdoublelist(feature, i, n)
-    GDAL.checknull(ptr)
+    ptr = GDAL.checknull(GDAL.getfieldasdoublelist(feature.ptr, i, n))
     pointer_to_array(ptr, n[], false)
 end
 
@@ -254,7 +252,7 @@ the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief.
 """
 asstringlist(feature::Feature, i::Integer) =
-    unsafe_loadstringlist(GDAL.C.OGR_F_GetFieldAsStringList(feature, i))
+    unsafe_loadstringlist(GDAL.C.OGR_F_GetFieldAsStringList(feature.ptr, i))
 
 """
     OGR_F_GetFieldAsBinary(OGRFeatureH hFeat,
@@ -271,8 +269,7 @@ Its lifetime may be very brief.
 """
 function asbinary(feature::Feature, i::Integer)
     n = Ref{Cint}()
-    ptr = GDAL.getfieldasbinary(feature, i, n)
-    GDAL.checknull(ptr)
+    ptr = GDAL.checknull(GDAL.getfieldasbinary(feature.ptr, i, n))
     pointer_to_array(ptr, n[], false)
 end
 
@@ -301,10 +298,12 @@ Fetch field value as date and time.
 TRUE on success or FALSE on failure.
 """
 function asdatetime(feature::Feature, i::Integer)
-    pyr=Ref{Cint}(); pmth=Ref{Cint}(); pday=Ref{Cint}(); phr=Ref{Cint}()
-    pmin=Ref{Cint}(); psec=Ref{Cint}(); ptz=Ref{Cint}()
-    result = GDAL.getfieldasdatetime(feature,i,pyr,pmth,pday,phr,pmin,psec,ptz)
-    (Bool(result) == false) && error("Failed to fetch datetime at index $i")
+    pyr = Ref{Cint}(); pmth = Ref{Cint}(); pday = Ref{Cint}()
+    phr = Ref{Cint}(); pmin = Ref{Cint}(); psec = Ref{Cint}(); ptz=Ref{Cint}()
+    result = Bool(GDAL.getfieldasdatetime(
+        feature.ptr, i, pyr, pmth, pday, phr, pmin, psec, ptz
+    ))
+    (result == false) && error("Failed to fetch datetime at index $i")
     DateTime(pyr[], pmth[], pday[], phr[], pmin[], psec[])
 end
 
@@ -343,22 +342,22 @@ end
 asnothing(feature::Feature, i::Integer) = nothing
 
 const _FETCHFIELD = Dict{GDAL.OGRFieldType, Function}(
-                         GDAL.OFTInteger => asint,              #0
-                         GDAL.OFTIntegerList => asintlist,      #1
-                         GDAL.OFTReal => asdouble,              #2
-                         GDAL.OFTRealList => asdoublelist,      #3
-                         GDAL.OFTString => asstring,            #4
-                         GDAL.OFTStringList => asstringlist,    #5
-                           # const OFTWideString = (UInt32)(6)
-                       # const OFTWideStringList = (UInt32)(7)
-                         GDAL.OFTBinary => asbinary,            #8
-                                 # const OFTDate = (UInt32)(9)
-                                 # const OFTTime = (UInt32)(10)
-                         GDAL.OFTDateTime => asdatetime,        #11
-                         GDAL.OFTInteger64 => asint64,          #12
-                         GDAL.OFTInteger64List => asint64list  #,13
-                    # const OFTMaxType = (UInt32)(13)
-                    )
+    GDAL.OFTInteger         => asint,           #0
+    GDAL.OFTIntegerList     => asintlist,       #1
+    GDAL.OFTReal            => asdouble,        #2
+    GDAL.OFTRealList        => asdoublelist,    #3
+    GDAL.OFTString          => asstring,        #4
+    GDAL.OFTStringList      => asstringlist,    #5
+ # const OFTWideString =                (UInt32)(6)
+ # const OFTWideStringList =            (UInt32)(7)
+    GDAL.OFTBinary          => asbinary,        #8
+ # const OFTDate =                      (UInt32)(9)
+ # const OFTTime =                      (UInt32)(10)
+    GDAL.OFTDateTime        => asdatetime,      #11
+    GDAL.OFTInteger64       => asint64,         #12
+    GDAL.OFTInteger64List   => asint64list      #13
+ # const OFTMaxType =                   (UInt32)(13)
+ )
 
 function getfield(feature::Feature, i::Integer)
     if isfieldset(feature, i)
@@ -385,7 +384,7 @@ field types may be unaffected.
 * `value`: the value to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Cint) =
-    GDAL.setfieldinteger(feature, i, value)
+    (GDAL.setfieldinteger(feature.ptr, i, value); feature)
 
 """
 Set field to 64 bit integer value.
@@ -401,7 +400,7 @@ field types may be unaffected.
 * `value`: the value to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Int64) =
-    GDAL.setfieldinteger64(feature, i, value)
+    (GDAL.setfieldinteger64(feature.ptr, i, value); feature)
 
 """
 Set field to double value.
@@ -417,7 +416,7 @@ field types may be unaffected.
 * `value`: the value to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Cdouble) =
-    GDAL.setfielddouble(feature, i, value)
+    (GDAL.setfielddouble(feature.ptr, i, value); feature)
 
 """
 Set field to string value.
@@ -433,7 +432,7 @@ field types may be unaffected.
 * `value`: the value to assign.
 """
 setfield!(feature::Feature, i::Integer, value::AbstractString) =
-    GDAL.setfieldstring(feature, i, value)
+    (GDAL.setfieldstring(feature.ptr, i, value); feature)
 
 """
 Set field to list of integers value.
@@ -450,7 +449,7 @@ field types may be unaffected.
 * `panValues`: the values to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Vector{Cint}) =
-    GDAL.setfieldintegerlist(feature, i, length(value), value)
+    (GDAL.setfieldintegerlist(feature.ptr, i, length(value), value); feature)
 
 """
 Set field to list of 64 bit integers value.
@@ -467,7 +466,7 @@ field types may be unaffected.
 * `panValues`: the values to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Vector{GDAL.GIntBig}) =
-    GDAL.setfieldintegerlist(feature, i, length(value), value)
+    (GDAL.setfieldintegerlist(feature.ptr, i, length(value), value); feature)
 
 """
 Set field to list of doubles value.
@@ -484,7 +483,7 @@ field types may be unaffected.
 * `padfValues`: the values to assign.
 """
 setfield!(feature::Feature, i::Integer, value::Vector{Cdouble}) =
-    GDAL.setfielddoublelist(feature, i, length(value), value)
+    (GDAL.setfielddoublelist(feature.ptr, i, length(value), value); feature)
 
 """
 Set field to list of strings value.
@@ -499,9 +498,18 @@ field types may be unaffected.
 * `iField`: the field to set, from 0 to GetFieldCount()-1.
 * `papszValues`: the values to assign.
 """
-setfield!{T <: AbstractString}(feature::Feature, i::Integer, value::Vector{T}) =
-    ccall((:OGR_F_SetFieldStringList,GDAL.libgdal),Void,
-          (Feature,Cint,StringList),feature,i,value)
+function setfield!{T <: AbstractString}(
+        feature::Feature,
+        i::Integer,
+        value::Vector{T}
+    )
+    @gdal(OGR_F_SetFieldStringList::Void,
+        feature.ptr::GDALFeature,
+        i::Cint,
+        value::StringList
+    )
+    feature
+end
 
 # """
 #     OGR_F_SetFieldRaw(OGRFeatureH hFeat,
@@ -533,7 +541,7 @@ field types may be unaffected.
 * `pabyData`: the data to apply.
 """
 setfield!(feature::Feature, i::Integer, value::Vector{GDAL.GByte}) =
-    GDAL.setfieldbinary(feature, i, sizeof(value), value)
+    (GDAL.setfieldbinary(feature.ptr, i, sizeof(value), value); feature)
 
 """
 Set field to datetime.
@@ -554,48 +562,27 @@ field types may be unaffected.
 * `nSecond`: (0-59)
 * `nTZFlag`: (0=unknown, 1=localtime, 100=GMT, see data model for details)
 """
-setfield!(feature::Feature, i::Integer, dt::DateTime) = GDAL.setfielddatetime(
-    feature,i,Dates.year(dt),Dates.month(dt),Dates.day(dt),
-              Dates.hour(dt),Dates.minute(dt),Dates.second(dt),0
-)
-
-# """
-#     OGR_F_SetFieldDateTimeEx(OGRFeatureH hFeat,
-#                              int iField,
-#                              int nYear,
-#                              int nMonth,
-#                              int nDay,
-#                              int nHour,
-#                              int nMinute,
-#                              float fSecond,
-#                              int nTZFlag) -> void
-# Set field to datetime.
-# ### Parameters
-# * `hFeat`: handle to the feature that owned the field.
-# * `iField`: the field to set, from 0 to GetFieldCount()-1.
-# * `nYear`: (including century)
-# * `nMonth`: (1-12)
-# * `nDay`: (1-31)
-# * `nHour`: (0-23)
-# * `nMinute`: (0-59)
-# * `fSecond`: (0-59, with millisecond accuracy)
-# * `nTZFlag`: (0=unknown, 1=localtime, 100=GMT, see data model for details)
-# """
-# function setfielddatetimeex(arg1::Ptr{OGRFeatureH},arg2::Integer,
-#         arg3::Integer,arg4::Integer,arg5::Integer,arg6::Integer,arg7::Integer,
-#         arg8::Cfloat,arg9::Integer)
-#     ccall((:OGR_F_SetFieldDateTimeEx,libgdal),Void,(Ptr{OGRFeatureH},Cint,
-#           Cint,Cint,Cint,Cint,Cint,Cfloat,Cint),arg1,arg2,arg3,arg4,arg5,arg6,
-#           arg7,arg8,arg9)
-# end
-
+function setfield!(feature::Feature, i::Integer, dt::DateTime, tzflag::Int = 0)
+    GDAL.setfielddatetime(
+        feature.ptr,
+        i,
+        Dates.year(dt),
+        Dates.month(dt),
+        Dates.day(dt),
+        Dates.hour(dt),
+        Dates.minute(dt),
+        Dates.second(dt),
+        tzflag
+    )
+    feature
+end
 
 """
 Fetch number of geometry fields on this feature.
 
 This will always be the same as the geometry field count for OGRFeatureDefn.
 """
-ngeomfield(feature::Feature) = GDAL.getgeomfieldcount(feature)
+ngeomfield(feature::Feature) = GDAL.getgeomfieldcount(feature.ptr)
 
 """
 Fetch definition for this geometry field.
@@ -609,7 +596,7 @@ The field definition (from the OGRFeatureDefn). This is an
 internal reference, and should not be deleted or modified.
 """
 getgeomfielddefn(feature::Feature, i::Integer) =
-    GDAL.getgeomfielddefnref(feature, i)
+    GeomFieldDefn(GDAL.getgeomfielddefnref(feature.ptr, i))
 
 """
 Fetch the geometry field index given geometry field name.
@@ -624,7 +611,7 @@ This is a cover for the OGRFeatureDefn::GetGeomFieldIndex() method.
 the geometry field index, or -1 if no matching geometry field is found.
 """
 getgeomfieldindex(feature::Feature, name::AbstractString="") =
-    GDAL.getgeomfieldindex(feature, name)
+    GDAL.getgeomfieldindex(feature.ptr, name)
 
 """
 Fetch pointer to the feature geometry.
@@ -636,7 +623,8 @@ Fetch pointer to the feature geometry.
 ### Returns
 an internal feature geometry. This object should not be modified.
 """
-getgeomfield(feature::Feature, i::Integer) = GDAL.getgeomfieldref(feature, i)
+getgeomfield(feature::Feature, i::Integer) =
+    Geometry(GDAL.getgeomfieldref(feature.ptr, i))
 
 """
 Set feature geometry of a specified geometry field.
@@ -656,8 +644,9 @@ OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the
 OGRFeatureDefn (checking not yet implemented).
 """
 function setgeomfielddirectly!(feature::Feature, i::Integer, geom::Geometry)
-    result = GDAL.setgeomfielddirectly(feature, i, geom)
+    result = GDAL.setgeomfielddirectly(feature.ptr, i, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry directly"
+    feature
 end
 
 """
@@ -677,17 +666,18 @@ OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type
 is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
 function setgeomfield!(feature::Feature, i::Integer, geom::Geometry)
-    result = GDAL.setgeomfield(feature, i, geom)
+    result = GDAL.setgeomfield(feature.ptr, i, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry"
+    feature
 end
 
 """
 Get feature identifier.
 
 ### Returns
-feature id or OGRNullFID if none has been assigned.
+feature id or `OGRNullFID` (`-1`) if none has been assigned.
 """
-getfid(feature::Feature) = GDAL.getfid(feature)
+getfid(feature::Feature) = GDAL.getfid(feature.ptr)
 
 """
 Set the feature identifier.
@@ -700,8 +690,9 @@ Set the feature identifier.
 On success OGRERR_NONE, or on failure some other value.
 """
 function setfid!(feature::Feature, i::Integer)
-    result = GDAL.setfid(feature, i)
+    result = GDAL.setfid(feature.ptr, i)
     @ogrerr result "OGRErr $result: Failed to set FID $i"
+    feature
 end
 
 """
@@ -711,16 +702,17 @@ Set one feature from another.
 * `feature1`: handle to the feature to set to.
 * `feature2`: handle to the feature from which geometry, and field values
     will be copied.
-* `forgiving`: TRUE if the operation should continue despite lacking output
+* `forgiving`: `true` if the operation should continue despite lacking output
     fields matching some of the source fields.
 
 ### Returns
 OGRERR_NONE if the operation succeeds, even if some values are not transferred,
 otherwise an error code.
 """
-function setfrom!(feature1::Feature, feature2::Feature, forgiving::Bool=false)
-    result = GDAL.setfrom(feature1, feature2, forgiving)
+function setfrom!(feature1::Feature, feature2::Feature, forgiving::Bool = false)
+    result = GDAL.setfrom(feature1.ptr, feature2.ptr, forgiving)
     @ogrerr result "OGRErr $result: Failed to set feature"
+    feature1
 end
 
 """
@@ -730,66 +722,65 @@ Set one feature from another.
 * `feature1`: the feature to set to.
 * `feature2`: the feature from which geometry and field values will be copied
 * `indices`: indices of the destination feature's fields stored at the
-    corresponding index of the source feature's fields. A value of -1 should be
-    used to ignore the source's field. The array should not be NULL and be as
-    long as the number of fields in the source feature.
-* `forgiving`: TRUE if the operation should continue despite lacking output
+    corresponding index of the source feature's fields. A value of `-1` should
+    be used to ignore the source's field. The array should not be NULL and be
+    as long as the number of fields in the source feature.
+* `forgiving`: `true` if the operation should continue despite lacking output
     fields matching some of the source fields.
 
 ### Returns
 OGRERR_NONE if the operation succeeds, even if some values are not transferred,
 otherwise an error code.
 """
-function setfrom!(feature1::Feature, feature2::Feature, indices::Vector{Cint},
-                 forgiving::Bool=false)
-    result = GDAL.setfromwithmap(feature1, feature2, forgiving, indices)
+function setfrom!(
+        feature1::Feature,
+        feature2::Feature,
+        indices::Vector{Cint},
+        forgiving::Bool = false
+    )
+    result = GDAL.setfromwithmap(feature1.ptr, feature2.ptr, forgiving, indices)
     @ogrerr result "OGRErr $result: Failed to set feature with map"
+    feature1
 end
 
 
 "Fetch style string for this feature."
-getstylestring(feature::Feature) = GDAL.getstylestring(feature)
+getstylestring(feature::Feature) = GDAL.getstylestring(feature.ptr)
 
 """
 Set feature style string.
 
-This method operate exactly as OGRFeature::SetStyleStringDirectly() except that
+This method operate exactly as `setstylestringdirectly!()` except that
 it doesn't assume ownership of the passed string, but makes a copy of it.
-
-This method operate exactly as OGR_F_SetStyleStringDirectly() except that it
-does not assume ownership of the passed string, but instead makes a copy of it.
 """
 setstylestring!(feature::Feature, style::AbstractString) =
-    GDAL.setstylestring(feature, style)
+    (GDAL.setstylestring(feature.ptr, style); feature)
 
 """
 Set feature style string.
 
-This method operate exactly as OGRFeature::SetStyleString() except that it
+This method operate exactly as `setstylestring!()` except that it
 assumes ownership of the passed string.
-
-This method operate exactly as OGR_F_SetStyleString() except that it assumes
-ownership of the passed string.
 """
 setstylestringdirectly!(feature::Feature, style::AbstractString) =
-    GDAL.setstylestringdirectly(feature, style)
+    (GDAL.setstylestringdirectly(feature.ptr, style); feature)
 
 "OGR_F_GetStyleTable(OGRFeatureH hFeat) -> OGRStyleTableH"
-getstyletable(feature::Feature) = GDAL.getstyletable(feature)
+getstyletable(feature::Feature) = StyleTable(GDAL.getstyletable(feature.ptr))
 
 """
     OGR_F_SetStyleTableDirectly(OGRFeatureH hFeat,
                                 OGRStyleTableH hStyleTable) -> void
 """
 setstyletabledirectly!(feature::Feature, styletable::StyleTable) =
-    GDAL.setstyletabledirectly(feature, styletable)
+    (GDAL.setstyletabledirectly(feature.ptr, styletable.ptr); feature)
 
 """
     OGR_F_SetStyleTable(OGRFeatureH hFeat,
                         OGRStyleTableH hStyleTable) -> void
 """
 setstyletable!(feature::Feature, styletable::StyleTable) =
-    GDAL.setstyletable(feature, styletable)
+    (GDAL.setstyletable(feature.ptr, styletable.ptr); feature)
 
 """
 Returns the native data for the feature.
@@ -808,7 +799,7 @@ than what can be obtained with the rest of the API, but it may be useful in
 round-tripping scenarios where some characteristics of the underlying format
 are not captured otherwise by the OGR abstraction.
 """
-getnativedata(feature::Feature) = GDAL.getnativedata(feature)
+getnativedata(feature::Feature) = GDAL.getnativedata(feature.ptr)
 
 """
 Sets the native data for the feature.
@@ -819,7 +810,7 @@ native data may be in different format, which is indicated by
 GetNativeMediaType().
 """
 setnativedata!(feature::Feature, data::AbstractString) =
-    GDAL.setnativedata(feature, data)
+    (GDAL.setnativedata(feature.ptr, data); feature)
 
 """
 Returns the native media type for the feature.
@@ -828,7 +819,7 @@ The native media type is the identifier for the format of the native data. It
 follows the IANA RFC 2045 (see https://en.wikipedia.org/wiki/Media_type),
 e.g. \"application/vnd.geo+json\" for JSON.
 """
-getmediatype(feature::Feature) = GDAL.getnativemediatype(feature)
+getmediatype(feature::Feature) = GDAL.getnativemediatype(feature.ptr)
 
 """
 Sets the native media type for the feature.
@@ -838,7 +829,7 @@ follows the IANA RFC 2045 (see https://en.wikipedia.org/wiki/Media_type),
 e.g. \"application/vnd.geo+json\" for JSON.
 """
 setmediatype!(feature::Feature, mediatype::AbstractString) =
-    GDAL.setnativemediatype(feature, mediatype)
+    (GDAL.setnativemediatype(feature.ptr, mediatype); feature)
 
 """
 Fill unset fields with default values that might be defined.
@@ -846,31 +837,35 @@ Fill unset fields with default values that might be defined.
 ### Parameters
 * `feature`: handle to the feature.
 * `notnull`: if we should fill only unset fields with a not-null constraint.
-* `papszOptions`: unused currently. Must be set to NULL.
+* `papszOptions`: unused currently. Must be set to `NULL`.
 """
-fillunsetwithdefault!(feature::Feature; notnull::Bool=true,
-                      options=StringList(C_NULL)) =
-    GDAL.fillunsetwithdefault(feature, notnull, options)
+function fillunsetwithdefault!(
+        feature::Feature;
+        notnull::Bool   = true,
+        options         = StringList(C_NULL)
+    )
+    GDAL.fillunsetwithdefault(feature.ptr, notnull, options)
+end
 
 """
 Validate that a feature meets constraints of its schema.
 
 The scope of test is specified with the nValidateFlags parameter.
 
-Regarding OGR_F_VAL_WIDTH, the test is done assuming the string width must be
+Regarding `OGR_F_VAL_WIDTH`, the test is done assuming the string width must be
 interpreted as the number of UTF-8 characters. Some drivers might interpret the
 width as the number of bytes instead. So this test is rather conservative (if it
 fails, then it will fail for all interpretations).
 
 ### Parameters
 * `feature`: handle to the feature to validate.
-* `flags`: OGR_F_VAL_ALL or combination of OGR_F_VAL_NULL,
-    OGR_F_VAL_GEOM_TYPE, OGR_F_VAL_WIDTH and OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT
-    with '|' operator
-* `emiterror`: TRUE if a CPLError() must be emitted when a check fails
+* `flags`: `OGR_F_VAL_ALL` or combination of `OGR_F_VAL_NULL`,
+    `OGR_F_VAL_GEOM_TYPE`, `OGR_F_VAL_WIDTH` and
+    `OGR_F_VAL_ALLOW_NULL_WHEN_DEFAULT` with `|` operator
+* `emiterror`: `true` if a `CPLError()` must be emitted when a check fails
 
 ### Returns
-TRUE if all enabled validation tests pass.
+`true` if all enabled validation tests pass.
 """
 validate(feature::Feature, flags::Integer, emiterror::Bool) =
-    Bool(GDAL.validate(feature, flags, emiterror))
+    Bool(GDAL.validate(feature.ptr, flags, emiterror))

--- a/src/ogr/styletable.jl
+++ b/src/ogr/styletable.jl
@@ -7,8 +7,8 @@ OGRStyleMgr factory.
 ### Returns
 an handle to the new style manager object.
 """
-unsafe_createstylemanager(styletable::StyleTable = StyleTable(C_NULL)) =
-    GDAL.sm_create(styletable)
+unsafe_createstylemanager(styletable = GDALStyleTable(C_NULL)) =
+    StyleManager(GDAL.sm_create(styletable))
 
 """
 Destroy Style Manager.
@@ -16,7 +16,8 @@ Destroy Style Manager.
 ### Parameters
 * `stylemanager`: handle to the style manager to destroy.
 """
-destroy(stylemanager::StyleManager) = GDAL.destroy(stylemanager)
+destroy(sm::StyleManager) = (GDAL.destroy(sm.ptr); sm.ptr = C_NULL)
+
 
 """
 Initialize style manager from the style string of a feature.
@@ -29,7 +30,7 @@ Initialize style manager from the style string of a feature.
 the style string read from the feature, or NULL in case of error.
 """
 initialize!(stylemanager::StyleManager, feature::Feature) =
-    GDAL.initfromfeature(stylemanager, feature)
+    GDAL.initfromfeature(stylemanager.ptr, feature.ptr)
 
 """
 Initialize style manager from the style string.
@@ -41,11 +42,13 @@ Initialize style manager from the style string.
 TRUE on success, FALSE on errors.
 """
 initialize!(stylemanager::StyleManager, stylestring::AbstractString) =
-    Bool(GDAL.initstylestring(stylemanager, stylestring))
+    Bool(GDAL.initstylestring(stylemanager.ptr, stylestring))
 
 initialize!(stylemanager::StyleManager) =
-    Bool(ccall((:OGR_SM_InitStyleString,GDAL.libgdal),Cint,(StyleManager,
-                Ptr{UInt8}),stylemanager,Ptr{UInt8}(C_NULL)))
+    Bool(@gdal(OGR_SM_InitStyleString::Cint,
+        stylemanager.ptr::GDALStyleManager,
+        C_NULL::Ptr{UInt8}
+    ))
 
 """
 Get the number of parts in a style.
@@ -59,12 +62,16 @@ Get the number of parts in a style.
 the number of parts (style tools) in the style.
 """
 npart(stylemanager::StyleManager) =
-    ccall((:OGR_SM_GetPartCount,GDAL.libgdal),Cint,(StyleManager,Ptr{UInt8}),
-          stylemanager,C_NULL)
+    @gdal(OGR_SM_GetPartCount::Cint,
+        stylemanager.ptr::GDALStyleManager,
+        C_NULL::Ptr{UInt8}
+    )
 
-npart(stylemanager::StyleManager,stylestring::AbstractString) =
-    ccall((:OGR_SM_GetPartCount,GDAL.libgdal),Cint,(StyleManager,Ptr{UInt8}),
-          stylemanager,stylestring)
+npart(stylemanager::StyleManager, stylestring::AbstractString) =
+    @gdal(OGR_SM_GetPartCount::Cint,
+        stylemanager.ptr::GDALStyleManager,
+        stylestring::Ptr{UInt8}
+    )
 
 """
 Fetch a part (style tool) from the current style.
@@ -78,12 +85,15 @@ Fetch a part (style tool) from the current style.
 ### Returns
 OGRStyleToolH of the requested part (style tools) or NULL on error.
 """
-getpart(stylemanager::StyleManager,id::Integer,stylestring::AbstractString) =
-    GDAL.getpart(stylemanager, id, stylestring)
+getpart(stylemanager::StyleManager, id::Integer, stylestring::AbstractString) =
+    StyleTool(GDAL.getpart(stylemanager.ptr, id, stylestring))
 
 getpart(stylemanager::StyleManager,id::Integer) =
-    GDAL.checknull(ccall((:OGR_SM_GetPart,GDAL.libgdal),StyleTool,(StyleManager,
-                         Cint,Ptr{UInt8}),stylemanager,id,C_NULL))
+    StyleTool(GDAL.checknull(@gdal(OGR_SM_GetPart::GDALStyleTool,
+        stylemanager.ptr::GDALStyleManager,
+        id::Cint,
+        C_NULL::Ptr{UInt8}
+    )))
 
 """
 Add a part (style tool) to the current style.
@@ -95,8 +105,8 @@ Add a part (style tool) to the current style.
 ### Returns
 TRUE on success, FALSE on errors.
 """
-addpart!(stylemanager::StyleManager,styletool::StyleTool) =
-    Bool(GDAL.addpart(stylemanager, styletool))
+addpart!(stylemanager::StyleManager, styletool::StyleTool) =
+    Bool(GDAL.addpart(stylemanager.ptr, styletool.ptr))
 
 """
 Add a style to the current style table.
@@ -110,14 +120,24 @@ Add a style to the current style table.
 ### Returns
 TRUE on success, FALSE on errors.
 """
-addstyle!(stylemanager::StyleManager,
-          stylename::AbstractString,
-          stylestring::AbstractString) =
-    Bool(GDAL.addstyle(stylemanager, stylename, stylestring))
+function addstyle!(
+        stylemanager::StyleManager,
+        stylename::AbstractString,
+        stylestring::AbstractString
+    )
+    Bool(GDAL.addstyle(stylemanager.ptr, stylename, stylestring))
+end
 
-addstyle!(stylemanager::StyleManager, stylename::AbstractString) =
-    Bool(ccall((:OGR_SM_AddStyle,GDAL.libgdal),Cint,(StyleManager,Cstring,
-                Ptr{UInt8}),stylemanager,stylename,C_NULL))
+function addstyle!(
+        stylemanager::StyleManager,
+        stylename::AbstractString
+    )
+    Bool(@gdal(OGR_SM_AddStyle::Cint,
+        stylemanager.ptr::GDALStyleManager,
+        stylename::Cstring,
+        C_NULL::Ptr{UInt8}
+    ))
+end
 
 """
 OGRStyleTool factory.
@@ -130,8 +150,9 @@ OGRStyleTool factory.
 an handle to the new style tool object or NULL if the creation failed.
 """
 unsafe_createstyletool(classid::OGRSTClassId) =
-    GDAL.checknull(ccall((:OGR_ST_Create,GDAL.libgdal),StyleTool,
-                         (GDAL.OGRSTClassId,),classid))
+    StyleTool(GDAL.checknull(@gdal(OGR_ST_Create::GDALStyleTool,
+        classid::GDAL.OGRSTClassId
+    )))
 
 """
 Destroy Style Tool.
@@ -139,7 +160,8 @@ Destroy Style Tool.
 ### Parameters
 * `styletool`: handle to the style tool to destroy.
 """
-destroy(styletool::StyleTool) = GDAL.destroy(styletool)
+destroy(styletool::StyleTool) =
+    (GDAL.destroy(styletool.ptr); styletool.ptr = C_NULL)
 
 """
 Determine type of Style Tool.
@@ -151,7 +173,7 @@ Determine type of Style Tool.
 the style tool type, one of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or
 OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
 """
-gettype(styletool::StyleTool) = OGRSTClassId(GDAL.gettype(styletool))
+gettype(styletool::StyleTool) = OGRSTClassId(GDAL.gettype(styletool.ptr))
 
 """
 Get Style Tool units.
@@ -162,7 +184,7 @@ Get Style Tool units.
 ### Returns
 the style tool units.
 """
-getunit(styletool::StyleTool) = OGRSTUnitId(GDAL.getunit(styletool))
+getunit(styletool::StyleTool) = OGRSTUnitId(GDAL.getunit(styletool.ptr))
 
 """
     OGR_ST_SetUnit(OGRStyleToolH styletool,
@@ -175,8 +197,11 @@ Set Style Tool units.
 * `scale`: ground to paper scale factor.
 """
 setunit!(styletool::StyleTool, newunit::OGRSTUnitId, scale::Real) =
-    ccall((:OGR_ST_SetUnit,GDAL.libgdal),Void,(StyleTool,GDAL.OGRSTUnitId,
-          Cdouble),styletool,newunit,scale)
+    @gdal(OGR_ST_SetUnit::Void,
+        styletool.ptr::GDALStyleTool,
+        newunit::GDAL.OGRSTUnitId,
+        scale::Cdouble
+    )
 
 """
 Get Style Tool parameter value as a string.
@@ -192,10 +217,10 @@ Get Style Tool parameter value as a string.
 ### Returns
 the parameter value as a string and sets `nullflag`.
 """
-asstring(styletool::StyleTool,id::Integer,nullflag::Ref{Cint}) =
-    GDAL.getparamstr(styletool, id, nullflag)
+asstring(styletool::StyleTool, id::Integer, nullflag::Ref{Cint}) =
+    GDAL.getparamstr(styletool.ptr, id, nullflag)
 
-asstring(styletool::StyleTool,id::Integer) =
+asstring(styletool::StyleTool, id::Integer) =
     asstring(styletool, id, Ref{Cint}(0))
 
 """
@@ -212,10 +237,10 @@ Get Style Tool parameter value as an integer.
 ### Returns
 the parameter value as an integer and sets `nullflag`.
 """
-asint(styletool::StyleTool,id::Integer,nullflag::Ref{Cint}) =
-    GDAL.getparamnum(styletool, id, nullflag)
+asint(styletool::StyleTool, id::Integer, nullflag::Ref{Cint}) =
+    GDAL.getparamnum(styletool.ptr, id, nullflag)
 
-asint(styletool::StyleTool,id::Integer) =
+asint(styletool::StyleTool, id::Integer) =
     asint(styletool, id, Ref{Cint}(0))
 
 """
@@ -232,10 +257,10 @@ Get Style Tool parameter value as a double.
 ### Returns
 the parameter value as a double and sets `nullflag`.
 """
-asdouble(styletool::StyleTool,id::Integer,nullflag::Ref{Cint}) =
-    GDAL.getparamdbl(styletool, id, nullflag)
+asdouble(styletool::StyleTool, id::Integer, nullflag::Ref{Cint}) =
+    GDAL.getparamdbl(styletool.ptr, id, nullflag)
 
-asdouble(styletool::StyleTool,id::Integer) =
+asdouble(styletool::StyleTool, id::Integer) =
     asdouble(styletool, id, Ref{Cint}(0))
 
 """
@@ -248,8 +273,8 @@ Set Style Tool parameter value from a string.
         or OGRSTLabelParam enumerations)
 * `value`: the new parameter value
 """
-setparam!(styletool::StyleTool,id::Integer,value::AbstractString) =
-    GDAL.setparamstr(styletool, id, value)
+setparam!(styletool::StyleTool, id::Integer, value::AbstractString) =
+    GDAL.setparamstr(styletool.ptr, id, value)
 
 """
 Set Style Tool parameter value from an integer.
@@ -261,8 +286,8 @@ Set Style Tool parameter value from an integer.
         or OGRSTLabelParam enumerations)
 * `value`: the new parameter value
 """
-setparam!(styletool::StyleTool,id::Integer,value::Integer) =
-    GDAL.setparamnum(styletool, id, value)
+setparam!(styletool::StyleTool, id::Integer, value::Integer) =
+    GDAL.setparamnum(styletool.ptr, id, value)
 
 """
 Set Style Tool parameter value from a double.
@@ -275,7 +300,7 @@ Set Style Tool parameter value from a double.
 * `value`: the new parameter value
 """
 setparam!(styletool::StyleTool,id::Integer,value::Float64) =
-    GDAL.setparamdbl(styletool, id, value)
+    GDAL.setparamdbl(styletool.ptr, id, value)
 
 """
 Get the style string for this Style Tool.
@@ -286,7 +311,7 @@ Get the style string for this Style Tool.
 ### Returns
 the style string for this style tool or "" if the styletool is invalid.
 """
-getstylestring(styletool::StyleTool) = GDAL.getstylestring(styletool)
+getstylestring(styletool::StyleTool) = GDAL.getstylestring(styletool.ptr)
 
 """
 Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
@@ -298,11 +323,14 @@ Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
 ### Returns
 (R,G,B,A) tuple of Cints.
 """
-function getrgba(styletool::StyleTool,color::AbstractString)
+function getrgba(styletool::StyleTool, color::AbstractString)
     red = Ref{Cint}(0); green = Ref{Cint}(0)
     blue = Ref{Cint}(0); alpha = Ref{Cint}(0)
-    result = GDAL.getrgbfromstring(styletool, color, red, green, blue, alpha)
-    Bool(result) || error("Error in getting RGBA from Styletool")
+    result = Bool(GDAL.getrgbfromstring(styletool.ptr, color, 
+        red, green,
+        blue, alpha
+    ))
+    result || error("Error in getting RGBA from Styletool")
     (red[], green[], blue[], alpha[])
 end
 
@@ -312,8 +340,7 @@ OGRStyleTable factory.
 ### Returns
 an handle to the new style table object.
 """
-unsafe_createstyletable() =
-    GDAL.checknull(ccall((:OGR_STBL_Create,GDAL.libgdal),StyleTable,()))
+unsafe_createstyletable() = StyleTable(GDAL.stbl_create())
 
 """
 Destroy Style Table.
@@ -321,7 +348,7 @@ Destroy Style Table.
 ### Parameters
 * `styletable`: handle to the style table to destroy.
 """
-destroy(styletable::StyleTable) = GDAL.destroy(styletable)
+destroy(st::StyleTable) = (GDAL.destroy(st.ptr); st.ptr = C_NULL)
 
 """
 Add a new style in the table.
@@ -334,9 +361,13 @@ Add a new style in the table.
 ### Returns
 TRUE on success, FALSE on error
 """
-addstyle!(styletable::StyleTable, stylename::AbstractString,
-          stylestring::AbstractString) =
-    Bool(GDAL.addstyle(styletable, stylename, stylestring))
+function addstyle!(
+        styletable::StyleTable,
+        stylename::AbstractString,
+        stylestring::AbstractString
+    )
+    Bool(GDAL.addstyle(styletable.ptr, stylename, stylestring))
+end
 
 """
 Save a style table to a file.
@@ -347,7 +378,7 @@ Save a style table to a file.
 TRUE on success, FALSE on error
 """
 savestyletable(styletable::StyleTable, filename::AbstractString) =
-    Bool(GDAL.savestyletable(styletable, filename))
+    Bool(GDAL.savestyletable(styletable.ptr, filename))
 
 """
 Load a style table from a file.
@@ -360,7 +391,7 @@ Load a style table from a file.
 TRUE on success, FALSE on error
 """
 loadstyletable!(styletable::StyleTable, filename::AbstractString) =
-    Bool(GDAL.loadstyletable(styletable, filename))
+    Bool(GDAL.loadstyletable(styletable.ptr, filename))
 
 """
 Get a style string by name.
@@ -372,7 +403,8 @@ Get a style string by name.
 ### Returns
 the style string matching the name or NULL if not found or error.
 """
-find(styletable::StyleTable, name::AbstractString) = GDAL.find(styletable, name)
+find(styletable::StyleTable, name::AbstractString) =
+    GDAL.find(styletable.ptr, name)
 
 """
 Reset the next style pointer to 0.
@@ -380,7 +412,8 @@ Reset the next style pointer to 0.
 ### Parameters
 * `styletable`: handle to the style table.
 """
-resetreading!(styletable::StyleTable) = GDAL.resetstylestringreading(styletable)
+resetreading!(styletable::StyleTable) =
+    GDAL.resetstylestringreading(styletable.ptr)
 
 """
 Get the next style string from the table.
@@ -391,7 +424,7 @@ Get the next style string from the table.
 ### Returns
 the next style string or NULL on error.
 """
-nextstyle(styletable::StyleTable) = GDAL.getnextstyle(styletable)
+nextstyle(styletable::StyleTable) = GDAL.getnextstyle(styletable.ptr)
 
 """
 Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
@@ -402,4 +435,4 @@ Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
 ### Returns
 the Name of the last style string or NULL on error.
 """
-laststyle(styletable::StyleTable) = GDAL.getlaststylename(styletable)
+laststyle(styletable::StyleTable) = GDAL.getlaststylename(styletable.ptr)

--- a/src/ogr/styletable.jl
+++ b/src/ogr/styletable.jl
@@ -41,13 +41,10 @@ Initialize style manager from the style string.
 ### Returns
 TRUE on success, FALSE on errors.
 """
-initialize!(stylemanager::StyleManager, stylestring::AbstractString) =
-    Bool(GDAL.initstylestring(stylemanager.ptr, stylestring))
-
-initialize!(stylemanager::StyleManager) =
+initialize!(stylemanager::StyleManager, stylestring = C_NULL) =
     Bool(@gdal(OGR_SM_InitStyleString::Cint,
         stylemanager.ptr::GDALStyleManager,
-        C_NULL::Ptr{UInt8}
+        stylestring::Ptr{UInt8}
     ))
 
 """
@@ -85,14 +82,11 @@ Fetch a part (style tool) from the current style.
 ### Returns
 OGRStyleToolH of the requested part (style tools) or NULL on error.
 """
-getpart(stylemanager::StyleManager, id::Integer, stylestring::AbstractString) =
-    StyleTool(GDAL.getpart(stylemanager.ptr, id, stylestring))
-
-getpart(stylemanager::StyleManager,id::Integer) =
+unsafe_getpart(stylemanager::StyleManager, id::Integer, stylestring = C_NULL) =
     StyleTool(GDAL.checknull(@gdal(OGR_SM_GetPart::GDALStyleTool,
         stylemanager.ptr::GDALStyleManager,
         id::Cint,
-        C_NULL::Ptr{UInt8}
+        stylestring::Ptr{UInt8}
     )))
 
 """
@@ -299,7 +293,7 @@ Set Style Tool parameter value from a double.
         or OGRSTLabelParam enumerations)
 * `value`: the new parameter value
 """
-setparam!(styletool::StyleTool,id::Integer,value::Float64) =
+setparam!(styletool::StyleTool, id::Integer, value::Float64) =
     GDAL.setparamdbl(styletool.ptr, id, value)
 
 """

--- a/src/raster/colortable.jl
+++ b/src/raster/colortable.jl
@@ -3,13 +3,13 @@
 Construct a new color table.
 """
 unsafe_createcolortable(palette::GDALPaletteInterp) =
-    GDAL.createcolortable(GDAL.GDALPaletteInterp(palette))
+    ColorTable(GDAL.createcolortable(GDAL.GDALPaletteInterp(palette)))
 
 "Destroys a color table."
-destroy(colortable::ColorTable) = GDAL.destroycolortable(colortable)
+destroy(ct::ColorTable) = (GDAL.destroycolortable(ct.ptr); ct.ptr = C_NULL)
 
 "Make a copy of a color table."
-unsafe_clone(colortable::ColorTable) = GDAL.clonecolortable(colortable)
+unsafe_clone(ct::ColorTable) = ColorTable(GDAL.clonecolortable(ct.ptr))
 
 """
 Fetch palette interpretation.
@@ -18,14 +18,14 @@ Fetch palette interpretation.
 palette interpretation enumeration value, usually `GPI_RGB`.
 """
 getpaletteinterp(ct::ColorTable) =
-    GDALPaletteInterp(GDAL.getpaletteinterpretation(ct))
+    GDALPaletteInterp(GDAL.getpaletteinterpretation(ct.ptr))
 
 "Get number of color entries in table."
-ncolorentry(colortable::ColorTable) = GDAL.getcolorentrycount(colortable)
+ncolorentry(ct::ColorTable) = GDAL.getcolorentrycount(ct.ptr)
 
 "Fetch a color entry from table."
-getcolorentry(colortable::ColorTable, i::Integer) =
-    unsafe_load(GDAL.getcolorentry(colortable, i))
+getcolorentry(ct::ColorTable, i::Integer) =
+    unsafe_load(GDAL.getcolorentry(ct.ptr, i))
 
 """
 Fetch a table entry in RGB format.
@@ -40,9 +40,9 @@ tables.
 ### Returns
 TRUE on success, or FALSE if the conversion isn't supported.
 """
-function getcolorentryasrgb(colortable::ColorTable, i::Integer)
-    colorentry = Ref{GDAL.GDALColorEntry}(GDAL.GDALColorEntry(0,0,0,0))
-    result = Bool(GDAL.getcolorentryasrgb(colortable, i, colorentry))
+function getcolorentryasrgb(ct::ColorTable, i::Integer)
+    colorentry = Ref{GDAL.GDALColorEntry}(GDAL.GDALColorEntry(0, 0, 0, 0))
+    result = Bool(GDAL.getcolorentryasrgb(ct.ptr, i, colorentry))
     result || warn("The conversion to RGB isn't supported.")
     colorentry[]
 end
@@ -60,8 +60,8 @@ The table is grown as needed to hold the supplied offset.
 * `i`     entry offset from `0` to `ncolorentry()-1`.
 * `entry` value to assign to table.
 """
-setcolorentry!(colortable::ColorTable, i::Integer, entry::GDAL.GDALColorEntry) =
-    GDAL.setcolorentry(colortable, i, Ref{GDAL.GDALColorEntry}(entry))
+setcolorentry!(ct::ColorTable, i::Integer, entry::GDAL.GDALColorEntry) =
+    (GDAL.setcolorentry(ct.ptr, i, Ref{GDAL.GDALColorEntry}(entry)); ct)
 
 """
 Create color ramp.
@@ -78,11 +78,15 @@ called several times to create multiples ramps in the same color table.
 ### Returns
 total number of entries, -1 to report error
 """
-createcolorramp!(colortable::ColorTable,
-                 startindex::Integer,
-                 startcolor::GDAL.GDALColorEntry,
-                 endindex::Integer,
-                 endcolor::GDAL.GDALColorEntry) =
-    GDAL.createcolorramp(colortable,
-                         startindex, Ref{GDAL.GDALColorEntry}(startcolor),
-                           endindex, Ref{GDAL.GDALColorEntry}(endcolor))
+function createcolorramp!(
+        ct::ColorTable,
+        startindex::Integer,
+        startcolor::GDAL.GDALColorEntry,
+        endindex::Integer,
+        endcolor::GDAL.GDALColorEntry
+    )
+    GDAL.createcolorramp(ct.ptr,
+        startindex, Ref{GDAL.GDALColorEntry}(startcolor),
+        endindex, Ref{GDAL.GDALColorEntry}(endcolor)
+    )
+end

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -1,5 +1,4 @@
 
-
 """
 Read/write a region of image data from multiple bands.
 
@@ -54,15 +53,18 @@ with additional arguments to specify resampling and progress callback, or
 option can also be defined to override the default resampling to one of
 `BILINEAR`, `CUBIC`, `CUBICSPLINE`, `LANCZOS`, `AVERAGE` or `MODE`.
 """
-function rasterio!{T <: Real}(dataset::Dataset,
-                              buffer::Array{T, 3},
-                              bands::Vector{Cint},
-                              access::GDALRWFlag=GF_Read,
-                              pxspace::Integer = 0,
-                              linespace::Integer = 0,
-                              bandspace::Integer = 0)
+function rasterio!{T <: Real}(
+        dataset::Dataset,
+        buffer::Array{T, 3},
+        bands::Vector{Cint},
+        access::GDALRWFlag  = GF_Read,
+        pxspace::Integer    = 0,
+        linespace::Integer  = 0,
+        bandspace::Integer  = 0
+    )
     rasterio!(dataset, buffer, bands, 0, 0, width(dataset), height(dataset),
-              access, pxspace, linespace, bandspace)
+        access, pxspace, linespace, bandspace
+    )
 end
 
 function rasterio!{T <: Real, U <: Integer}(
@@ -71,14 +73,16 @@ function rasterio!{T <: Real, U <: Integer}(
         bands::Vector{Cint},
         rows::UnitRange{U},
         cols::UnitRange{U},
-        access::GDALRWFlag=GF_Read,
-        pxspace::Integer = 0,
-        linespace::Integer = 0,
-        bandspace::Integer = 0)
+        access::GDALRWFlag  = GF_Read,
+        pxspace::Integer    = 0,
+        linespace::Integer  = 0,
+        bandspace::Integer  = 0
+    )
     xsize = cols[end] - cols[1] + 1; xsize < 0 && error("invalid window width")
     ysize = rows[end] - rows[1] + 1; ysize < 0 && error("invalid window height")
     rasterio!(dataset, buffer, bands, cols[1], rows[1], xsize, ysize, access,
-              pxspace, linespace, bandspace)
+        pxspace, linespace, bandspace
+    )
 end
 
 """
@@ -137,13 +141,16 @@ option can also be defined to override the default resampling to one of
 ### Returns
 `CE_Failure` if the access fails, otherwise `CE_None`.
 """
-function rasterio!{T <: Real}(rasterband::RasterBand,
-                              buffer::Array{T,2},
-                              access::GDALRWFlag=GF_Read,
-                              pxspace::Integer=0,
-                              linespace::Integer=0)
+function rasterio!{T <: Real}(
+        rasterband::RasterBand,
+        buffer::Array{T,2},
+        access::GDALRWFlag  = GF_Read,
+        pxspace::Integer    = 0,
+        linespace::Integer  = 0
+    )
     rasterio!(rasterband, buffer, 0, 0, width(rasterband), height(rasterband),
-              access, pxspace, linespace)
+        access, pxspace, linespace
+    )
 end
 
 function rasterio!{T <: Real, U <: Integer}(
@@ -151,49 +158,88 @@ function rasterio!{T <: Real, U <: Integer}(
         buffer::Array{T,2},
         rows::UnitRange{U},
         cols::UnitRange{U},
-        access::GDALRWFlag=GF_Read,
-        pxspace::Integer = 0,
-        linespace::Integer = 0)
+        access::GDALRWFlag  = GF_Read,
+        pxspace::Integer    = 0,
+        linespace::Integer  = 0
+    )
     xsize = length(cols); xsize < 1 && error("invalid window width")
     ysize = length(rows); ysize < 1 && error("invalid window height")
     rasterio!(rasterband, buffer, cols[1]-1, rows[1]-1, xsize, ysize,
-              access, pxspace, linespace)
+        access, pxspace, linespace
+    )
 end
 
 read!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
     rasterio!(rb, buffer, GF_Read)
 
-read!{T <: Real}(rb::RasterBand, buffer::Array{T,2}, xoffset::Integer,
-                  yoffset::Integer, xsize::Integer, ysize::Integer) =
+function read!{T <: Real}(
+        rb::RasterBand,
+        buffer::Array{T,2},
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
+end
 
-read!{T <: Real, U <: Integer}(rb::RasterBand, buffer::Array{T,2},
-                               rows::UnitRange{U}, cols::UnitRange{U}) =
+function read!{T <: Real, U <: Integer}(
+        rb::RasterBand,
+        buffer::Array{T,2},
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     rasterio!(rb, buffer, rows, cols)
+end
 
 read(rb::RasterBand) =
     rasterio!(rb, Array(getdatatype(rb), width(rb), height(rb)))
 
-function read(rb::RasterBand, xoffset::Integer, yoffset::Integer,
-               xsize::Integer, ysize::Integer)
+function read(
+        rb::RasterBand,
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     buffer = Array(getdatatype(rb), width(rb), height(rb))
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
 end
 
 
-read{U <: Integer}(rb::RasterBand, rows::UnitRange{U}, cols::UnitRange{U}) =
-    rasterio!(rb, Array(getdatatype(rb), length(cols), length(rows)), rows, cols)
+function read{U <: Integer}(
+        rb::RasterBand,
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
+    rasterio!(rb,
+        Array(getdatatype(rb), length(cols), length(rows)),
+        rows, cols
+    )
+end
 
 write!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
     rasterio!(rb, buffer, GF_Write)
 
-write!{T <: Real}(rb::RasterBand, buffer::Array{T,2}, xoffset::Integer,
-                   yoffset::Integer, xsize::Integer, ysize::Integer) =
+function write!{T <: Real}(
+        rb::RasterBand,
+        buffer::Array{T, 2},
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize, GF_Write)
+end
 
-write!{T <: Real, U <: Integer}(rb::RasterBand, buffer::Array{T,2},
-                                 rows::UnitRange{U}, cols::UnitRange{U}) =
+function write!{T <: Real, U <: Integer}(
+        rb::RasterBand,
+        buffer::Array{T, 2},
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     rasterio!(rb, buffer, rows, cols, GF_Write)
+end
 
 read!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer) =
     read!(getband(dataset, i), buffer)
@@ -206,81 +252,163 @@ function read!{T <: Real}(dataset::Dataset, buffer::Array{T,3})
     rasterio!(dataset, buffer, collect(Cint, 1:nband), GF_Read)
 end
 
-read!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer,
-        xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer) =
+function read!{T <: Real}(
+        dataset::Dataset,
+        buffer::Array{T, 2},
+        i::Integer,
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     read!(getband(dataset, i), buffer, xoffset, yoffset, xsize, ysize)
+end
 
-read!{T <: Real}(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint},
-        xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer) =
+function read!{T <: Real}(
+        dataset::Dataset,
+        buffer::Array{T, 3},
+        indices::Vector{Cint},
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     rasterio!(dataset, buffer, indices, xoffset, yoffset, xsize, ysize)
+end
 
-read!{T <: Real, U <: Integer}(dataset::Dataset, buffer::Array{T,2},
-                i::Integer, rows::UnitRange{U}, cols::UnitRange{U}) =
+function read!{T <: Real, U <: Integer}(
+        dataset::Dataset,
+        buffer::Array{T, 2},
+        i::Integer,
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     read!(getband(dataset, i), buffer, rows, cols)
+end
 
-read!{T <: Real, U <: Integer}(dataset::Dataset, buffer::Array{T,3},
-                indices::Vector{Cint}, rows::UnitRange{U}, cols::UnitRange{U}) =
+function read!{T <: Real, U <: Integer}(
+        dataset::Dataset,
+        buffer::Array{T, 3},
+        indices::Vector{Cint},
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     rasterio!(dataset, buffer, indices, rows, cols)
+end
 
 read(dataset::Dataset, i::Integer) = read(getband(dataset, i))
 
 function read(dataset::Dataset, indices::Vector{Cint})
     buffer = Array(getdatatype(getband(dataset, indices[1])),
-                   width(dataset), height(dataset), length(indices))
+        width(dataset), height(dataset), length(indices)
+    )
     rasterio!(dataset, buffer, indices)
 end
 
 function read(dataset::Dataset)
     buffer = Array(getdatatype(getband(dataset, 1)),
-                   width(dataset), height(dataset), nraster(dataset))
+        width(dataset), height(dataset), nraster(dataset)
+    )
     read!(dataset, buffer)
 end
 
-read(dataset::Dataset, i::Integer, xoffset::Integer, yoffset::Integer,
-      xsize::Integer, ysize::Integer) =
+function read(
+        dataset::Dataset,
+        i::Integer,
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     read(getband(dataset, i), xoffset, yoffset, xsize, ysize)
+end
 
-function read{T <: Integer}(dataset::Dataset, indices::Vector{T},
-        xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
+function read{T <: Integer}(
+        dataset::Dataset,
+        indices::Vector{T},
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     buffer = Array(getdatatype(getband(dataset, indices[1])),
-                   width(dataset), height(dataset), length(indices))
+        width(dataset), height(dataset), length(indices)
+    )
     rasterio!(dataset, buffer, indices, xsize, ysize, xoffset, yoffset)
 end
 
-read{U <: Integer}(dataset::Dataset, i::Integer, rows::UnitRange{U},
-                    cols::UnitRange{U}) =
+function read{U <: Integer}(
+        dataset::Dataset,
+        i::Integer,
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     read(getband(dataset, i), rows, cols)
+end
 
-function read{U <: Integer}(dataset::Dataset, indices::Vector{Cint},
-                             rows::UnitRange{U}, cols::UnitRange{U})
+function read{U <: Integer}(
+        dataset::Dataset,
+        indices::Vector{Cint},
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     buffer = Array(getdatatype(getband(dataset, indices[1])),
-                   width(dataset), height(dataset), length(indices))
+        width(dataset), height(dataset), length(indices)
+    )
     rasterio!(dataset, buffer, indices, rows, cols)
 end
 
 write!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer) =
     write!(getband(dataset, i), buffer)
 
-write!{T <: Real}(dataset::Dataset, buffer::Array{T,3},
-                   indices::Vector{Cint})=
+write!{T <: Real}(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}) =
     rasterio!(dataset, buffer, indices, GF_Write)
 
-write!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer,
-        xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer) =
+function write!{T <: Real}(
+        dataset::Dataset,
+        buffer::Array{T, 2},
+        i::Integer,
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
     write!(getband(dataset, i), buffer, xoffset, yoffset, xsize, ysize)
+end
 
-write!{T <: Real}(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint},
-        xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer) =
-    rasterio!(dataset, buffer, indices, xoffset, yoffset, xsize, ysize,
-              GF_Write)
+function write!{T <: Real}(
+        dataset::Dataset,
+        buffer::Array{T, 3},
+        indices::Vector{Cint},
+        xoffset::Integer,
+        yoffset::Integer,
+        xsize::Integer,
+        ysize::Integer
+    )
+    rasterio!(dataset, buffer, indices, xoffset, yoffset,
+        xsize, ysize, GF_Write
+    )
+end
 
-write!{T <: Real, U <: Integer}(dataset::Dataset, buffer::Array{T,2},
-                        i::Integer, rows::UnitRange{U}, cols::UnitRange{U}) =
+function write!{T <: Real, U <: Integer}(
+        dataset::Dataset,
+        buffer::Array{T, 2},
+        i::Integer,
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     write!(getband(dataset, i), buffer, rows, cols)
+end
 
-write!{T <: Real, U <: Integer}(dataset::Dataset, buffer::Array{T,3},
-            indices::Vector{Cint}, rows::UnitRange{U}, cols::UnitRange{U}) =
+function write!{T <: Real, U <: Integer}(
+        dataset::Dataset,
+        buffer::Array{T, 3},
+        indices::Vector{Cint},
+        rows::UnitRange{U},
+        cols::UnitRange{U}
+    )
     rasterio!(dataset, buffer, indices, rows, cols, GF_Write)
+end
 
 for (T,GT) in _GDALTYPE
     eval(quote
@@ -291,19 +419,19 @@ for (T,GT) in _GDALTYPE
                            yoffset::Integer,
                            xsize::Integer,
                            ysize::Integer,
-                           access::GDALRWFlag=GF_Read,
-                           pxspace::Integer=0,
-                           linespace::Integer=0,
-                           bandspace::Integer=0,
-                           extraargs=Ptr{GDAL.GDALRasterIOExtraArg}(C_NULL))
+                           access::GDALRWFlag   = GF_Read,
+                           pxspace::Integer     = 0,
+                           linespace::Integer   = 0,
+                           bandspace::Integer   = 0,
+                           extraargs = Ptr{GDAL.GDALRasterIOExtraArg}(C_NULL))
             (dataset == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize, zbsize = size(buffer)
             nband = length(bands); @assert nband == zbsize
             result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),GDAL.CPLErr,
-                           (Dataset,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,
+                           (GDALDataset,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,
                             Ptr{Void},Cint,Cint,GDAL.GDALDataType,Cint,
                             Ptr{Cint},GDAL.GSpacing,GDAL.GSpacing,GDAL.GSpacing,
-                            Ptr{GDAL.GDALRasterIOExtraArg}),dataset,access,
+                            Ptr{GDAL.GDALRasterIOExtraArg}),dataset.ptr,access,
                             xoffset,yoffset,xsize,ysize,pointer(buffer),xbsize,
                             ybsize,$GT,nband,pointer(bands),pxspace,linespace,
                             bandspace,extraargs)
@@ -317,17 +445,17 @@ for (T,GT) in _GDALTYPE
                            yoffset::Integer,
                            xsize::Integer,
                            ysize::Integer,
-                           access::GDALRWFlag=GF_Read,
-                           pxspace::Integer=0,
-                           linespace::Integer=0,
-                           extraargs=Ptr{GDAL.GDALRasterIOExtraArg}(C_NULL))
+                           access::GDALRWFlag   = GF_Read,
+                           pxspace::Integer     = 0,
+                           linespace::Integer   = 0,
+                           extraargs = Ptr{GDAL.GDALRasterIOExtraArg}(C_NULL))
             (rasterband == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize = size(buffer)
             result = ccall((:GDALRasterIOEx,GDAL.libgdal),GDAL.CPLErr,
-                           (RasterBand,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,
+                           (GDALRasterBand,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,
                             Ptr{Void},Cint,Cint,GDAL.GDALDataType,GDAL.GSpacing,
                             GDAL.GSpacing,Ptr{GDAL.GDALRasterIOExtraArg}),
-                            rasterband,access,xoffset,yoffset,xsize,ysize,
+                            rasterband.ptr,access,xoffset,yoffset,xsize,ysize,
                             pointer(buffer),xbsize,ybsize,$GT,pxspace,linespace,
                             extraargs)
             @cplerr result "Access in RasterIO failed."
@@ -353,7 +481,7 @@ access use RasterIO().
             GetRasterDataType().
 """
 function readblock!(rb::RasterBand, xoffset::Integer, yoffset::Integer, buffer)
-    result = GDAL.readblock(rb, xoffset, yoffset, buffer)
+    result = GDAL.readblock(rb.ptr, xoffset, yoffset, buffer)
     @cplerr result "Failed to read block at ($xoffset,$yoffset)"
     buffer
 end
@@ -375,7 +503,7 @@ access use RasterIO().
             GetRasterDataType().
 """
 function writeblock!(rb::RasterBand, xoffset::Integer, yoffset::Integer, buffer)
-    result = GDAL.writeblock(rb, xoffset, yoffset, buffer)
+    result = GDAL.writeblock(rb.ptr, xoffset, yoffset, buffer)
     @cplerr result "Failed to write block at ($xoffset,$yoffset)"
     buffer
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+Dates

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 cd(dirname(@__FILE__)) do
     isdir("tmp") || mkpath("tmp")
+    include("test_gdal_tutorials.jl")
     include("test_geometry.jl")
     include("test_types.jl")
     include("test_drivers.jl")
@@ -13,7 +14,6 @@ cd(dirname(@__FILE__)) do
     include("test_rasterattrtable.jl")
     include("test_ospy_examples.jl")
     include("test_geos_operations.jl")
-    include("test_gdal_tutorials.jl")
     include("test_cookbook_geometry.jl")
     # left out until https://github.com/visr/GDAL.jl/issues/30 is resolved
     # include("test_cookbook_projection.jl")

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -9,7 +9,6 @@ facts("Test methods for dataset") do
                 @fact AG.noverview(AG.getband(copydataset,1)) --> 0
                 AG.buildoverviews!(copydataset, Cint[2,4,8])
                 @fact AG.noverview(AG.getband(copydataset,1)) --> 3
-                #AG.deletelayer!(copydataset, 0)
                 AG.copywholeraster(dataset, copydataset,
                                    progressfunc=GDAL.C.GDALTermProgress)
             end
@@ -22,3 +21,5 @@ facts("Test methods for dataset") do
     rm("tmp/utmcopy.tif")
     rm("tmp/utmcopy2.tif")
 end
+
+# untested: AG.deletelayer!(copydataset, 0)

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -42,9 +42,9 @@ end
 
 facts("Test Driver Capabilities") do
 AG.registerdrivers() do
-    drivers = AG.drivers()
+    drivers = AG.listdrivers()
     println(drivers)
-    AG.options(AG.shortname(AG.getdriver("GTiff")))
+    AG.options(AG.getdriver("GTiff"))
     println(AG.identifydriver("data/point.geojson"))
     println(AG.identifydriver("data/utmsmall.tif"))
     println(AG.identifydriver("data/A.tif"))

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -44,7 +44,7 @@ facts("Test Driver Capabilities") do
 AG.registerdrivers() do
     drivers = AG.listdrivers()
     println(drivers)
-    AG.options(AG.getdriver("GTiff"))
+    println(AG.driveroptions("GTiff"))
     println(AG.identifydriver("data/point.geojson"))
     println(AG.identifydriver("data/utmsmall.tif"))
     println(AG.identifydriver("data/A.tif"))

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -1,5 +1,6 @@
 using FactCheck
 import ArchGDAL; const AG = ArchGDAL
+import Dates
 
 AG.registerdrivers() do
     AG.read("data/point.geojson") do dataset
@@ -12,7 +13,10 @@ AG.registerdrivers() do
                 println(f2)
                 println(AG.getgeom(f2))
                 fid2 = AG.getfid(f2); println(fid2)
-                println(AG.equals(AG.getgeom(f1),AG.getgeom(f2)))
+                println(AG.equals(AG.getgeom(f1), AG.getgeom(f2)))
+                AG.clone(f1) do f3
+                    @fact AG.equals(AG.getgeom(f1), AG.getgeom(f3)) --> true
+                end
                 AG.setfid!(f1, fid2); AG.setfid!(f2, fid1)
                 println(fid1, fid2)
                 println(AG.getfid(f1), AG.getfid(f2))
@@ -69,6 +73,79 @@ AG.registerdrivers() do
             @fact AG.getfield(f, 1) --> nothing
             AG.fillunsetwithdefault!(f, notnull=false)
             @fact AG.getfield(f, 1) --> "nope"
+        end
+    end
+
+    AG.create("", "MEMORY") do output
+        layer = AG.createlayer(output, "dummy", geom=AG.wkbPolygon)
+        AG.createfielddefn("int64field", AG.OFTInteger64) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("doublefield", AG.OFTReal) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("intlistfield", AG.OFTIntegerList) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("int64listfield", AG.OFTInteger64List) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("doublelistfield", AG.OFTRealList) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("stringlistfield", AG.OFTStringList) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("binaryfield", AG.OFTBinary) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfielddefn("datetimefield", AG.OFTDateTime) do fielddefn
+            AG.createfield!(layer, fielddefn)
+        end
+        AG.createfeature(layer) do feature
+            AG.setfield!(feature, 0, 1)
+            AG.setfield!(feature, 1, 1.0)
+            AG.setfield!(feature, 2, Cint[1, 2])
+            AG.setfield!(feature, 3, Int64[1, 2])
+            AG.setfield!(feature, 4, Float64[1.0, 2.0])
+            AG.setfield!(feature, 5, ["1", "2.0"])
+            AG.setfield!(feature, 6, GDAL.GByte[1,2,3,4])
+            AG.setfield!(feature, 7, Dates.DateTime(2016,9,25,21,17,0))
+
+            AG.createfeature(layer) do newfeature
+                AG.setfrom!(newfeature, feature)
+                @fact AG.getfield(newfeature, 0) --> 1
+                @fact AG.getfield(newfeature, 1) --> roughly(1.0)
+                @fact AG.getfield(newfeature, 2) --> Cint[1, 2]
+                @fact AG.getfield(newfeature, 3) --> Int64[1, 2]
+                @fact AG.getfield(newfeature, 4) --> roughly([1.0, 2.0])
+                @fact AG.getfield(newfeature, 5) --> ["1", "2.0"]
+                @fact AG.getfield(newfeature, 6) --> GDAL.GByte[1,2,3,4]
+                @fact AG.getfield(newfeature, 7) --> Dates.DateTime(2016,9,25,21,17,0)
+
+                AG.createfeature(layer) do lastfeature
+                    AG.setfrom!(lastfeature, feature)
+                    AG.setfield!(lastfeature, 0, 45)
+                    AG.setfield!(lastfeature, 1, 18.2)
+                    AG.setfield!(lastfeature, 5, ["foo", "bar"])
+                    @fact AG.getfield(lastfeature, 0) --> 45
+                    @fact AG.getfield(lastfeature, 1) --> roughly(18.2)
+                    @fact AG.getfield(lastfeature, 2) --> Cint[1, 2]
+                    @fact AG.getfield(lastfeature, 3) --> Int64[1, 2]
+                    @fact AG.getfield(lastfeature, 4) --> roughly([1.0, 2.0])
+                    @fact AG.getfield(lastfeature, 5) --> ["foo", "bar"]
+                    @fact AG.getfield(lastfeature, 6) --> GDAL.GByte[1,2,3,4]
+                    @fact AG.getfield(lastfeature, 7) --> Dates.DateTime(2016,9,25,21,17,0)
+
+                    @fact AG.getfield(newfeature, 0) --> 1
+                    @fact AG.getfield(newfeature, 1) --> roughly(1.0)
+                    @fact AG.getfield(newfeature, 5) --> ["1", "2.0"]
+                    AG.setfrom!(newfeature, lastfeature, collect(Cint, 0:7))
+                    @fact AG.getfield(newfeature, 0) --> 45
+                    @fact AG.getfield(newfeature, 1) --> roughly(18.2)
+                    @fact AG.getfield(newfeature, 5) --> ["foo", "bar"]
+                end
+            end
         end
     end
 end

--- a/test/test_gdal_tutorials.jl
+++ b/test/test_gdal_tutorials.jl
@@ -68,7 +68,7 @@ AG.registerdrivers() do
             layer = AG.getlayer(dataset, 0)
             @fact AG.getname(layer) --> "OGRGeoJSON"
             layerbyname = AG.getlayer(dataset, "OGRGeoJSON")
-            @fact layerbyname --> layer
+            @fact layerbyname.ptr --> layer.ptr
             AG.resetreading!(layer)
 
             featuredefn = AG.getlayerdefn(layer)

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -33,11 +33,11 @@ facts("Create a Point") do
         end
         AG.flattento2d!(point)
         @fact AG.getcoorddim(point) --> 2
-        @fact AG.nonlineargeomisenabledflag() --> true
-        AG.enablenonlineargeom(false)
-        @fact AG.nonlineargeomisenabledflag() --> false
-        AG.enablenonlineargeom(true)
-        @fact AG.nonlineargeomisenabledflag() --> true
+        @fact AG.getnonlineargeomflag() --> true
+        AG.setnonlineargeomflag!(false)
+        @fact AG.getnonlineargeomflag() --> false
+        AG.setnonlineargeomflag!(true)
+        @fact AG.getnonlineargeomflag() --> true
         AG.closerings!(point)
         @fact AG.toJSON(point) --> "{ \"type\": \"Point\", \"coordinates\": [ 100.0, 70.0 ] }"
     end

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -153,6 +153,7 @@ facts("Testing remaining methods for geometries") do
 end
 
 # Untested
+# toISOWKT(geom::Geometry)
 # unsafe_polygonfromedges(lines::Geometry, besteffort::Bool,autoclose::Bool, tol::Real)
 # setspatialref!(geom::Geometry, spatialref::SpatialRef)
 # getspatialref(geom::Geometry) = GDAL.getspatialreference(geom)

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -226,15 +226,20 @@ end
 facts("Simplify") do
     AG.fromWKT("POLYGON EMPTY") do g1
         @fact AG.isempty(g1) --> true
-        AG.simplify!(g1, 43.2)
-        @fact AG.isempty(g1) --> true
+        AG.simplify(g1, 43.2) do g2
+            @fact AG.isempty(g2) --> false
+        end
     end
 
     AG.fromWKT("POLYGON((56.528666666700 25.2101666667, 56.529000000000 25.2105000000, 56.528833333300 25.2103333333, 56.528666666700 25.2101666667))") do g1
-        @fact AG.toWKT(AG.simplify!(g1, 0.0)) --> "POLYGON EMPTY"
+        AG.simplify(g1, 0.0) do g2
+            @fact AG.toWKT(g2) --> "POLYGON EMPTY"
+        end
     end
 
     AG.fromWKT("POLYGON((56.528666666700 25.2101666667, 56.529000000000 25.2105000000, 56.528833333300 25.2103333333, 56.528666666700 25.2101666667))") do g1
-        @fact AG.toWKT(AG.simplifypreservetopology!(g1, 43.2)) --> "POLYGON ((56.5286666667 25.2101666667,56.529 25.2105,56.5288333333 25.2103333333,56.5286666667 25.2101666667))"
+        AG.simplifypreservetopology(g1, 43.2) do g2
+            @fact AG.toWKT(g2) --> "POLYGON ((56.5286666667 25.2101666667,56.529 25.2105,56.5288333333 25.2103333333,56.5286666667 25.2101666667))"
+        end
     end
 end

--- a/test/test_ospy_examples.jl
+++ b/test/test_ospy_examples.jl
@@ -93,6 +93,7 @@ AG.read("ospy/data1/sites.shp") do input
         AG.createfield!(outlayer, AG.getfielddefn(inlayerdefn, 1))
         for infeature in inlayer
             id = AG.getfield(infeature, 0)
+            @fact AG.asint64(infeature, 0) --> id
             cover = AG.getfield(infeature, 1)
             if cover == "trees"
                 AG.createfeature(outlayer) do outfeature
@@ -182,8 +183,7 @@ facts("Homework 3") do
                 AG.buffer(AG.getgeom(nibleyFeature), 1500) do bufferGeom
                     AG.setspatialfilter!(siteslayer, bufferGeom)
                     for sitefeature in siteslayer
-                        id_index = AG.getfieldindex(sitefeature, "ID")
-                        println(AG.getfield(sitefeature, id_index))
+                        println(AG.getfield(sitefeature, "ID"))
     end end end end end
     
     #reference: http://www.gis.usu.edu/~chrisg/python/2009/lectures/ospy_hw3b.py

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -35,21 +35,6 @@ facts("Test methods for rasterband") do
             AG.deletenodatavalue!(rb)
             @fact AG.getnodatavalue(rb) --> roughly(-1e10)
 
-            AG.createcolortable(AG.GPI_RGB) do ct
-                AG.createcolorramp!(ct,
-                    128, GDAL.GDALColorEntry(0,0,0,0),
-                    255, GDAL.GDALColorEntry(0,0,255,0)
-                )
-                AG.setcolortable!(rb, ct)
-                println(AG.getcolortable(rb))
-                AG.clearcolortable!(rb)
-                
-                AG.createRAT(ct) do rat
-                    AG.setdefaultRAT!(rb, rat)
-                    println(AG.getdefaultRAT(rb))
-                end
-            end
-
             AG.createcopy(dataset, "tmp/utmsmall.tif") do dest
                 destband = AG.getband(dest, 1)
                 AG.copywholeraster!(rb, destband)
@@ -59,9 +44,9 @@ facts("Test methods for rasterband") do
                 @fact AG.noverview(destband) --> 3
                 println(destband)
 
-                @fact AG.getcolorinterp(rb) --> AG.GCI_PaletteIndex
-                AG.setcolorinterp!(rb, AG.GCI_RedBand)
-                @fact AG.getcolorinterp(rb) --> AG.GCI_RedBand
+                @fact AG.getcolorinterp(destband) --> AG.GCI_GrayIndex
+                AG.setcolorinterp!(destband, AG.GCI_RedBand)
+                @fact AG.getcolorinterp(destband) --> AG.GCI_RedBand
 
                 println(AG.getsampleoverview(destband, 100))
                 println(AG.getsampleoverview(destband, 200))
@@ -80,6 +65,21 @@ facts("Test methods for rasterband") do
                     AG.getoverview(destband, 0),
                     AG.getoverview(destband, 2)
                 ])
+
+                AG.createcolortable(AG.GPI_RGB) do ct
+                    AG.createcolorramp!(ct,
+                        128, GDAL.GDALColorEntry(0,0,0,0),
+                        255, GDAL.GDALColorEntry(0,0,255,0)
+                    )
+                    AG.setcolortable!(destband, ct)
+                    println(AG.getcolortable(destband))
+                    AG.clearcolortable!(destband)
+                    
+                    AG.createRAT(ct) do rat
+                        AG.setdefaultRAT!(destband, rat)
+                        println(AG.getdefaultRAT(destband))
+                    end
+                end
             end
 
             rm("tmp/utmsmall.tif")

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -36,16 +36,18 @@ facts("Test methods for rasterband") do
             @fact AG.getnodatavalue(rb) --> roughly(-1e10)
 
             AG.createcolortable(AG.GPI_RGB) do ct
-                # AG.setcolortable!(rb, ct)
-                # println(AG.getcolortable(rb))
-                # AG.clearcolortable!(rb)
+                AG.createcolorramp!(ct,
+                    128, GDAL.GDALColorEntry(0,0,0,0),
+                    255, GDAL.GDALColorEntry(0,0,255,0)
+                )
+                AG.setcolortable!(rb, ct)
+                println(AG.getcolortable(rb))
+                AG.clearcolortable!(rb)
                 
                 AG.createRAT(ct) do rat
                     AG.setdefaultRAT!(rb, rat)
                     println(AG.getdefaultRAT(rb))
                 end
-
-                # AG.setcolorinterp!(rb, AG.GCI_RedBand)
             end
 
             AG.createcopy(dataset, "tmp/utmsmall.tif") do dest
@@ -56,6 +58,11 @@ facts("Test methods for rasterband") do
                 AG.buildoverviews!(dest, Cint[2, 4, 8])
                 @fact AG.noverview(destband) --> 3
                 println(destband)
+
+                @fact AG.getcolorinterp(rb) --> AG.GCI_PaletteIndex
+                AG.setcolorinterp!(rb, AG.GCI_RedBand)
+                @fact AG.getcolorinterp(rb) --> AG.GCI_RedBand
+
                 println(AG.getsampleoverview(destband, 100))
                 println(AG.getsampleoverview(destband, 200))
                 println(AG.getsampleoverview(destband, 500))
@@ -68,6 +75,11 @@ facts("Test methods for rasterband") do
                 AG.fillraster!(destband, 3)
                 AG.setcategorynames!(destband, ["foo","bar"])
                 @fact AG.getcategorynames(destband) --> ["foo", "bar"]
+
+                AG.regenerateoverviews!(destband, AG.RasterBand[
+                    AG.getoverview(destband, 0),
+                    AG.getoverview(destband, 2)
+                ])
             end
 
             rm("tmp/utmsmall.tif")

--- a/test/test_styletable.jl
+++ b/test/test_styletable.jl
@@ -2,69 +2,69 @@ using FactCheck
 import ArchGDAL; const AG = ArchGDAL
 
 facts("Testing StyleTable Methods") do
-    AG.registerdrivers() do
-        AG.createstylemanager() do sm
-            AG.initialize!(sm)
-            @fact AG.npart(sm) --> 0
-            AG.initialize!(sm, "some stylestring")
-            @fact AG.npart(sm) --> 1
-            AG.addstyle!(sm,"name1","style1")
-            @fact AG.npart(sm) --> 1
-            AG.addstyle!(sm,"name2")
-            @fact AG.npart(sm) --> 1
-
-            AG.createstyletool(AG.OGRSTCBrush) do st
-                @fact AG.gettype(st) --> AG.OGRSTCBrush
-                @fact AG.getunit(st) --> AG.OGRSTUMM
-                AG.setunit!(st, AG.OGRSTUPixel, 2.0)
-                @fact AG.getunit(st) --> AG.OGRSTUPixel
-
-
-                AG.setparam!(st, 0, 0)
-                    @fact AG.asint(st, 0) --> 0
-                    @fact AG.asstring(st, 0) --> "0"
-                    @fact AG.asdouble(st, 0) --> 0
-                AG.setparam!(st, 1, 12)
-                    @fact AG.asint(st, 1) --> 12
-                    @fact AG.asstring(st, 1) --> "12"
-                    @fact AG.asdouble(st, 1) --> 12
-                AG.setparam!(st, 2, "foo")
-                    @fact AG.asstring(st, 2) --> "foo"
-
-                @fact AG.npart(sm) --> 1
-                AG.addpart!(sm, st)
-                @fact AG.npart(sm) --> 2
-                @fact AG.npart(sm, "some stylestring") --> 1
-                println(AG.getpart(sm, 1))
-            end
-
-            AG.createstyletable() do stbl
-                AG.addstyle!(stbl, "name1", "style1")
-                AG.addstyle!(stbl, "name2", "style2")
-                AG.addstyle!(stbl, "name3", "style3")
-                AG.addstyle!(stbl, "name4", "style4")
-                @fact AG.find(stbl, "name3") --> "style3"
-                @fact AG.laststyle(stbl) --> ""
-                @fact AG.nextstyle(stbl) --> "style1"
-                @fact AG.nextstyle(stbl) --> "style2"
-                AG.resetreading!(stbl)
-                @fact AG.nextstyle(stbl) --> "style1"
-                AG.savestyletable(stbl, "tmp/styletable.txt")
-            end
-            AG.createstyletable() do stbl
-                AG.loadstyletable!(stbl, "tmp/styletable.txt")
-                @fact AG.find(stbl, "name3") --> "style3"
-                @fact AG.laststyle(stbl) --> ""
-                @fact AG.nextstyle(stbl) --> "style1"
-                @fact AG.nextstyle(stbl) --> "style2"
-                AG.resetreading!(stbl)
-                @fact AG.nextstyle(stbl) --> "style1"
-            end
-            rm("tmp/styletable.txt")
+    AG.createstylemanager() do sm
+        @fact AG.initialize!(sm) --> true
+        @fact AG.npart(sm) --> 0
+        @fact AG.initialize!(sm, "PEN(w:2px,c:#000000,id:\"mapinfo-pen-2,ogr-pen-0\")") --> true
+        AG.getpart(sm, 0) do st
+            @fact AG.getstylestring(st) --> "PEN(w:2px,c:#000000,id:\"mapinfo-pen-2,ogr-pen-0\")"
+            @fact AG.getrgba(st, "#123456") --> (18, 52, 86, 255)
         end
+        @fact AG.npart(sm) --> 1
+        @fact AG.addstyle!(sm, "name1", "style1") --> false
+        @fact AG.npart(sm) --> 1
+        @fact AG.addstyle!(sm, "name2") --> false
+        @fact AG.npart(sm) --> 1
+
+        AG.createstyletool(AG.OGRSTCBrush) do st
+            @fact AG.gettype(st) --> AG.OGRSTCBrush
+            @fact AG.getunit(st) --> AG.OGRSTUMM
+            AG.setunit!(st, AG.OGRSTUPixel, 2.0)
+            @fact AG.getunit(st) --> AG.OGRSTUPixel
+
+            AG.setparam!(st, 0, 0)
+                @fact AG.asint(st, 0) --> 0
+                @fact AG.asstring(st, 0) --> "0"
+                @fact AG.asdouble(st, 0) --> 0
+            AG.setparam!(st, 1, 12)
+                @fact AG.asint(st, 1) --> 12
+                @fact AG.asstring(st, 1) --> "12"
+                @fact AG.asdouble(st, 1) --> 12
+            AG.setparam!(st, 2, "foo")
+                @fact AG.asstring(st, 2) --> "foo"
+            AG.setparam!(st, 3, 0.5)
+                @fact AG.asdouble(st, 3) --> roughly(0.5)
+
+            @fact AG.npart(sm) --> 1
+            AG.addpart!(sm, st)
+            @fact AG.npart(sm) --> 2
+            @fact AG.npart(sm, "some stylestring") --> 1
+        end
+
+        AG.createstyletable() do stbl
+            AG.addstyle!(stbl, "name1", "style1")
+            AG.addstyle!(stbl, "name2", "style2")
+            AG.addstyle!(stbl, "name3", "style3")
+            AG.addstyle!(stbl, "name4", "style4")
+            @fact AG.find(stbl, "name3") --> "style3"
+            @fact AG.laststyle(stbl) --> ""
+            @fact AG.nextstyle(stbl) --> "style1"
+            @fact AG.nextstyle(stbl) --> "style2"
+            AG.resetreading!(stbl)
+            @fact AG.nextstyle(stbl) --> "style1"
+            AG.savestyletable(stbl, "tmp/styletable.txt")
+        end
+        AG.createstyletable() do stbl
+            AG.loadstyletable!(stbl, "tmp/styletable.txt")
+            @fact AG.find(stbl, "name3") --> "style3"
+            @fact AG.laststyle(stbl) --> ""
+            @fact AG.nextstyle(stbl) --> "style1"
+            @fact AG.nextstyle(stbl) --> "style2"
+            AG.resetreading!(stbl)
+            @fact AG.nextstyle(stbl) --> "style1"
+        end
+        rm("tmp/styletable.txt")
     end
 end
 
-# initialize!(stylemanager::StyleManager, feature::Feature)
-# getpart(stylemanager::StyleManager,id::Integer,stylestring::AbstractString)
-# getrgba(styletool::StyleTool,color::AbstractString)
+# Untested: initialize!(stylemanager::StyleManager, feature::Feature)


### PR DESCRIPTION
Main changes:
- introduce Wrapper Types for GDAL handles (closes #11)
- major effort at consistency in code format
- introduction of a `@gdal` macro to simplify `ccall`s
- removal of `nfeature` from `Base.display` for FeatureLayers, since it can take a prohibitively long time for some databases
- bugfixes for `simplify` and `simplifypreservetopology`