### PR TITLE
don't require or import Dates

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
 FactCheck
-Dates

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -1,6 +1,5 @@
 using FactCheck
 import ArchGDAL; const AG = ArchGDAL
-import Dates
 
 AG.registerdrivers() do
     AG.read("data/point.geojson") do dataset


### PR DESCRIPTION
it is in Base since julia v0.4, and putting it in the test/REQUIRE will cause the Dates.jl packages that is there for v0.3 compat to be downloaded

`import Dates` does nothing since Dates as a module is exported into Base