### PR TITLE
Update to Julia 0.6, drop 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
- - julia -e 'Pkg.clone("https://github.com/visr/GDAL.jl.git"); Pkg.build("GDAL"); Pkg.clone(pwd()); Pkg.build("ArchGDAL"); Pkg.test("ArchGDAL"; coverage=true)'
+ - julia --color=yes -e 'Pkg.clone("https://github.com/visr/GDAL.jl.git"); Pkg.build("GDAL"); Pkg.clone(pwd()); Pkg.build("ArchGDAL"); Pkg.test("ArchGDAL"; coverage=true)'
 after_success:
 - julia -e 'cd(Pkg.dir("ArchGDAL")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ os:
 julia:
   - release
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
+  fast_finish: true
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 julia> import ArchGDAL; const AG = ArchGDAL
 ArchGDAL
 
+julia> import Base.read
+
 julia> function read(f, filename)
            return AG.registerdrivers() do
                AG.read(filename) do dataset

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 
 
 ```julia
-  | | |_| | | | (_| |  |  Version 0.4.6 (2016-06-19 17:16 UTC)
- _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
-|__/                   |  x86_64-apple-darwin13.4.0
+   _       _ _(_)_     |  A fresh approach to technical computing
+  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
+   _ _   _| |_  __ _   |  Type "?help" for help.
+  | | | | | | |/ _` |  |
+  | | |_| | | | (_| |  |  Version 0.6.0 (2017-08-03 08:04 UTC)
+ _/ |\__'_|_|_|\__'_|  |  Commit 80a9f1f11* (58 days old release-0.6)
+|__/                   |  x86_64-apple-darwin16.7.0
 
 julia> import ArchGDAL; const AG = ArchGDAL
 ArchGDAL

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -16,7 +16,7 @@ function Base.done(layer::FeatureLayer, state::Vector{Feature})
     end
 end
 
-immutable BlockIterator
+struct BlockIterator
     rows::Cint
     cols::Cint
     ni::Cint
@@ -51,7 +51,7 @@ function Base.next(obj::BlockIterator, iter::Int)
 end
 Base.done(obj::BlockIterator, iter::Int) = (iter == obj.n)
 
-immutable WindowIterator
+struct WindowIterator
     blockiter::BlockIterator
 end
 function windows(raster::RasterBand)
@@ -65,7 +65,7 @@ function Base.next(obj::WindowIterator, iter::Int)
 end
 Base.done(obj::WindowIterator, iter::Int) = Base.done(obj.blockiter, iter)
 
-type BufferIterator{T <: Real}
+mutable struct BufferIterator{T <: Real}
     raster::RasterBand
     w::WindowIterator
     buffer::Array{T, 2}

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -74,7 +74,7 @@ function bufferwindows(raster::RasterBand)
     BufferIterator(
         raster,
         windows(raster),
-        Array(getdatatype(raster), getblocksize(raster)...)
+        Array{getdatatype(raster)}(getblocksize(raster)...)
     )
 end
 Base.start(obj::BufferIterator) = Base.start(obj.w)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -527,7 +527,7 @@ function getgeotransform!(dataset::Dataset, transform::Vector{Cdouble})
     transform
 end
 
-getgeotransform(dataset::Dataset) = getgeotransform!(dataset, Array(Cdouble, 6))
+getgeotransform(dataset::Dataset) = getgeotransform!(dataset, Array{Cdouble}(6))
 
 "Set the affine transformation coefficients."
 function setgeotransform!(dataset::Dataset, transform::Vector{Cdouble})

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -74,7 +74,7 @@ in the list of creation options are compatible with the capabilities declared
 by the `GDAL_DMD_CREATIONOPTIONLIST` metadata item. In case of incompatibility
 a (non fatal) warning will be emited and `FALSE` will be returned.
 """
-validate{T <: AbstractString}(drv::Driver, options::Vector{T}) = 
+validate(drv::Driver, options::Vector{T}) where {T <: AbstractString} = 
     Bool(@gdal(GDALValidateCreationOptions::Cint,
         drv.ptr::GDALDriver,
         options::StringList

--- a/src/gcp.jl
+++ b/src/gcp.jl
@@ -18,7 +18,7 @@ function invgeotransform!(gt_in::Vector{Cdouble}, gt_out::Vector{Cdouble})
 end
 
 invgeotransform(gt_in::Vector{Cdouble}) =
-    invgeotransform!(gt_in, Array(Cdouble, 6))
+    invgeotransform!(gt_in, Array{Cdouble}(6))
 
 """
 Apply GeoTransform to x/y coordinate.
@@ -37,7 +37,7 @@ georeferenced `(geo_x,geo_y)` location.
 function applygeotransform(geotransform::Vector{Cdouble},
                            pixel::Cdouble,
                            line::Cdouble)
-    geo_xy = Array(Cdouble, 2)
+    geo_xy = Array{Cdouble}(2)
     geo_x = pointer(geo_xy)
     geo_y = geo_x + sizeof(Cdouble)
     GDAL.applygeotransform(pointer(geotransform), pixel, line, geo_x, geo_y)
@@ -63,4 +63,4 @@ function composegeotransform!(gt1::Vector{Cdouble}, gt2::Vector{Cdouble},
 end
 
 composegeotransform(gt1::Vector{Cdouble}, gt2::Vector{Cdouble}) =
-    composegeotransform!(gt1, gt2, Array(Cdouble, 6))
+    composegeotransform!(gt1, gt2, Array{Cdouble}(6))

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -177,8 +177,9 @@ pointer may be NULL or non-NULL.
 """
 function asintlist(feature::Feature, i::Integer)
     n = Ref{Cint}()
+    a = Array{Int32}
     ptr = GDAL.checknull(GDAL.getfieldasintegerlist(feature.ptr, i, n))
-    pointer_to_array(ptr, n[], false)
+    unsafe_wrap(a, ptr, n.x)
 end
 
 """
@@ -197,8 +198,9 @@ pointer may be NULL or non-NULL.
 """
 function asint64list(feature::Feature, i::Integer)
     n = Ref{Cint}()
+    a = Array{Int64}
     ptr = GDAL.checknull(GDAL.getfieldasinteger64list(feature.ptr, i, n))
-    pointer_to_array(ptr, n[], false)
+    unsafe_wrap(a, ptr, n.x)
 end
 
 """
@@ -218,7 +220,8 @@ pointer may be NULL or non-NULL.
 function asdoublelist(feature::Feature, i::Integer)
     n = Ref{Cint}()
     ptr = GDAL.checknull(GDAL.getfieldasdoublelist(feature.ptr, i, n))
-    pointer_to_array(ptr, n[], false)
+    a = Array{Float64}
+    unsafe_wrap(a, ptr, n.x)
 end
 
 """
@@ -252,8 +255,9 @@ Its lifetime may be very brief.
 """
 function asbinary(feature::Feature, i::Integer)
     n = Ref{Cint}()
+    a = Array{UInt8}
     ptr = GDAL.checknull(GDAL.getfieldasbinary(feature.ptr, i, n))
-    pointer_to_array(ptr, n[], false)
+    unsafe_wrap(a, ptr, n.x)
 end
 
 """

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -54,7 +54,7 @@ function setgeom!(feature::Feature, geom::AbstractGeometry)
 end
 
 "Fetch an handle to internal feature geometry. It should not be modified."
-getgeom{G <: AbstractGeometry}(::Type{G}, feature::Feature) =
+getgeom(::Type{G}, feature::Feature) where {G <: AbstractGeometry} =
     G(GDAL.getgeometryref(feature.ptr))
 getgeom(feature::Feature) = getgeom(Geometry, feature)
 
@@ -481,11 +481,11 @@ field types may be unaffected.
 * `iField`: the field to set, from 0 to GetFieldCount()-1.
 * `papszValues`: the values to assign.
 """
-function setfield!{T <: AbstractString}(
+function setfield!(
         feature::Feature,
         i::Integer,
         value::Vector{T}
-    )
+    ) where T <: AbstractString
     @gdal(OGR_F_SetFieldStringList::Void,
         feature.ptr::GDALFeature,
         i::Cint,
@@ -606,7 +606,7 @@ Fetch pointer to the feature geometry.
 ### Returns
 an internal feature geometry. This object should not be modified.
 """
-getgeomfield{G <: AbstractGeometry}(::Type{G}, feature::Feature, i::Integer) =
+getgeomfield(::Type{G}, feature::Feature, i::Integer) where {G <: AbstractGeometry} =
     G(GDAL.getgeomfieldref(feature.ptr, i))
 getgeomfield(feature::Feature, i::Integer) = getgeomfield(Geometry, feature, i)
 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -76,15 +76,11 @@ Create an empty geometry of desired type.
 This is equivalent to allocating the desired geometry with new, but the
 allocation is guaranteed to take place in the context of the GDAL/OGR heap.
 """
-function unsafe_creategeom(::Type{G},
-        geomtype::OGRwkbGeometryType
-    ) where G <: AbstractGeometry
-    G(GDAL.checknull(@gdal(OGR_G_CreateGeometry::GDALGeometry,
-        geomtype::GDAL.OGRwkbGeometryType
-    )))
+function unsafe_creategeom(::Type{G}, geomtype::OGRwkbGeometryType ) where G <: AbstractGeometry
+    G(GDAL.checknull(@gdal(OGR_G_CreateGeometry::GDALGeometry, geomtype::GDAL.OGRwkbGeometryType)))
 end
-unsafe_creategeom(geomtype::OGRwkbGeometryType) =
-    unsafe_creategeom(Geometry, geomtype)
+
+unsafe_creategeom(geomtype::OGRwkbGeometryType) = unsafe_creategeom(Geometry, geomtype)
 
 """
 Tries to force the provided geometry to the specified geometry type.
@@ -173,7 +169,7 @@ Convert a geometry well known binary format.
 * `order`: One of wkbXDR or [wkbNDR] indicating MSB or LSB byte order resp.
 """
 function toWKB(geom::AbstractGeometry, order::OGRwkbByteOrder=wkbNDR)
-    buffer = Array(Cuchar, wkbsize(geom))
+    buffer = Array{Cuchar}(wkbsize(geom))
     result = @gdal(OGR_G_ExportToWkb::GDAL.OGRErr,
         geom.ptr::GDALGeometry,
         order::GDAL.OGRwkbByteOrder,
@@ -191,7 +187,7 @@ Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known binary format.
 * `order`: One of wkbXDR or [wkbNDR] indicating MSB or LSB byte order resp.
 """
 function toISOWKB(geom::AbstractGeometry, order::OGRwkbByteOrder=wkbNDR)
-    buffer = Array(Cuchar, wkbsize(geom))
+    buffer = Array{Cuchar}(wkbsize(geom))
     result = @gdal(OGR_G_ExportToIsoWkb::GDAL.OGRErr,
         geom.ptr::GDALGeometry,
         order::GDAL.OGRwkbByteOrder,

--- a/src/raster/rasterattributetable.jl
+++ b/src/raster/rasterattributetable.jl
@@ -244,14 +244,14 @@ Read or Write a block of strings to/from the Attribute Table.
 * `nrows`       Number of rows to read or write
 * `data`        Array of strings to read/write. Should be at least `nrows` long.
 """
-function attributeio!{T <: AbstractString}(
+function attributeio!(
         rat::RasterAttrTable,
         access::GDALRWFlag,
         col::Integer,
         startrow::Integer,
         nrows::Integer,
         data::Vector{T}
-    )
+    ) where T <: AbstractString
     result = @gdal(GDALRATValuesIOAsString::GDAL.CPLErr,
         rat.ptr::GDALRasterAttrTable,
         access::GDAL.GDALRWFlag,

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -15,7 +15,7 @@ meaning that right and bottom edge blocks may be incomplete. See `ReadBlock()`
 for an example of code dealing with these issues.
 """
 function getblocksize(rb::RasterBand)
-    xy = Array(Cint, 2); x = pointer(xy); y = x + sizeof(Cint)
+    xy = Array{Cint}(2); x = pointer(xy); y = x + sizeof(Cint)
     GDAL.getblocksize(rb.ptr, x, y)
     xy
 end

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -53,7 +53,7 @@ with additional arguments to specify resampling and progress callback, or
 option can also be defined to override the default resampling to one of
 `BILINEAR`, `CUBIC`, `CUBICSPLINE`, `LANCZOS`, `AVERAGE` or `MODE`.
 """
-function rasterio!{T <: Real}(
+function rasterio!(
         dataset::Dataset,
         buffer::Array{T, 3},
         bands::Vector{Cint},
@@ -61,13 +61,13 @@ function rasterio!{T <: Real}(
         pxspace::Integer    = 0,
         linespace::Integer  = 0,
         bandspace::Integer  = 0
-    )
+    ) where T <: Real
     rasterio!(dataset, buffer, bands, 0, 0, width(dataset), height(dataset),
         access, pxspace, linespace, bandspace
     )
 end
 
-function rasterio!{T <: Real, U <: Integer}(
+function rasterio!(
         dataset::Dataset,
         buffer::Array{T, 3},
         bands::Vector{Cint},
@@ -77,7 +77,7 @@ function rasterio!{T <: Real, U <: Integer}(
         pxspace::Integer    = 0,
         linespace::Integer  = 0,
         bandspace::Integer  = 0
-    )
+    ) where {T <: Real, U <: Integer}
     xsize = cols[end] - cols[1] + 1; xsize < 0 && error("invalid window width")
     ysize = rows[end] - rows[1] + 1; ysize < 0 && error("invalid window height")
     rasterio!(dataset, buffer, bands, cols[1], rows[1], xsize, ysize, access,
@@ -141,19 +141,19 @@ option can also be defined to override the default resampling to one of
 ### Returns
 `CE_Failure` if the access fails, otherwise `CE_None`.
 """
-function rasterio!{T <: Real}(
+function rasterio!(
         rasterband::RasterBand,
         buffer::Array{T,2},
         access::GDALRWFlag  = GF_Read,
         pxspace::Integer    = 0,
         linespace::Integer  = 0
-    )
+    ) where T <: Real
     rasterio!(rasterband, buffer, 0, 0, width(rasterband), height(rasterband),
         access, pxspace, linespace
     )
 end
 
-function rasterio!{T <: Real, U <: Integer}(
+function rasterio!(
         rasterband::RasterBand,
         buffer::Array{T,2},
         rows::UnitRange{U},
@@ -161,7 +161,7 @@ function rasterio!{T <: Real, U <: Integer}(
         access::GDALRWFlag  = GF_Read,
         pxspace::Integer    = 0,
         linespace::Integer  = 0
-    )
+    ) where {T <: Real, U <: Integer}
     xsize = length(cols); xsize < 1 && error("invalid window width")
     ysize = length(rows); ysize < 1 && error("invalid window height")
     rasterio!(rasterband, buffer, cols[1]-1, rows[1]-1, xsize, ysize,
@@ -169,26 +169,26 @@ function rasterio!{T <: Real, U <: Integer}(
     )
 end
 
-read!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
+read!(rb::RasterBand, buffer::Array{T,2}) where {T <: Real} =
     rasterio!(rb, buffer, GF_Read)
 
-function read!{T <: Real}(
+function read!(
         rb::RasterBand,
         buffer::Array{T,2},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
 end
 
-function read!{T <: Real, U <: Integer}(
+function read!(
         rb::RasterBand,
         buffer::Array{T,2},
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     rasterio!(rb, buffer, rows, cols)
 end
 
@@ -207,52 +207,52 @@ function read(
 end
 
 
-function read{U <: Integer}(
+function read(
         rb::RasterBand,
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where U <: Integer
     rasterio!(rb,
         Array(getdatatype(rb), length(cols), length(rows)),
         rows, cols
     )
 end
 
-write!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
+write!(rb::RasterBand, buffer::Array{T,2}) where {T <: Real} =
     rasterio!(rb, buffer, GF_Write)
 
-function write!{T <: Real}(
+function write!(
         rb::RasterBand,
         buffer::Array{T, 2},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize, GF_Write)
 end
 
-function write!{T <: Real, U <: Integer}(
+function write!(
         rb::RasterBand,
         buffer::Array{T, 2},
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     rasterio!(rb, buffer, rows, cols, GF_Write)
 end
 
-read!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer) =
+read!(dataset::Dataset, buffer::Array{T,2}, i::Integer) where {T <: Real} =
     read!(getband(dataset, i), buffer)
 
-read!{T <: Real}(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}) =
+read!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}) where {T <: Real} =
     rasterio!(dataset, buffer, indices, GF_Read)
 
-function read!{T <: Real}(dataset::Dataset, buffer::Array{T,3})
+function read!(dataset::Dataset, buffer::Array{T,3}) where T <: Real
     nband = nraster(dataset); @assert size(buffer, 3) == nband
     rasterio!(dataset, buffer, collect(Cint, 1:nband), GF_Read)
 end
 
-function read!{T <: Real}(
+function read!(
         dataset::Dataset,
         buffer::Array{T, 2},
         i::Integer,
@@ -260,11 +260,11 @@ function read!{T <: Real}(
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     read!(getband(dataset, i), buffer, xoffset, yoffset, xsize, ysize)
 end
 
-function read!{T <: Real}(
+function read!(
         dataset::Dataset,
         buffer::Array{T, 3},
         indices::Vector{Cint},
@@ -272,27 +272,27 @@ function read!{T <: Real}(
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     rasterio!(dataset, buffer, indices, xoffset, yoffset, xsize, ysize)
 end
 
-function read!{T <: Real, U <: Integer}(
+function read!(
         dataset::Dataset,
         buffer::Array{T, 2},
         i::Integer,
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     read!(getband(dataset, i), buffer, rows, cols)
 end
 
-function read!{T <: Real, U <: Integer}(
+function read!(
         dataset::Dataset,
         buffer::Array{T, 3},
         indices::Vector{Cint},
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     rasterio!(dataset, buffer, indices, rows, cols)
 end
 
@@ -323,48 +323,48 @@ function read(
     read(getband(dataset, i), xoffset, yoffset, xsize, ysize)
 end
 
-function read{T <: Integer}(
+function read(
         dataset::Dataset,
         indices::Vector{T},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Integer
     buffer = Array(getdatatype(getband(dataset, indices[1])),
         width(dataset), height(dataset), length(indices)
     )
     rasterio!(dataset, buffer, indices, xsize, ysize, xoffset, yoffset)
 end
 
-function read{U <: Integer}(
+function read(
         dataset::Dataset,
         i::Integer,
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where U <: Integer
     read(getband(dataset, i), rows, cols)
 end
 
-function read{U <: Integer}(
+function read(
         dataset::Dataset,
         indices::Vector{Cint},
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where U <: Integer
     buffer = Array(getdatatype(getband(dataset, indices[1])),
         width(dataset), height(dataset), length(indices)
     )
     rasterio!(dataset, buffer, indices, rows, cols)
 end
 
-write!{T <: Real}(dataset::Dataset, buffer::Array{T,2}, i::Integer) =
+write!(dataset::Dataset, buffer::Array{T,2}, i::Integer) where {T <: Real} =
     write!(getband(dataset, i), buffer)
 
-write!{T <: Real}(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}) =
+write!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}) where {T <: Real} =
     rasterio!(dataset, buffer, indices, GF_Write)
 
-function write!{T <: Real}(
+function write!(
         dataset::Dataset,
         buffer::Array{T, 2},
         i::Integer,
@@ -372,11 +372,11 @@ function write!{T <: Real}(
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     write!(getband(dataset, i), buffer, xoffset, yoffset, xsize, ysize)
 end
 
-function write!{T <: Real}(
+function write!(
         dataset::Dataset,
         buffer::Array{T, 3},
         indices::Vector{Cint},
@@ -384,29 +384,29 @@ function write!{T <: Real}(
         yoffset::Integer,
         xsize::Integer,
         ysize::Integer
-    )
+    ) where T <: Real
     rasterio!(dataset, buffer, indices, xoffset, yoffset,
         xsize, ysize, GF_Write
     )
 end
 
-function write!{T <: Real, U <: Integer}(
+function write!(
         dataset::Dataset,
         buffer::Array{T, 2},
         i::Integer,
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     write!(getband(dataset, i), buffer, rows, cols)
 end
 
-function write!{T <: Real, U <: Integer}(
+function write!(
         dataset::Dataset,
         buffer::Array{T, 3},
         indices::Vector{Cint},
         rows::UnitRange{U},
         cols::UnitRange{U}
-    )
+    ) where {T <: Real, U <: Integer}
     rasterio!(dataset, buffer, indices, rows, cols, GF_Write)
 end
 

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -193,7 +193,7 @@ function read!(
 end
 
 read(rb::RasterBand) =
-    rasterio!(rb, Array(getdatatype(rb), width(rb), height(rb)))
+    rasterio!(rb, Array{getdatatype(rb)}(width(rb), height(rb)))
 
 function read(
         rb::RasterBand,
@@ -202,10 +202,9 @@ function read(
         xsize::Integer,
         ysize::Integer
     )
-    buffer = Array(getdatatype(rb), width(rb), height(rb))
+    buffer = Array{getdatatype(rb)}(width(rb), height(rb))
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
 end
-
 
 function read(
         rb::RasterBand,
@@ -213,7 +212,7 @@ function read(
         cols::UnitRange{U}
     ) where U <: Integer
     rasterio!(rb,
-        Array(getdatatype(rb), length(cols), length(rows)),
+        Array{getdatatype(rb)}(length(cols), length(rows)),
         rows, cols
     )
 end
@@ -299,14 +298,14 @@ end
 read(dataset::Dataset, i::Integer) = read(getband(dataset, i))
 
 function read(dataset::Dataset, indices::Vector{Cint})
-    buffer = Array(getdatatype(getband(dataset, indices[1])),
+    buffer = Array{getdatatype(getband(dataset, indices[1]))}(
         width(dataset), height(dataset), length(indices)
     )
     rasterio!(dataset, buffer, indices)
 end
 
 function read(dataset::Dataset)
-    buffer = Array(getdatatype(getband(dataset, 1)),
+    buffer = Array{getdatatype(getband(dataset, 1))}(
         width(dataset), height(dataset), nraster(dataset)
     )
     read!(dataset, buffer)
@@ -331,7 +330,7 @@ function read(
         xsize::Integer,
         ysize::Integer
     ) where T <: Integer
-    buffer = Array(getdatatype(getband(dataset, indices[1])),
+    buffer = Array{getdatatype(getband(dataset, indices[1]))}(
         width(dataset), height(dataset), length(indices)
     )
     rasterio!(dataset, buffer, indices, xsize, ysize, xoffset, yoffset)
@@ -352,7 +351,7 @@ function read(
         rows::UnitRange{U},
         cols::UnitRange{U}
     ) where U <: Integer
-    buffer = Array(getdatatype(getband(dataset, indices[1])),
+    buffer = Array{getdatatype(getband(dataset, indices[1]))}(
         width(dataset), height(dataset), length(indices)
     )
     rasterio!(dataset, buffer, indices, rows, cols)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,42 +1,42 @@
-typealias GDALColorTable      Ptr{GDAL.GDALColorTableH}
-typealias GDALCoordTransform  Ptr{GDAL.OGRCoordinateTransformationH}
-typealias GDALDataset         Ptr{GDAL.GDALDatasetH}
-typealias GDALDriver          Ptr{GDAL.GDALDriverH}
-typealias GDALFeature         Ptr{GDAL.OGRFeatureH}
-typealias GDALFeatureDefn     Ptr{GDAL.OGRFeatureDefnH}
-typealias GDALFeatureLayer    Ptr{GDAL.OGRLayerH}
-typealias GDALField           Ptr{GDAL.OGRField}
-typealias GDALFieldDefn       Ptr{GDAL.OGRFieldDefnH}
-typealias GDALGeometry        Ptr{GDAL.OGRGeometryH}
-typealias GDALGeomFieldDefn   GDAL.OGRGeomFieldDefnH
-typealias GDALProgressFunc    Ptr{GDAL.GDALProgressFunc}
-typealias GDALRasterAttrTable Ptr{GDAL.GDALRasterAttributeTableH}
-typealias GDALRasterBand      Ptr{GDAL.GDALRasterBandH}
-typealias GDALSpatialRef      Ptr{GDAL.OGRSpatialReferenceH}
-typealias GDALStyleManager    Ptr{GDAL.OGRStyleMgrH}
-typealias GDALStyleTable      Ptr{GDAL.OGRStyleTableH}
-typealias GDALStyleTool       Ptr{GDAL.OGRStyleToolH}
+const GDALColorTable      =      Ptr{GDAL.GDALColorTableH}
+const GDALCoordTransform  =  Ptr{GDAL.OGRCoordinateTransformationH}
+const GDALDataset         =         Ptr{GDAL.GDALDatasetH}
+const GDALDriver          =          Ptr{GDAL.GDALDriverH}
+const GDALFeature         =         Ptr{GDAL.OGRFeatureH}
+const GDALFeatureDefn     =     Ptr{GDAL.OGRFeatureDefnH}
+const GDALFeatureLayer    =    Ptr{GDAL.OGRLayerH}
+const GDALField           =           Ptr{GDAL.OGRField}
+const GDALFieldDefn       =       Ptr{GDAL.OGRFieldDefnH}
+const GDALGeometry        =        Ptr{GDAL.OGRGeometryH}
+const GDALGeomFieldDefn   =   GDAL.OGRGeomFieldDefnH
+const GDALProgressFunc    =    Ptr{GDAL.GDALProgressFunc}
+const GDALRasterAttrTable = Ptr{GDAL.GDALRasterAttributeTableH}
+const GDALRasterBand      =      Ptr{GDAL.GDALRasterBandH}
+const GDALSpatialRef      =      Ptr{GDAL.OGRSpatialReferenceH}
+const GDALStyleManager    =    Ptr{GDAL.OGRStyleMgrH}
+const GDALStyleTable      =      Ptr{GDAL.OGRStyleTableH}
+const GDALStyleTool       =       Ptr{GDAL.OGRStyleToolH}
 
-typealias StringList          Ptr{Ptr{UInt8}}
+const StringList          =          Ptr{Ptr{UInt8}}
 
-abstract AbstractGeometry # needs to have a `ptr::GDALGeometry` attribute
-type ColorTable;                    ptr::GDALColorTable         end
-type CoordTransform;                ptr::GDALCoordTransform     end
-type Dataset;                       ptr::GDALDataset            end
-type Driver;                        ptr::GDALDriver             end
-type Feature;                       ptr::GDALFeature            end
-type FeatureDefn;                   ptr::GDALFeatureDefn        end
-type FeatureLayer;                  ptr::GDALFeatureLayer       end
-type Field;                         ptr::GDALField              end
-type FieldDefn;                     ptr::GDALFieldDefn          end
-type Geometry <: AbstractGeometry;  ptr::GDALGeometry           end
-type GeomFieldDefn;                 ptr::GDALGeomFieldDefn      end
-type RasterAttrTable;               ptr::GDALRasterAttrTable    end
-type RasterBand;                    ptr::GDALRasterBand         end
-type SpatialRef;                    ptr::GDALSpatialRef         end
-type StyleManager;                  ptr::GDALStyleManager       end
-type StyleTable;                    ptr::GDALStyleTable         end
-type StyleTool;                     ptr::GDALStyleTool          end
+abstract type AbstractGeometry end # needs to have a `ptr::GDALGeometry` attribute
+mutable struct ColorTable;                    ptr::GDALColorTable         end
+mutable struct CoordTransform;                ptr::GDALCoordTransform     end
+mutable struct Dataset;                       ptr::GDALDataset            end
+mutable struct Driver;                        ptr::GDALDriver             end
+mutable struct Feature;                       ptr::GDALFeature            end
+mutable struct FeatureDefn;                   ptr::GDALFeatureDefn        end
+mutable struct FeatureLayer;                  ptr::GDALFeatureLayer       end
+mutable struct Field;                         ptr::GDALField              end
+mutable struct FieldDefn;                     ptr::GDALFieldDefn          end
+mutable struct Geometry <: AbstractGeometry;  ptr::GDALGeometry           end
+mutable struct GeomFieldDefn;                 ptr::GDALGeomFieldDefn      end
+mutable struct RasterAttrTable;               ptr::GDALRasterAttrTable    end
+mutable struct RasterBand;                    ptr::GDALRasterBand         end
+mutable struct SpatialRef;                    ptr::GDALSpatialRef         end
+mutable struct StyleManager;                  ptr::GDALStyleManager       end
+mutable struct StyleTable;                    ptr::GDALStyleTable         end
+mutable struct StyleTool;                     ptr::GDALStyleTool          end
 
 @enum(CPLErr,
       CE_None       = (UInt32)(0),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,14 +3,14 @@ macro gdal(args...)
     @assert args[1].head == :(::)
     fhead = (args[1].args[1], GDAL.libgdal)
     returntype = args[1].args[2]
-    argtypes = Expr(:tuple, [a.args[2] for a in args[2:end]]...)
-    args = [a.args[1] for a in args[2:end]]
+    argtypes = Expr(:tuple, [esc(a.args[2]) for a in args[2:end]]...)
+    args = [esc(a.args[1]) for a in args[2:end]]
     return quote ccall($fhead, $returntype, $argtypes, $(args...)) end
 end
 
 macro ogrerr(code, message)
     return quote
-        if $code != GDAL.OGRERR_NONE
+        if $(esc(code)) != GDAL.OGRERR_NONE
             error($message)
         end
     end
@@ -18,7 +18,7 @@ end
 
 macro cplerr(code, message)
     return quote
-        if $code != GDAL.CE_None
+        if $(esc(code)) != GDAL.CE_None
             error($message)
         end
     end
@@ -26,7 +26,7 @@ end
 
 macro cplwarn(code, message)
     return quote
-        if $code != GDAL.CE_None
+        if $(esc(code)) != GDAL.CE_None
             warn($message)
         end
     end
@@ -34,7 +34,7 @@ end
 
 macro cplprogress(progressfunc)
     return quote
-        cfunction($progressfunc,Cint,(Cdouble,Cstring,Ptr{Void}))
+        cfunction($(esc(progressfunc)),Cint,(Cdouble,Cstring,Ptr{Void}))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using FactCheck
 FactCheck.setstyle(:compact)
 
 cd(dirname(@__FILE__)) do
-    # isdir("tmp") || mkpath("tmp")
+    isdir("tmp") || mkpath("tmp")
     include("test_gdal_tutorials.jl")
     include("test_geometry.jl")
     include("test_types.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
+using FactCheck
+FactCheck.setstyle(:compact)
+
 cd(dirname(@__FILE__)) do
-    isdir("tmp") || mkpath("tmp")
+    # isdir("tmp") || mkpath("tmp")
     include("test_gdal_tutorials.jl")
     include("test_geometry.jl")
     include("test_types.jl")
@@ -15,7 +18,7 @@ cd(dirname(@__FILE__)) do
     include("test_ospy_examples.jl")
     include("test_geos_operations.jl")
     include("test_cookbook_geometry.jl")
-    # include("test_cookbook_projection.jl")
+    include("test_cookbook_projection.jl")
 end
 
 FactCheck.exitstatus()

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -1,3 +1,4 @@
+using FactCheck
 import ArchGDAL; const AG = ArchGDAL
 
 function read(f, filename)

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -75,6 +75,7 @@ AG.registerdrivers() do
         end
     end
 
+    println("Memory")
     AG.create("", "MEMORY") do output
         layer = AG.createlayer(output, "dummy", geom=AG.wkbPolygon)
         AG.createfielddefn("int64field", AG.OFTInteger64) do fielddefn
@@ -115,7 +116,7 @@ AG.registerdrivers() do
                 AG.setfrom!(newfeature, feature)
                 @fact AG.getfield(newfeature, 0) --> 1
                 @fact AG.getfield(newfeature, 1) --> roughly(1.0)
-                @fact AG.getfield(newfeature, 2) --> Cint[1, 2]
+                @fact AG.getfield(newfeature, 2) --> Int32[1, 2]
                 @fact AG.getfield(newfeature, 3) --> Int64[1, 2]
                 @fact AG.getfield(newfeature, 4) --> roughly([1.0, 2.0])
                 @fact AG.getfield(newfeature, 5) --> ["1", "2.0"]
@@ -129,7 +130,7 @@ AG.registerdrivers() do
                     AG.setfield!(lastfeature, 5, ["foo", "bar"])
                     @fact AG.getfield(lastfeature, 0) --> 45
                     @fact AG.getfield(lastfeature, 1) --> roughly(18.2)
-                    @fact AG.getfield(lastfeature, 2) --> Cint[1, 2]
+                    @fact AG.getfield(lastfeature, 2) --> Int32[1, 2]
                     @fact AG.getfield(lastfeature, 3) --> Int64[1, 2]
                     @fact AG.getfield(lastfeature, 4) --> roughly([1.0, 2.0])
                     @fact AG.getfield(lastfeature, 5) --> ["foo", "bar"]

--- a/test/test_ospy_examples.jl
+++ b/test/test_ospy_examples.jl
@@ -243,7 +243,7 @@ AG.read("ospy/data4/aster.img") do ds
             band = AG.getband(ds, 1)
             count = 0
             total = 0
-            buffer = Array(AG.getdatatype(band), AG.getblocksize(band)...)
+            buffer = Array{AG.getdatatype(band)}(AG.getblocksize(band)...)
             for (cols,rows) in AG.windows(band)
                 AG.rasterio!(band, buffer, rows, cols)
                 data = buffer[1:length(cols),1:length(rows)]
@@ -277,9 +277,9 @@ AG.read("ospy/data4/aster.img") do ds
             inband2 = AG.getband(ds, 2); inband3 = AG.getband(ds, 3)
             (xbsize, ybsize) = AG.getblocksize(inband2)
 
-            buffer2 = Array(Float32, ybsize, xbsize)
-            buffer3 = Array(Float32, ybsize, xbsize)
-            ndvi    = Array(Float32, ybsize, xbsize)
+            buffer2 = Array{Float32}(ybsize, xbsize)
+            buffer3 = Array{Float32}(ybsize, xbsize)
+            ndvi    = Array{Float32}(ybsize, xbsize)
             AG.create("", "MEM",
                       width=cols, height=rows, nbands=1, dtype=Float32) do outDS
                 for ((i,j),(nrows,ncols)) in AG.blocks(inband2)
@@ -360,8 +360,8 @@ facts("Homework 5(b)") do
             yOffset2 = round(Int, (maxY2 - maxY) / pixelHeight1)
 
             dtype = AG.getdatatype(band1)
-            data1 = Array(dtype, rows, cols)
-            data2 = Array(dtype, rows, cols)
+            data1 = Array{dtype}(rows, cols)
+            data2 = Array{dtype}(rows, cols)
             # create the output image
             AG.create("", "MEM",width=cols, height=rows, nbands=1,
                       dtype=AG.getdatatype(band1)) do dsout

--- a/test/test_rasterattrtable.jl
+++ b/test/test_rasterattrtable.jl
@@ -22,11 +22,11 @@ facts("Testing Raster Attribute Tables") do
         AG.setrowcount!(rat, 5)
         @fact AG.nrow(rat) --> 5
 
-        @fact AG.attributeio!(rat, AG.GF_Read, 0, 0, 5, Array(Cint,5)) -->
+        @fact AG.attributeio!(rat, AG.GF_Read, 0, 0, 5, Array{Cint}(5)) -->
             fill(0,5)
-        @fact AG.attributeio!(rat, AG.GF_Read, 0, 0, 5, Array(Float64,5)) -->
+        @fact AG.attributeio!(rat, AG.GF_Read, 0, 0, 5, Array{Float64}(5)) -->
             fill(0,5)
-        @fact AG.attributeio!(rat, AG.GF_Read, 1, 0, 5, Array(Float64,5)) -->
+        @fact AG.attributeio!(rat, AG.GF_Read, 1, 0, 5, Array{Float64}(5)) -->
             fill(0,5)
 
         @fact AG.asstring(rat, 2, 0) --> "0"

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -7,7 +7,7 @@ AG.registerdrivers() do
             band = AG.getband(ds, 1)
             count = 0
             total = 0
-            buffer = Array(AG.getdatatype(band), AG.getblocksize(band)..., 1)
+            buffer = Array{AG.getdatatype(band)}(AG.getblocksize(band)..., 1)
             for (cols,rows) in AG.windows(band)
                 AG.rasterio!(ds, buffer, Cint[1], rows-1, cols-1)
                 data = buffer[1:length(cols),1:length(rows)]
@@ -22,7 +22,7 @@ AG.registerdrivers() do
             band = AG.getband(ds, 1)
             count = 0
             total = 0
-            buffer = Array(AG.getdatatype(band), AG.getblocksize(band)..., 1)
+            buffer = Array{AG.getdatatype(band)}(AG.getblocksize(band)..., 1)
             for (cols,rows) in AG.windows(band)
                 AG.read!(ds, buffer, Cint[1], rows-1, cols-1)
                 data = buffer[1:length(cols),1:length(rows)]
@@ -37,7 +37,7 @@ AG.registerdrivers() do
             band = AG.getband(ds, 1)
             count = 0
             total = 0
-            buffer = Array(AG.getdatatype(band), AG.getblocksize(band)...)
+            buffer = Array{AG.getdatatype(band)}(AG.getblocksize(band)...)
             for (cols,rows) in AG.windows(band)
                 AG.read!(ds, buffer, 1, rows, cols)
                 data = buffer[1:length(cols),1:length(rows)]
@@ -52,7 +52,7 @@ AG.registerdrivers() do
             band = AG.getband(ds, 1)
             count = 0
             total = 0
-            buffer = Array(AG.getdatatype(band), AG.getblocksize(band)...)
+            buffer = Array{AG.getdatatype(band)}(AG.getblocksize(band)...)
             for (cols,rows) in AG.windows(band)
                 AG.read!(band, buffer, rows, cols)
                 data = buffer[1:length(cols),1:length(rows)]
@@ -68,7 +68,7 @@ AG.registerdrivers() do
             count = 0
             total = 0
             xbsize, ybsize = AG.getblocksize(band)
-            buffer = Array(AG.getdatatype(band), ybsize, xbsize)
+            buffer = Array{AG.getdatatype(band)}(ybsize, xbsize)
             for ((i,j),(nrows,ncols)) in AG.blocks(band)
                 # AG.rasterio!(ds,buffer,Cint[1],i,j,nrows,ncols)
                 # AG.read!(band, buffer, j, i, ncols, nrows)
@@ -83,7 +83,7 @@ AG.registerdrivers() do
 
         @time begin
             band = AG.getband(ds, 1)
-            buffer = Array(AG.getdatatype(band), AG.width(ds), AG.height(ds), 1)
+            buffer = Array{AG.getdatatype(band)}(AG.width(ds), AG.height(ds), 1)
             AG.rasterio!(ds, buffer, Cint[1])
             count = sum(buffer .> 0)
             total = sum(buffer)
@@ -93,7 +93,7 @@ AG.registerdrivers() do
 
         @time begin
             band = AG.getband(ds, 1)
-            buffer = Array(AG.getdatatype(band), AG.width(ds), AG.height(ds))
+            buffer = Array{AG.getdatatype(band)}(AG.width(ds), AG.height(ds))
             AG.read!(band, buffer)
             count = sum(buffer .> 0)
             total = sum(buffer)
@@ -103,7 +103,7 @@ AG.registerdrivers() do
 
         @time begin
             band = AG.getband(ds, 1)
-            buffer = Array(AG.getdatatype(band), AG.width(ds), AG.height(ds))
+            buffer = Array{AG.getdatatype(band)}(AG.width(ds), AG.height(ds))
             AG.read!(ds, buffer, 1)
             count = sum(buffer .> 0)
             total = sum(buffer)
@@ -113,7 +113,7 @@ AG.registerdrivers() do
 
         @time begin
             band = AG.getband(ds, 1)
-            buffer = Array(AG.getdatatype(band), AG.width(ds), AG.height(ds), 1)
+            buffer = Array{AG.getdatatype(band)}(AG.width(ds), AG.height(ds), 1)
             AG.read!(ds, buffer, Cint[1])
             count = sum(buffer .> 0)
             total = sum(buffer)
@@ -123,7 +123,7 @@ AG.registerdrivers() do
 
         @time begin
             band = AG.getband(ds, 1)
-            buffer = Array(AG.getdatatype(band), AG.width(ds), AG.height(ds), 3)
+            buffer = Array{AG.getdatatype(band)}(AG.width(ds), AG.height(ds), 3)
             AG.read!(ds, buffer)
             count = sum(buffer[:,:,1] .> 0)
             total = sum(buffer[:,:,1])


### PR DESCRIPTION
Upgrade to 0.6
- Dropped 0.5 support
- Fixed all 0.6 deprecation warnings
- Readme now includes import Base.read
- Travis builds fixed, now with colors
- Included projection tests (was commented out)

This introduced some serious errors:
- Unescaped arguments in macros in 0.6, see JuliaLang/julia/#19587 and PR #15850
- Pointer_to_array was removed in 0.5

These are fixed now, no thanks to FactCheck (FC)
- FC complained about 8 failings tests, but not where. Compact output showed roughly where.
- The errors were actually the non existent pointer_to_array functions, which somehow didn't stop FC
- FC needs to be updated to 0.6, all remaining deprecation warnings are from FC.

Would advise to move away from FC.
