### PR TITLE
Implement Datastreams and IGeometry

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+DataStreams

--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -3,6 +3,7 @@ module ArchGDAL
     using Compat
     import Compat.String
     import GDAL
+    import DataStreams: Data
 
     include("utils.jl")
     include("types.jl")
@@ -23,5 +24,6 @@ module ArchGDAL
     include("context.jl")
     include("base/iterators.jl")
     include("base/display.jl")
+    include("datastreams.jl")
 
 end # module

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -1,0 +1,81 @@
+mutable struct Source <: Data.Source
+    schema::Data.Schema
+    featurelayer::FeatureLayer
+    feature::ArchGDAL.Feature
+    ngeom::Int
+end
+
+function Source(layer::FeatureLayer)
+    layerdefn = getlayerdefn(layer)
+    ngeom = ngeomfield(layerdefn)
+    nfld = nfield(layerdefn)
+    header = [
+        ["geometry$(i-1)" for i in 1:ngeom];
+        [getname(getfielddefn(layerdefn,i-1)) for i in 1:nfld]
+    ]
+    types = [
+        [IGeometry for i in 1:ngeom];
+        [_FIELDTYPE[gettype(getfielddefn(layerdefn,i-1))] for i in 1:nfld]
+    ]
+    ArchGDAL.Source(
+        Data.Schema(header, types, nfeature(layer)),
+        layer,
+        unsafe_nextfeature(layer),
+        ngeom
+    )
+end
+Data.isdone(s::ArchGDAL.Source, row, col) = s.feature.ptr == C_NULL
+Data.schema(source::ArchGDAL.Source, ::Type{Data.Field}) = source.schema
+Data.streamtype(::Type{ArchGDAL.Source}, ::Type{Data.Field}) = true
+
+function Data.streamfrom{T}(
+        source::ArchGDAL.Source,
+        ::Type{Data.Field},
+        ::Type{Nullable{T}},
+        row,
+        col
+    )
+    val = if col <= source.ngeom
+        Nullable{T}(getgeomfield(source.feature, col-1))
+    else
+        Nullable{T}(getfield(source.feature, col-source.ngeom-1))
+    end
+    if col == source.schema.cols
+        destroy(source.feature)
+        source.feature.ptr = @gdal(
+            OGR_L_GetNextFeature::GDALFeature,
+            source.featurelayer.ptr::GDALFeatureLayer
+        )
+        if row == source.schema.rows
+            @assert source.feature.ptr == C_NULL
+            resetreading!(source.featurelayer)
+        end
+    end
+    val
+end
+
+function Data.streamfrom{T}(
+        source::ArchGDAL.Source,
+        ::Type{Data.Field},
+        ::Type{T},
+        row,
+        col
+    )
+    val = if col <= source.ngeom
+        T(getgeomfield(source.feature, col-1).ptr)
+    else
+        T(getfield(source.feature, col-source.ngeom-1))
+    end
+    if col == source.schema.cols
+        destroy(source.feature)
+        source.feature.ptr = @gdal(
+            OGR_L_GetNextFeature::GDALFeature,
+            source.featurelayer.ptr::GDALFeatureLayer
+        )
+        if row == source.schema.rows
+            @assert source.feature.ptr == C_NULL
+            resetreading!(source.featurelayer)
+        end
+    end
+    val
+end

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -28,7 +28,7 @@ of failure of that function).
 OGRERR_NONE if successful, or OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry
 type is illegal for the OGRFeatureDefn (checking not yet implemented).
 """
-function setgeomdirectly!(feature::Feature, geom::AbstractGeometry)
+function setgeomdirectly!(feature::Feature, geom::Geometry)
     result = GDAL.setgeometrydirectly(feature.ptr, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry."
 end
@@ -54,9 +54,10 @@ function setgeom!(feature::Feature, geom::AbstractGeometry)
 end
 
 "Fetch an handle to internal feature geometry. It should not be modified."
-getgeom(::Type{G}, feature::Feature) where {G <: AbstractGeometry} =
-    G(GDAL.getgeometryref(feature.ptr))
-getgeom(feature::Feature) = getgeom(Geometry, feature)
+unsafe_getgeom(feature::Feature) =
+    Geometry(GDAL.getgeometryref(feature.ptr))
+getgeom(feature::Feature) =
+    IGeometry(GDAL.clone(GDAL.getgeometryref(feature.ptr)))
 
 """
 Fetch number of fields on this feature.
@@ -610,9 +611,10 @@ Fetch pointer to the feature geometry.
 ### Returns
 an internal feature geometry. This object should not be modified.
 """
-getgeomfield(::Type{G}, feature::Feature, i::Integer) where {G <: AbstractGeometry} =
-    G(GDAL.getgeomfieldref(feature.ptr, i))
-getgeomfield(feature::Feature, i::Integer) = getgeomfield(Geometry, feature, i)
+unsafe_getgeomfield(feature::Feature, i::Integer) =
+    Geometry(GDAL.getgeomfieldref(feature.ptr, i))
+getgeomfield(feature::Feature, i::Integer) = 
+    IGeometry(GDAL.clone(GDAL.getgeomfieldref(feature.ptr, i)))
 
 """
 Set feature geometry of a specified geometry field.
@@ -631,7 +633,7 @@ OGRERR_NONE if successful, or OGRERR_FAILURE if the index is invalid, or
 OGR_UNSUPPORTED_GEOMETRY_TYPE if the geometry type is illegal for the
 OGRFeatureDefn (checking not yet implemented).
 """
-function setgeomfielddirectly!(feature::Feature, i::Integer, geom::AbstractGeometry)
+function setgeomfielddirectly!(feature::Feature, i::Integer, geom::Geometry)
     result = GDAL.setgeomfielddirectly(feature.ptr, i, geom.ptr)
     @ogrerr result "OGRErr $result: Failed to set feature geometry directly"
     feature

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -25,6 +25,8 @@ end
 
 unsafe_fromWKB(data, args...) = unsafe_fromWKB(Geometry, data, args...)
 
+fromWKB(data, args...) = unsafe_fromWKB(IGeometry, data, args...)
+
 """
 Create a geometry object of the appropriate type from its well known text
 (WKT) representation.
@@ -50,8 +52,14 @@ function unsafe_fromWKT(
     @ogrerr result "Failed to create geometry from WKT"
     G(geom[])
 end
+
 unsafe_fromWKT(data::Vector{String}, args...) = unsafe_fromWKT(Geometry, data, args...)
+
+fromWKT(data::Vector{String}, args...) = unsafe_fromWKT(IGeometry, data, args...)
+
 unsafe_fromWKT(data::String, args...) = unsafe_fromWKT([data], args...)
+
+fromWKT(data::String, args...) = fromWKT([data], args...)
 
 """
 Destroy geometry object.
@@ -68,7 +76,10 @@ end
 function unsafe_clone(::Type{G}, geom::AbstractGeometry) where G <: AbstractGeometry
     G(GDAL.clone(geom.ptr))
 end
+
 unsafe_clone(geom::G) where {G <: AbstractGeometry} = unsafe_clone(G, geom)
+
+clone(geom::AbstractGeometry) = unsafe_clone(IGeometry, geom)
 
 """
 Create an empty geometry of desired type.
@@ -81,6 +92,8 @@ function unsafe_creategeom(::Type{G}, geomtype::OGRwkbGeometryType ) where G <: 
 end
 
 unsafe_creategeom(geomtype::OGRwkbGeometryType) = unsafe_creategeom(Geometry, geomtype)
+
+creategeom(geomtype::OGRwkbGeometryType) = unsafe_creategeom(IGeometry, geomtype)
 
 """
 Tries to force the provided geometry to the specified geometry type.
@@ -114,7 +127,8 @@ function unsafe_forceto(
 end
 unsafe_forceto(geom::AbstractGeometry, args...) =
     unsafe_forceto(Geometry, geom, args...)
-
+forceto(geom::AbstractGeometry, args...) =
+    unsafe_forceto(IGeometry, geom, args...)
 
 """
 Get the dimension of the geometry. 0 for points, 1 for lines and 2 for surfaces.
@@ -253,7 +267,10 @@ MultiLineString, MultiPolygon, MultiGeometry.
 """
 unsafe_fromGML(::Type{G}, data) where {G <: AbstractGeometry} =
     G(GDAL.createfromgml(data))
+
 unsafe_fromGML(data) = unsafe_fromGML(Geometry, data)
+
+fromGML(data) = unsafe_fromGML(IGeometry, data)
 
 "Convert a geometry into GML format."
 toGML(geom::AbstractGeometry) = GDAL.exporttogml(geom.ptr)
@@ -283,7 +300,10 @@ toJSON(geom::AbstractGeometry, options) =
 "Create a geometry object from its GeoJSON representation"
 unsafe_fromJSON(::Type{G}, data::String) where {G <: AbstractGeometry} =
     G(GDAL.creategeometryfromjson(data))
+
 unsafe_fromJSON(data::String) = unsafe_fromJSON(Geometry, data)
+
+fromJSON(data::String) = unsafe_fromJSON(IGeometry, data)
 
 "Assign spatial reference to this object."
 setspatialref!(geom::G, spatialref::SpatialRef) where {G <: AbstractGeometry} =
@@ -331,8 +351,12 @@ function unsafe_simplify(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.simplify(geom.ptr, tol))
 end
+
 unsafe_simplify(geom::AbstractGeometry, args...) =
     unsafe_simplify(Geometry, geom, args...)
+
+simplify(geom::AbstractGeometry, args...) =
+    unsafe_simplify(IGeometry, geom, args...)
 
 """
 Simplify the geometry while preserving topology.
@@ -346,8 +370,12 @@ function unsafe_simplifypreservetopology(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.simplifypreservetopology(geom.ptr, tol))
 end
+
 unsafe_simplifypreservetopology(geom::AbstractGeometry, args...) =
     unsafe_simplifypreservetopology(Geometry, geom, args...)
+
+simplifypreservetopology(geom::AbstractGeometry, args...) =
+    unsafe_simplifypreservetopology(IGeometry, geom, args...)
 
 """
 Return a Delaunay triangulation of the vertices of the geometry.
@@ -363,8 +391,12 @@ function unsafe_delaunaytriangulation(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.delaunaytriangulation(geom.ptr, tol, onlyedges))
 end
+
 unsafe_delaunaytriangulation(geom::AbstractGeometry, args...) =
     unsafe_delaunaytriangulation(Geometry, geom, args...)
+
+delaunaytriangulation(geom::AbstractGeometry, args...) =
+    unsafe_delaunaytriangulation(IGeometry, geom, args...)
 
 """
 Modify the geometry such it has no segment longer than the given distance.
@@ -435,8 +467,12 @@ geometry on which the method is invoked.
 """
 unsafe_boundary(::Type{G}, geom::AbstractGeometry) where {G <: AbstractGeometry} =
     G(GDAL.boundary(geom.ptr))
+
 unsafe_boundary(geom::AbstractGeometry, args...) =
     unsafe_boundary(Geometry, geom, args...)
+
+boundary(geom::AbstractGeometry, args...) =
+    unsafe_boundary(IGeometry, geom, args...)
 
 """
 Returns the convex hull of the geometry.
@@ -446,8 +482,12 @@ geometry on which the method is invoked.
 """
 unsafe_convexhull(::Type{G}, geom::AbstractGeometry) where {G <: AbstractGeometry} =
     G(GDAL.convexhull(geom.ptr))
+
 unsafe_convexhull(geom::AbstractGeometry, args...) =
     unsafe_convexhull(Geometry, geom, args...)
+
+convexhull(geom::AbstractGeometry, args...) =
+    unsafe_convexhull(IGeometry, geom, args...)
 
 """
 Compute buffer of geometry.
@@ -475,8 +515,12 @@ function unsafe_buffer(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.buffer(geom.ptr, dist, quadsegs))
 end
+
 unsafe_buffer(geom::AbstractGeometry, args...) =
     unsafe_buffer(Geometry, geom, args...)
+
+buffer(geom::AbstractGeometry, args...) =
+    unsafe_buffer(IGeometry, geom, args...)
 
 """
 Returns a new geometry representing the intersection of the geometries, or NULL
@@ -491,8 +535,12 @@ function unsafe_intersection(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.intersection(g1.ptr, g2.ptr))
 end
+
 unsafe_intersection(g1::AbstractGeometry, g2::AbstractGeometry, args...) =
     unsafe_intersection(Geometry, g1, g2, args...)
+
+intersection(g1::AbstractGeometry, g2::AbstractGeometry, args...) =
+    unsafe_intersection(IGeometry, g1, g2, args...)
 
 """
 Returns a new geometry representing the union of the geometries.
@@ -513,6 +561,9 @@ unsafe_union(::Type{G}, geom::AbstractGeometry) where {G <: AbstractGeometry} =
 unsafe_union(geom::AbstractGeometry, args...) =
     unsafe_union(Geometry, geom, args...)
 
+union(geom::AbstractGeometry, args...) =
+    unsafe_union(IGeometry, geom, args...)
+
 """
 Returns a point guaranteed to lie on the surface.
 
@@ -529,6 +580,9 @@ end
 
 unsafe_pointonsurface(geom::AbstractGeometry, args...) =
     unsafe_pointonsurface(Geometry, geom, args...)
+
+pointonsurface(geom::AbstractGeometry, args...) =
+    unsafe_pointonsurface(IGeometry, geom, args...)
 
 """
 Generates a new geometry which is the region of this geometry with the region of
@@ -547,6 +601,9 @@ end
 unsafe_difference(geom::AbstractGeometry, args...) =
     unsafe_difference(Geometry, geom, args...)
 
+difference(geom::AbstractGeometry, args...) =
+    unsafe_difference(IGeometry, geom, args...)
+
 """
 Returns a new geometry representing the symmetric difference of the geometries
 or NULL if the difference is empty or an error occurs.
@@ -559,6 +616,9 @@ end
 
 unsafe_symdifference(geom::AbstractGeometry, args...) =
     unsafe_symdifference(Geometry, geom, args...)
+
+symdifference(geom::AbstractGeometry, args...) =
+    unsafe_symdifference(IGeometry, geom, args...)
 
 "Returns the distance between the geometries or -1 if an error occurs."
 distance(g1::AbstractGeometry, g2::AbstractGeometry) = GDAL.distance(g1.ptr, g2.ptr)
@@ -591,6 +651,8 @@ end
 
 unsafe_centroid(geom::AbstractGeometry) = centroid!(geom, unsafe_createpoint())
 
+centroid(geom::AbstractGeometry) = centroid!(geom, createpoint())
+
 """
 Fetch point at given distance along curve.
 
@@ -610,6 +672,9 @@ end
 
 unsafe_pointalongline(geom::AbstractGeometry, args...) =
     unsafe_pointalongline(Geometry, geom, args...)
+
+pointalongline(geom::AbstractGeometry, args...) =
+    unsafe_pointalongline(IGeometry, geom, args...)
 
 """
 Clear geometry information.
@@ -645,8 +710,12 @@ failure.
 """
 unsafe_polygonize(::Type{G}, geom::AbstractGeometry) where {G <: AbstractGeometry} =
     G(GDAL.polygonize(geom.ptr))
+
 unsafe_polygonize(geom::AbstractGeometry, args...) =
     unsafe_polygonize(Geometry, geom, args...)
+
+polygonize(geom::AbstractGeometry, args...) =
+    unsafe_polygonize(IGeometry, geom, args...)
 
 "Fetch number of points from a geometry."
 npoint(geom::AbstractGeometry) = GDAL.getpointcount(geom.ptr)
@@ -808,13 +877,17 @@ For a polygon, `getgeom(polygon,i)` returns the exterior ring if
 * `geom`: the geometry container from which to get a geometry from.
 * `i`: index of the geometry to fetch, between 0 and getNumGeometries() - 1.
 """
-function getgeom(::Type{G},
+function unsafe_getgeom(::Type{G},
         geom::AbstractGeometry, i::Integer
     ) where G <: AbstractGeometry
     G(GDAL.getgeometryref(geom.ptr, i))
 end
+
+unsafe_getgeom(geom::AbstractGeometry, args...) =
+    unsafe_getgeom(Geometry, geom, args...)
+
 getgeom(geom::AbstractGeometry, args...) =
-    getgeom(Geometry, geom, args...)
+    unsafe_getgeom(IGeometry, unsafe_clone(geom), args...)
 
 """
 Add a geometry to a geometry container.
@@ -869,9 +942,7 @@ Remove a geometry from an exiting geometry container.
     The default is TRUE as the existing geometry is considered to own the
     geometries in it.
 """
-function removegeom!(geom::G,
-        i::Integer, todelete::Bool = true
-    ) where G <: AbstractGeometry
+function removegeom!(geom::AbstractGeometry, i::Integer, todelete::Bool = true)
     result = GDAL.removegeometry(geom.ptr, i, todelete)
     @ogrerr result "Failed to remove geometry. The index could be out of range."
     geom
@@ -886,7 +957,7 @@ Remove all geometries from an exiting geometry container.
     The default is TRUE as the existing geometry is considered to own the
     geometries in it.
 """
-function removeallgeoms!(geom::G, todelete::Bool = true) where G <: AbstractGeometry
+function removeallgeoms!(geom::AbstractGeometry, todelete::Bool = true)
     result = GDAL.removegeometry(geom.ptr, -1, todelete)
     @ogrerr result "Failed to remove all geometries."
     geom
@@ -935,8 +1006,12 @@ function unsafe_getlineargeom(::Type{G},
     ) where G <: AbstractGeometry
     G(GDAL.getlineargeometry(geom.ptr, stepsize, options))
 end
+
 unsafe_getlineargeom(geom::AbstractGeometry, args...) =
     unsafe_getlineargeom(Geometry, geom, args...)
+
+getlineargeom(geom::AbstractGeometry, args...) =
+    unsafe_getlineargeom(IGeometry, geom, args...)
 
 """
 Return curve version of this geometry.
@@ -953,8 +1028,12 @@ The reverse function is OGR_G_GetLinearGeometry().
 """
 unsafe_getcurvegeom(::Type{G}, geom::AbstractGeometry) where {G <: AbstractGeometry} =
     G(GDAL.getcurvegeometry(geom.ptr, C_NULL))
+
 unsafe_getcurvegeom(geom::AbstractGeometry, args...) =
     unsafe_getcurvegeom(Geometry, geom, args...)
+
+getcurvegeom(geom::AbstractGeometry, args...) =
+    unsafe_getcurvegeom(IGeometry, geom, args...)
 
 """
 Build a ring from a bunch of arcs.
@@ -979,8 +1058,12 @@ function unsafe_polygonfromedges(
     @ogrerr perr[] "Failed to build polygon from edges."
     G(result)
 end
+
 unsafe_polygonfromedges(geom::AbstractGeometry, args...) =
     unsafe_polygonfromedges(Geometry, geom, args...)
+
+polygonfromedges(geom::AbstractGeometry, args...) =
+    unsafe_polygonfromedges(IGeometry, geom, args...)
 
 """
 Set flag to enable/disable returning non-linear geometries in the C API.
@@ -1017,115 +1100,196 @@ for (geom, wkbgeom) in ((:geomcollection,   GDAL.wkbGeometryCollection),
                         (:multipolygon,     GDAL.wkbMultiPolygon),
                         (:point,            GDAL.wkbPoint),
                         (:polygon,          GDAL.wkbPolygon))
-    @eval $(Symbol("unsafe_create$geom"))() = unsafe_creategeom($wkbgeom)
+    eval(quote
+        function $(Symbol("unsafe_create$geom"))(::Type{G}) where G <: AbstractGeometry
+            unsafe_creategeom(G, $wkbgeom)
+        end
+
+        $(Symbol("unsafe_create$geom"))() = $(Symbol("unsafe_create$geom"))(Geometry)
+
+        $(Symbol("create$geom"))() = $(Symbol("unsafe_create$geom"))(IGeometry)
+    end)
 end
 
-function unsafe_createpoint(x::Real, y::Real)
-    geom = unsafe_creategeom(GDAL.wkbPoint)
+function unsafe_createpoint(::Type{G}, x::Real, y::Real) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbPoint)
     addpoint!(geom, x, y)
     geom
 end
 
-function unsafe_createpoint(x::Real, y::Real, z::Real)
-    geom = unsafe_creategeom(GDAL.wkbPoint)
+unsafe_createpoint(x::Real, y::Real) = unsafe_createpoint(Geometry, x, y)
+
+createpoint(x::Real, y::Real) = unsafe_createpoint(IGeometry, x, y)
+
+function unsafe_createpoint(::Type{G}, x::Real, y::Real, z::Real) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbPoint)
     addpoint!(geom, x, y, z)
     geom
 end
 
-function unsafe_createpoint(xy::Tuple{T,U}) where {T <: Real, U <: Real}
-    geom = unsafe_creategeom(GDAL.wkbPoint)
+unsafe_createpoint(x::Real, y::Real, z::Real) =
+    unsafe_createpoint(Geometry, x, y, z)
+
+createpoint(x::Real, y::Real, z::Real) =
+    unsafe_createpoint(IGeometry, x, y, z)
+
+function unsafe_createpoint(::Type{G}, xy::Tuple{T,U}) where {T <: Real, U <: Real, G <: AbstractGeometry}
+    geom = unsafe_creategeom(G, GDAL.wkbPoint)
     addpoint!(geom, xy...)
     geom
 end
 
-function unsafe_createpoint(xyz::Tuple{T,U,V}) where {T <: Real, U <: Real, V <: Real}
-    geom = unsafe_creategeom(GDAL.wkbPoint)
+unsafe_createpoint(xy::Tuple{T,U}) where {T <: Real, U <: Real} =
+    unsafe_createpoint(Geometry, xy)
+
+createpoint(xy::Tuple{T,U}) where {T <: Real, U <: Real} =
+    unsafe_createpoint(IGeometry, xy)
+
+function unsafe_createpoint(::Type{G}, xyz::Tuple{T,U,V}) where {T <: Real, U <: Real, V <: Real, G <: AbstractGeometry}
+    geom = unsafe_creategeom(G, GDAL.wkbPoint)
     addpoint!(geom, xyz...)
     geom
 end
+
+unsafe_createpoint(xyz::Tuple{T,U,V}) where {T <: Real, U <: Real, V <: Real} =
+    unsafe_createpoint(Geometry, xyz)
+
+createpoint(args...) = unsafe_createpoint(IGeometry, args...)
 
 # Tuples of Vectors
 for (geom, wkbgeom) in ((:linestring, GDAL.wkbLineString),
                         (:linearring, GDAL.wkbLinearRing))
     eval(quote
-        function $(Symbol("unsafe_create$geom"))(xs::Vector{Cdouble},
-                                                 ys::Vector{Cdouble})
-            geom = unsafe_creategeom($wkbgeom)
+        function $(Symbol("unsafe_create$geom"))(
+                ::Type{G},
+                xs::Vector{Cdouble},
+                ys::Vector{Cdouble}
+            ) where G <: AbstractGeometry
+            geom = unsafe_creategeom(G, $wkbgeom)
             for (x,y) in zip(xs, ys)
                 addpoint!(geom, x, y)
             end
             geom
         end
 
-        function $(Symbol("unsafe_create$geom"))(xs::Vector{Cdouble},
-                             ys::Vector{Cdouble},zs::Vector{Cdouble})
-            geom = unsafe_creategeom($wkbgeom)
+        function $(Symbol("unsafe_create$geom"))(
+                ::Type{G},
+                xs::Vector{Cdouble},
+                ys::Vector{Cdouble},
+                zs::Vector{Cdouble}
+            ) where G <: AbstractGeometry
+            geom = unsafe_creategeom(G, $wkbgeom)
             for (x,y,z) in zip(xs, ys, zs)
                 addpoint!(geom, x, y, z)
             end
             geom
         end
+
+        $(Symbol("unsafe_create$geom"))(args...) = $(Symbol("unsafe_create$geom"))(Geometry, args...)
+
+        $(Symbol("create$geom"))(args...) = $(Symbol("unsafe_create$geom"))(IGeometry, args...)
     end)
 end
 
-function unsafe_createpolygon(xs::Vector{Cdouble}, ys::Vector{Cdouble})
-    geom = unsafe_creategeom(GDAL.wkbPolygon)
+function unsafe_createpolygon(
+        ::Type{G},
+        xs::Vector{Cdouble},
+        ys::Vector{Cdouble}
+    ) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbPolygon)
     addgeomdirectly!(geom, unsafe_createlinearring(xs, ys))
     geom
 end
 
-function unsafe_createpolygon(xs::Vector{Cdouble}, ys::Vector{Cdouble},
-                              zs::Vector{Cdouble})
-    geom = unsafe_creategeom(GDAL.wkbPolygon)
+function unsafe_createpolygon(
+        ::Type{G},
+        xs::Vector{Cdouble},
+        ys::Vector{Cdouble},
+        zs::Vector{Cdouble}
+    ) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbPolygon)
     addgeomdirectly!(geom, unsafe_createlinearring(xs, ys, zs))
     geom
 end
 
-function unsafe_createmultipoint(xs::Vector{Cdouble}, ys::Vector{Cdouble})
-    geom = unsafe_creategeom(GDAL.wkbMultiPoint)
+unsafe_createpolygon(args...) = unsafe_createpolygon(Geometry, args...)
+
+createpolygon(args...) = unsafe_createpolygon(IGeometry, args...)
+
+function unsafe_createmultipoint(
+        ::Type{G},
+        xs::Vector{Cdouble},
+        ys::Vector{Cdouble}
+    ) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbMultiPoint)
     for (x, y) in zip(xs, ys)
         addgeomdirectly!(geom, unsafe_createpoint(x, y))
     end
     geom
 end
 
-function unsafe_createmultipoint(xs::Vector{Cdouble}, ys::Vector{Cdouble},
-                                 zs::Vector{Cdouble})
-    geom = unsafe_creategeom(GDAL.wkbMultiPoint)
+function unsafe_createmultipoint(
+        ::Type{G},
+        xs::Vector{Cdouble},
+        ys::Vector{Cdouble},
+        zs::Vector{Cdouble}
+    ) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbMultiPoint)
     for (x, y, z) in zip(xs, ys, zs)
         addgeomdirectly!(geom, unsafe_createpoint(x, y, z))
     end
     geom
 end
 
+unsafe_createmultipoint(args...) = unsafe_createmultipoint(Geometry, args...)
+
+createmultipoint(args...) = unsafe_createmultipoint(IGeometry, args...)
+
 # Vectors of Tuples
 for typeargs in (Vector{Tuple{Cdouble,Cdouble}},
                  Vector{Tuple{Cdouble,Cdouble,Cdouble}})
     for (geom, wkbgeom) in ((:linestring, GDAL.wkbLineString),
                             (:linearring, GDAL.wkbLinearRing))
-        @eval function $(Symbol("unsafe_create$geom"))(coords::$typeargs)
-                  geom = unsafe_creategeom($wkbgeom)
-                  for coord in coords
-                      addpoint!(geom, coord...)
-                  end
-                  geom
-              end
+        eval(quote
+            function $(Symbol("unsafe_create$geom"))(
+                    ::Type{G},
+                    coords::$typeargs
+                ) where G <: AbstractGeometry
+                geom = unsafe_creategeom(G, $wkbgeom)
+                for coord in coords; addpoint!(geom, coord...) end
+                geom
+            end
+
+            $(Symbol("unsafe_create$geom"))(coords::$typeargs) =
+                $(Symbol("unsafe_create$geom"))(Geometry, coords)
+
+            $(Symbol("create$geom"))(coords::$typeargs) =
+                $(Symbol("unsafe_create$geom"))(IGeometry, coords)
+        end)
     end
 
     eval(quote
-        function unsafe_createpolygon(coords::$typeargs)
-            geom = unsafe_creategeom(GDAL.wkbPolygon)
+        function unsafe_createpolygon(::Type{G}, coords::$typeargs) where G <: AbstractGeometry
+            geom = unsafe_creategeom(G, GDAL.wkbPolygon)
             addgeomdirectly!(geom, unsafe_createlinearring(coords))
             geom
         end
 
-        function unsafe_createmultipoint(coords::$typeargs)
-            geom = unsafe_creategeom(GDAL.wkbMultiPoint)
+        unsafe_createpolygon(coords::$typeargs) = unsafe_createpolygon(Geometry, coords)
+
+        createpolygon(coords::$typeargs) = unsafe_createpolygon(IGeometry, coords)
+
+        function unsafe_createmultipoint(::Type{G}, coords::$typeargs) where G <: AbstractGeometry
+            geom = unsafe_creategeom(G, GDAL.wkbMultiPoint)
             for point in coords
                 addgeomdirectly!(geom, unsafe_createpoint(point))
             end
             geom
         end
+
+        unsafe_createmultipoint(coords::$typeargs) = unsafe_createmultipoint(Geometry, coords)
+
+        createmultipoint(coords::$typeargs) = unsafe_createmultipoint(IGeometry, coords)
     end)
 end
 
@@ -1134,22 +1298,38 @@ for typeargs in (Vector{Vector{Tuple{Cdouble,Cdouble}}},
     for (geom, wkbgeom, f) in ((:polygon, GDAL.wkbPolygon, :unsafe_createlinearring),
                                (:multilinestring, GDAL.wkbMultiLineString, :unsafe_createlinestring),
                                (:multipolygon_noholes, GDAL.wkbMultiPolygon, :unsafe_createpolygon))
-        @eval function $(Symbol("unsafe_create$geom"))(coords::$typeargs)
-                  geom = unsafe_creategeom($wkbgeom)
-                  for coord in coords
-                      addgeomdirectly!(geom, $(f)(coord))
-                  end
-                  geom
-              end
+        eval(quote
+            function $(Symbol("unsafe_create$geom"))(
+                    ::Type{G},
+                    coords::$typeargs
+                ) where G <: AbstractGeometry
+                geom = unsafe_creategeom(G, $wkbgeom)
+                for coord in coords; addgeomdirectly!(geom, $(f)(coord)) end
+                geom
+            end
+
+            $(Symbol("unsafe_create$geom"))(coords::$typeargs) =
+                $(Symbol("unsafe_create$geom"))(Geometry, coords::$typeargs)
+
+            $(Symbol("create$geom"))(coords::$typeargs) =
+                $(Symbol("unsafe_create$geom"))(IGeometry, coords::$typeargs)
+        end)
     end
 end
 
 function unsafe_createmultipolygon(
+        ::Type{G},
         coords::Vector{Vector{Vector{Tuple{Cdouble,Cdouble}}}}
-    )
-    geom = unsafe_creategeom(GDAL.wkbMultiPolygon)
+    ) where G <: AbstractGeometry
+    geom = unsafe_creategeom(G, GDAL.wkbMultiPolygon)
     for coord in coords
         addgeomdirectly!(geom, unsafe_createpolygon(coord))
     end
     geom
 end
+
+unsafe_createmultipolygon(coords::Vector{Vector{Vector{Tuple{Cdouble,Cdouble}}}}) =
+    unsafe_createmultipolygon(Geometry, coords)
+
+createmultipolygon(coords::Vector{Vector{Vector{Tuple{Cdouble,Cdouble}}}}) =
+    unsafe_createmultipolygon(IGeometry, coords)

--- a/src/types.jl
+++ b/src/types.jl
@@ -30,6 +30,15 @@ mutable struct FeatureLayer;                  ptr::GDALFeatureLayer       end
 mutable struct Field;                         ptr::GDALField              end
 mutable struct FieldDefn;                     ptr::GDALFieldDefn          end
 mutable struct Geometry <: AbstractGeometry;  ptr::GDALGeometry           end
+mutable struct IGeometry <: AbstractGeometry
+    ptr::GDALGeometry
+
+    function IGeometry(ptr::GDALGeometry)
+        geom = new(GDAL.clone(ptr))
+        finalizer(geom, g -> (destroy(g.ptr); g.ptr = C_NULL))
+        geom
+    end
+end
 mutable struct GeomFieldDefn;                 ptr::GDALGeomFieldDefn      end
 mutable struct RasterAttrTable;               ptr::GDALRasterAttrTable    end
 mutable struct RasterBand;                    ptr::GDALRasterBand         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,7 +35,7 @@ mutable struct IGeometry <: AbstractGeometry
 
     function IGeometry(ptr::GDALGeometry)
         geom = new(GDAL.clone(ptr))
-        finalizer(geom, g -> (destroy(g.ptr); g.ptr = C_NULL))
+        finalizer(geom, destroy)
         geom
     end
 end

--- a/test/test_cookbook_geometry.jl
+++ b/test/test_cookbook_geometry.jl
@@ -28,6 +28,9 @@ import GDAL, ArchGDAL; const AG = ArchGDAL
         AG.addpoint!(point, 1198054.34, 648493.09)
         println(AG.toWKT(point))
     AG.destroy(point)
+
+    # Method 5
+    println(AG.toWKT(AG.createpoint(1198054.34, 648493.09)))
 end
 
 @testset "Create a LineString" begin
@@ -65,6 +68,14 @@ end
         AG.addpoint!(line, 1281307.30760719,   636467.6640211721)
         println(AG.toWKT(line))
     AG.destroy(line)
+
+    # Method 5
+    println(AG.toWKT(AG.createlinestring([
+        (1116651.439379124,  637392.6969887456),
+        (1188804.0108498496, 652655.7409537067),
+        (1226730.3625203592, 634155.0816022386),
+        (1281307.30760719,   636467.6640211721)
+    ])))
 end
 
 @testset "Create a Polygon" begin
@@ -131,6 +142,15 @@ end
         AG.addgeomdirectly!(poly, ring) # ownership of ring passed to poly
         println(AG.toWKT(poly))
     AG.destroy(poly)
+
+    println(AG.toWKT(AG.createpolygon([
+        (1179091.1646903288, 712782.8838459781),
+        (1161053.0218226474, 667456.2684348812),
+        (1214704.933941905,  641092.8288590391),
+        (1228580.428455506,  682719.3123998424),
+        (1218405.0658121984, 721108.1805541387),
+        (1179091.1646903288, 712782.8838459781)
+    ])))
 end 
 
 @testset "Create a Polygon with holes" begin
@@ -213,6 +233,22 @@ end
         AG.addgeomdirectly!(poly, innerring)
         println(AG.toWKT(poly))
     AG.destroy(poly)
+
+    # Method 5
+    println(AG.toWKT(AG.createpolygon([
+        # outerring
+        [(1154115.274565847,  686419.4442701361),
+         (1154115.274565847,  653118.2574374934),
+         (1165678.1866605144, 653118.2574374934),
+         (1165678.1866605144, 686419.4442701361),
+         (1154115.274565847,  686419.4442701361)],
+        # innerring(s)
+        [(1149490.1097279799, 691044.6091080031),
+         (1149490.1097279799, 648030.5761158396),
+         (1191579.1097525698, 648030.5761158396),
+         (1191579.1097525698, 691044.6091080031),
+         (1149490.1097279799, 691044.6091080031)]
+    ])))
 end
 
 @testset "Create a MultiPoint" begin
@@ -256,6 +292,13 @@ end
         AG.addgeomdirectly!(multipoint, point3)
         println(AG.toWKT(multipoint))
     AG.destroy(multipoint)
+
+    # Method 5
+    println(AG.toWKT(AG.createmultipoint([
+        (1251243.7361610543, 598078.7958668759),
+        (1240605.8570339603, 601778.9277371694),
+        (1250318.7031934808, 606404.0925750365)
+    ])))
 end
 
 @testset "Create a MultiLineString" begin
@@ -309,6 +352,14 @@ end
 
         println(AG.toWKT(multiline))
     AG.destroy(multiline)
+
+    # Method 5
+    println(AG.toWKT(AG.createmultilinestring(Vector{Tuple{Float64,Float64}}[
+        [(1214242.4174581182, 617041.9717021306),
+         (1234593.142744733,  629529.9167643716)],
+        [(1184641.3624957693, 626754.8178616514),
+         (1219792.6152635587, 606866.6090588232)]
+    ])))
 end
 
 @testset "Create a MultiPolygon" begin
@@ -398,6 +449,20 @@ end
 
         println(AG.toWKT(multipolygon))
     AG.destroy(multipolygon)
+
+    # Method 5
+    println(AG.toWKT(AG.createmultipolygon_noholes(Vector{Tuple{Float64,Float64}}[
+             [(1204067.0548148106, 634617.5980860253),
+              (1204067.0548148106, 620742.1035724243),
+              (1215167.4504256917, 620742.1035724243),
+              (1215167.4504256917, 634617.5980860253),
+              (1204067.0548148106, 634617.5980860253)],
+             [(1179553.6811741155, 647105.5431482664),
+              (1179553.6811741155, 626292.3013778647),
+              (1194354.20865529,   626292.3013778647),
+              (1194354.20865529,   647105.5431482664),
+              (1179553.6811741155, 647105.5431482664)]
+            ])))
 end
 
 @testset "Create a GeometryCollection" begin
@@ -452,6 +517,10 @@ end
     AG.fromWKT(wkt) do point
         println((AG.getx(point, 0), AG.gety(point, 0)))
     end
+
+    # Method 3
+    point = AG.fromWKT(wkt)
+    println((AG.getx(point, 0), AG.gety(point, 0)))
 end
 
 @testset "Create Geometry from GeoJSON" begin
@@ -466,6 +535,10 @@ end
     AG.fromJSON(geojson) do point
         println((AG.getx(point, 0), AG.gety(point, 0)))
     end
+
+    # Method 3
+    point = AG.fromJSON(geojson)
+    println((AG.getx(point, 0), AG.gety(point, 0)))
 end
 
 @testset "Create Geometry from GML" begin
@@ -482,6 +555,10 @@ end
     AG.fromGML(gml) do point
         println((AG.getx(point, 0), AG.gety(point, 0)))
     end
+
+    # Method 3
+    point = AG.fromGML(gml)
+    println((AG.getx(point, 0), AG.gety(point, 0)))
 end
 
 @testset "Create Geometry from WKB" begin
@@ -497,20 +574,34 @@ end
     AG.fromWKB(wkb) do point
         println((AG.getx(point, 0), AG.gety(point, 0)))
     end
+
+    # Method 3
+    point = AG.fromWKB(wkb)
+    println((AG.getx(point, 0), AG.gety(point, 0)))
 end
 
 @testset "Count Points in a Geometry" begin
     wkt = "LINESTRING (1181866.263593049 615654.4222507705, 1205917.1207499576 623979.7189589312, 1227192.8790041457 643405.4112779726, 1224880.2965852122 665143.6860159477)"
+
+    # Method 1
     AG.fromWKT(wkt) do geom
         println("Geometry has $(AG.npoint(geom)) points")
     end
+
+    # Method 2
+    println("Geometry has $(AG.npoint(AG.fromWKT(wkt))) points")
 end
 
 @testset "Count Geometries in a Geometry" begin
     wkt = "MULTIPOINT (1181866.263593049 615654.4222507705, 1205917.1207499576 623979.7189589312, 1227192.8790041457 643405.4112779726, 1224880.2965852122 665143.6860159477)"
+
+    # Method 1
     AG.fromWKT(wkt) do geom
         println("Geometry has $(AG.npoint(geom)) points")
     end
+
+    # Method 2
+    println("Geometry has $(AG.npoint(AG.fromWKT(wkt))) points")
 end
 
 @testset "Iterate over Geometries in a Geometry" begin
@@ -533,6 +624,8 @@ end
 
 @testset "Buffer a Geometry" begin
     wkt = "POINT (1198054.34 648493.09)"
+
+    # Method 1
     AG.fromWKT(wkt) do pt
         bufferdist = 500
         AG.buffer(pt, bufferdist) do poly
@@ -540,6 +633,9 @@ end
             println("$(AG.toWKT(poly))")
         end
     end
+
+    # Method 2
+    println("$(AG.toWKT(AG.buffer(AG.fromWKT(wkt), 500)))")
 end
 
 # @testset "Calculate Envelope of a Geometry" begin
@@ -581,6 +677,7 @@ end
     wkt1 = "POLYGON ((1208064.271243039 624154.6783778917, 1208064.271243039 601260.9785661874, 1231345.9998651114 601260.9785661874, 1231345.9998651114 624154.6783778917, 1208064.271243039 624154.6783778917))"
     wkt2 = "POLYGON ((1199915.6662253144 633079.3410163528, 1199915.6662253144 614453.958118695, 1219317.1067437078 614453.958118695, 1219317.1067437078 633079.3410163528, 1199915.6662253144 633079.3410163528)))"
 
+    # Method 1
     AG.fromWKT(wkt1) do poly1
     AG.fromWKT(wkt2) do poly2
         AG.intersection(poly1, poly2) do poly3
@@ -588,11 +685,16 @@ end
         end
     end
     end
+
+    # Method 2
+    println(AG.toWKT(AG.intersection(AG.fromWKT(wkt1), AG.fromWKT(wkt2))))
 end
 
 @testset "Calculate union between two Geometries" begin
     wkt1 = "POLYGON ((1208064.271243039 624154.6783778917, 1208064.271243039 601260.9785661874, 1231345.9998651114 601260.9785661874, 1231345.9998651114 624154.6783778917, 1208064.271243039 624154.6783778917))"
     wkt2 = "POLYGON ((1199915.6662253144 633079.3410163528, 1199915.6662253144 614453.958118695, 1219317.1067437078 614453.958118695, 1219317.1067437078 633079.3410163528, 1199915.6662253144 633079.3410163528)))"
+
+    # Method 1
     AG.fromWKT(wkt1) do poly1
     AG.fromWKT(wkt2) do poly2
         AG.union(poly1, poly2) do poly3
@@ -602,6 +704,9 @@ end
         end
     end
     end
+
+    # Method 2
+    println(AG.toWKT(AG.union(AG.fromWKT(wkt1), AG.fromWKT(wkt2))))
 end
 
 @testset "Write Geometry to GeoJSON|GML|WKT|WKB" begin
@@ -620,6 +725,8 @@ end
 
 @testset "Force polygon to multipolygon" begin
     wkt = "POLYGON ((1179091.164690328761935 712782.883845978067257,1161053.021822647424415 667456.268434881232679,1214704.933941904921085 641092.828859039116651,1228580.428455505985767 682719.312399842427112,1218405.065812198445201 721108.180554138729349,1179091.164690328761935 712782.883845978067257))"
+
+    # Method 1
     AG.fromWKT([wkt]) do poly
         println("Before: $(AG.toWKT(poly))")
         if AG.getgeomtype(poly) == GDAL.wkbPolygon
@@ -628,4 +735,7 @@ end
             end
         end
     end
+
+    # Method 2
+    println(AG.forceto(AG.fromWKT([wkt]), GDAL.wkbMultiPolygon))
 end

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -41,9 +41,44 @@ import GDAL, ArchGDAL; const AG = ArchGDAL
         AG.closerings!(point)
         @test AG.toJSON(point) == "{ \"type\": \"Point\", \"coordinates\": [ 100.0, 70.0 ] }"
     end
+
+    # Method 2
+    point = AG.createpoint(100, 70)
+    @test AG.getdim(point) == 0
+    @test AG.getcoorddim(point) == 2
+    AG.setcoorddim!(point, 3)
+    @test AG.getcoorddim(point) == 3
+    @test AG.isvalid(point) == true
+    @test AG.issimple(point) == true
+    @test AG.isring(point) == false
+    @test AG.getz(point, 0) == 0
+    println(AG.getenvelope(point))
+    println(AG.getenvelope3d(point))
+    @test AG.toISOWKB(point, GDAL.wkbNDR) == UInt8[0x01,0xe9,0x03,0x00,0x00,
+    0x00,0x00,0x00,0x00,0x00,0x00,0x59,0x40,0x00,0x00,0x00,0x00,0x00,0x80,
+    0x51,0x40,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]
+    @test AG.toISOWKB(point, GDAL.wkbXDR) == UInt8[0x00,0x00,0x00,0x03,0xe9,
+    0x40,0x59,0x00,0x00,0x00,0x00,0x00,0x00,0x40,0x51,0x80,0x00,0x00,0x00,
+    0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]
+    @test AG.toKML(point, "relativeToGround") == "<Point><altitudeMode>relativeToGround</altitudeMode><coordinates>100,70,0</coordinates></Point>"
+    @test AG.toKML(point, "clampToGround") == "<Point><altitudeMode>clampToGround</altitudeMode><coordinates>100,70,0</coordinates></Point>"
+    @test AG.toKML(point) == "<Point><coordinates>100,70,0</coordinates></Point>"
+    @test AG.toJSON(point) == "{ \"type\": \"Point\", \"coordinates\": [ 100.0, 70.0, 0.0 ] }"
+    @test AG.equals(point, AG.createpoint(100,70,0)) == true
+    @test AG.equals(point, AG.createpoint((100,70,0))) == true
+    AG.flattento2d!(point)
+    @test AG.getcoorddim(point) == 2
+    @test AG.getnonlineargeomflag() == true
+    AG.setnonlineargeomflag!(false)
+    @test AG.getnonlineargeomflag() == false
+    AG.setnonlineargeomflag!(true)
+    @test AG.getnonlineargeomflag() == true
+    AG.closerings!(point)
+    @test AG.toJSON(point) == "{ \"type\": \"Point\", \"coordinates\": [ 100.0, 70.0 ] }"
 end
 
 @testset "Testing construction of complex geometries" begin
+    @test AG.toWKT(AG.createlinestring([1.,2.,3.], [4.,5.,6.])) == "LINESTRING (1 4,2 5,3 6)"
     AG.createlinestring([1.,2.,3.], [4.,5.,6.]) do geom
         @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
         AG.closerings!(geom)
@@ -59,6 +94,7 @@ end
         @test AG.toWKT(geom) == "LINESTRING (1 4 7,10 10 10,3 6 9,11 11 11)"
     end
     
+    @test AG.toWKT(AG.createlinearring([1.,2.,3.], [4.,5.,6.])) == "LINEARRING (1 4,2 5,3 6)"
     AG.createlinearring([1.,2.,3.], [4.,5.,6.]) do geom
         @test AG.toWKT(geom) == "LINEARRING (1 4,2 5,3 6)"
         AG.setpointcount!(geom, 5)
@@ -72,6 +108,7 @@ end
         @test AG.toWKT(geom) == "LINEARRING (1 4 7,2 5 8,3 6 9,1 4 7)"
     end
 
+    @test AG.toWKT(AG.createpolygon([1.,2.,3.], [4.,5.,6.])) == "POLYGON ((1 4,2 5,3 6))"
     AG.createpolygon([1.,2.,3.], [4.,5.,6.]) do geom
         @test AG.toWKT(geom) == "POLYGON ((1 4,2 5,3 6))"
     end
@@ -81,6 +118,7 @@ end
         @test AG.toWKT(geom) == "POLYGON ((1 4 7,2 5 8,3 6 9,1 4 7))"
     end
 
+    @test AG.toWKT(AG.createmultipoint([1.,2.,3.], [4.,5.,6.])) == "MULTIPOINT (1 4,2 5,3 6)"
     AG.createmultipoint([1.,2.,3.], [4.,5.,6.]) do geom
         @test AG.toWKT(geom) == "MULTIPOINT (1 4,2 5,3 6)"
     end
@@ -88,6 +126,14 @@ end
         @test AG.toWKT(geom) == "MULTIPOINT (1 4 7,2 5 8,3 6 9)"
     end
 
+    @test AG.toWKT(AG.createmultipolygon(Vector{Vector{Tuple{Cdouble,Cdouble}}}[
+        Vector{Tuple{Cdouble,Cdouble}}[
+            [(0,0),(0,4),(4,4),(4,0)],
+            [(1,1),(1,3),(3,3),(3,1)]],
+        Vector{Tuple{Cdouble,Cdouble}}[
+            [(10,0),(10,4),(14,4),(14,0)],
+            [(11,1),(11,3),(13,3),(13,1)]]]
+    )) == "MULTIPOLYGON (((0 0,0 4,4 4,4 0),(1 1,1 3,3 3,3 1)),((10 0,10 4,14 4,14 0),(11 1,11 3,13 3,13 1)))"
     AG.createmultipolygon(Vector{Vector{Tuple{Cdouble,Cdouble}}}[
                             Vector{Tuple{Cdouble,Cdouble}}[
                                 [(0,0),(0,4),(4,4),(4,0)],
@@ -99,10 +145,12 @@ end
     end
 
     AG.fromWKT("CURVEPOLYGON(CIRCULARSTRING(-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0 0.5,1 0,0 1,-1 0))") do geom
+        @test AG.toWKT(AG.getcurvegeom(AG.getlineargeom(geom, 0.5))) == "CURVEPOLYGON (CIRCULARSTRING (-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0.0 0.5,1 0,0 1,-1 0))"
         AG.getlineargeom(geom, 0.5) do lgeom
             AG.getcurvegeom(lgeom) do clgeom
                 @test AG.toWKT(clgeom) == "CURVEPOLYGON (CIRCULARSTRING (-2 0,-1 -1,0 0,1 -1,2 0,0 2,-2 0),(-1 0,0.0 0.5,1 0,0 1,-1 0))"
             end
+            @test AG.ngeom(AG.polygonize(AG.forceto(lgeom, GDAL.wkbMultiLineString))) == 2
             AG.forceto(lgeom, GDAL.wkbMultiLineString) do mlsgeom
                 AG.polygonize(mlsgeom) do plgeom
                     @test AG.ngeom(plgeom) == 2
@@ -126,14 +174,20 @@ end
         @test AG.touches(geom1, geom2) == true
         @test AG.crosses(geom1, geom2) == false
         @test AG.overlaps(geom1, geom2) == false
+
+        @test AG.toWKT(AG.boundary(geom2)) == "GEOMETRYCOLLECTION EMPTY"
         AG.boundary(geom2) do result
             @test AG.toWKT(result) == "GEOMETRYCOLLECTION EMPTY"
         end
+
+        @test AG.toWKT(AG.union(geom1, geom2)) == "GEOMETRYCOLLECTION (POINT (2 5 8),POINT (3 6 9),POLYGON ((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),POLYGON ((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
         AG.union(geom1, geom2) do result
             @test AG.toWKT(result) == "GEOMETRYCOLLECTION (POINT (2 5 8),POINT (3 6 9),POLYGON ((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),POLYGON ((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
             @test AG.hascurvegeom(result, true) == false
             @test AG.hascurvegeom(result, false) == false
         end
+
+        @test AG.toWKT(AG.difference(geom1, geom2)) == "MULTIPOLYGON (((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
         AG.difference(geom1, geom2) do result
             @test AG.toWKT(result) == "MULTIPOLYGON (((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
             AG.segmentize!(result, 20)
@@ -141,6 +195,8 @@ end
             AG.segmentize!(result, 2)
             @test AG.toWKT(result) == "MULTIPOLYGON (((0 0 8,0.0 1.33333333333333 8,0.0 2.66666666666667 8,0 4 8,1.33333333333333 4.0 8,2.66666666666667 4.0 8,4 4 8,4.0 2.66666666666667 8,4.0 1.33333333333333 8,4 0 8,2.66666666666667 0.0 8,1.33333333333333 0.0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),((10 0 8,10.0 1.33333333333333 8,10.0 2.66666666666667 8,10 4 8,11.3333333333333 4.0 8,12.6666666666667 4.0 8,14 4 8,14.0 2.66666666666667 8,14.0 1.33333333333333 8,14 0 8,12.6666666666667 0.0 8,11.3333333333333 0.0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
         end
+
+        @test AG.toWKT(AG.symdifference(geom1, geom2)) == "GEOMETRYCOLLECTION (POINT (2 5 8),POINT (3 6 9),POLYGON ((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),POLYGON ((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
         AG.symdifference(geom1, geom2) do result
             @test AG.toWKT(result) == "GEOMETRYCOLLECTION (POINT (2 5 8),POINT (3 6 9),POLYGON ((0 0 8,0 4 8,4 4 8,4 0 8,0 0 8),(1 1 8,3 1 8,3 3 8,1 3 8,1 1 8)),POLYGON ((10 0 8,10 4 8,14 4 8,14 0 8,10 0 8),(11 1 8,13 1 8,13 3 8,11 3 8,11 1 8)))"
             AG.removegeom!(result, 1)


### PR DESCRIPTION
where I stands for Interactive, since these are meant for
REPL/Interactive use, and have finalizers registered, rather than
handled through context management.

The general API is

* `unsafe_<method>(G, args…)` will return a geometry of type G
* `unsafe_<method>(args…)` will return a geometry of type Geometry (which
has to be destroyed)
* `<method>(::Function, args…)` allows for the do-block syntax which
creates a geometry::Geometry which is operated on by the function,
before being destroyed.
* `<method>(args…)` returns a geometry of type IGeometry