### PR TITLE
Updated installation instructions for Julia 0.7/1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,14 @@ This package aims to be a complete solution for working with GDAL in Julia, simi
 - **versatility**: ArchGDAL will strive to remain small in its assumptions about the range of user-needs, and to make it easy for users to build their own extensions/conveniences.
 
 ## Installation
-This package is currently unregistered, so add it using `Pkg.clone`, then find or get the GDAL dependencies using `Pkg.build`:
+This package is currently unregistered, so add it running:
 
 ```julia
-Pkg.add("GDAL")
-Pkg.clone("https://github.com/yeesian/ArchGDAL.jl.git")
+pkg> add https://github.com/yeesian/ArchGDAL.jl #master
 ```
 
 To test if it is installed correctly,
 
 ```julia
-Pkg.test("ArchGDAL")
+pkg> test ArchGDAL
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,17 +16,14 @@ This package aims to be a complete solution for working with GDAL in Julia, simi
 - **versatility**: ArchGDAL will strive to remain small in its assumptions about the range of user-needs, and to make it easy for users to build their own extensions/conveniences.
 
 ## Installation
-This package is currently unregistered, so add it using `Pkg.clone`, then find or get the GDAL dependencies using `Pkg.build`:
+This package is currently unregistered, so add it running:
 
 ```julia
-Pkg.clone("https://github.com/visr/GDAL.jl.git")
-Pkg.build("GDAL")
-Pkg.clone("https://github.com/yeesian/ArchGDAL.jl.git")
+pkg> add https://github.com/yeesian/ArchGDAL.jl #master
 ```
 
-`Pkg.build("GDAL")` searches for a GDAL 2.1+ shared library on the path. If not found, it will download and install it. To test if it is installed correctly, use:
+To test if it is installed correctly,
 
 ```julia
-Pkg.test("GDAL")
-Pkg.test("ArchGDAL")
+pkg> test ArchGDAL
 ```


### PR DESCRIPTION
This PR updates the installation instructions both in the readme and in the documentation.

Based this on the branch [oneo](https://github.com/yeesian/ArchGDAL.jl/tree/oneo) from PR #53, since it does not make sense to merge it into master before that PR is merged.