### PR TITLE
Disable installing/using GDAL explicitely

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ build_script:
 
 test_script:
   - echo "%JL_TEST_SCRIPT%"
-  - C:\julia\bin\julia -E "using Pkg; Pkg.add("""GDAL"""); using GDAL; GDAL.GDAL_DATA[]" -e "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
 
 # # Uncomment to support code coverage upload. Should only be enabled for packages
 # # which would have coverage gaps without running on Windows

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -4,6 +4,7 @@ import ArchGDAL; const AG = ArchGDAL
 
 @testset "Reproject a Geometry" begin
     @testset "Method 1" begin
+        GDAL.__init__()
         source = AG.unsafe_importEPSG(2927); target = AG.unsafe_importEPSG(4326)
             transform = AG.unsafe_createcoordtrans(source, target)
                 point = AG.unsafe_fromWKT("POINT (1120351.57 741921.42)")
@@ -16,6 +17,7 @@ import ArchGDAL; const AG = ArchGDAL
     end
 
     @testset "Method 2" begin
+        GDAL.__init__()
         AG.importEPSG(2927) do source; AG.importEPSG(4326) do target
             AG.createcoordtrans(source, target) do transform
                 AG.fromWKT("POINT (1120351.57 741921.42)") do point
@@ -41,7 +43,7 @@ end
             end
         end
     end
-
+    GDAL.__init__()
     AG.importEPSG(26912) do spatialref
         @test AG.toPROJ4(spatialref) == "+proj=utm +zone=12 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs "
         @test AG.toWKT(spatialref)[1:6] == "PROJCS"

--- a/test/test_fielddefn.jl
+++ b/test/test_fielddefn.jl
@@ -55,6 +55,7 @@ import ArchGDAL; const AG = ArchGDAL
 end
 
 @testset "Tests for Geom Field Defn" begin
+    GDAL.__init__()
     AG.creategeomfielddefn("geomname", GDAL.wkbPolygon) do gfd
         @test AG.getname(gfd) == "geomname"
         AG.setname!(gfd, "my name!")


### PR DESCRIPTION
as to mimic Windows user running `]test ArchGDAL`.

It seems that for Windows:
- Setting GDAL_DATA using `CPLSetConfigOption` is required
- This config is lost by calling `@testset`. You can check this by calling `AG.getconfigoption("GDAL_DATA")`.



