### PR TITLE
import GeoInterface methods explicitly

### DIFF
--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -2,6 +2,7 @@ module ArchGDAL
 
     import GDAL, GeoInterface
     import DataStreams: Data
+    import GeoInterface: coordinates, geotype
     using Dates
 
     include("utils.jl")


### PR DESCRIPTION
So that `ArchGDAL.coordinates` works. Without this GeoInterface also needs to be imported to use `coordinates`, which makes a few things like using Requires.jl more complicated.