### PR TITLE
WIP: Geo format type wrappers and generic methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 DataStreams = "0.4.2"
 GDAL = "1.0.2"
 GeoInterface = "0.4, 0.5"
-GeoFormatTypes = "0.2"
+GeoFormatTypes = "0.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 DataStreams = "0.4.2"
 GDAL = "1.0.2"
 GeoInterface = "0.4, 0.5"
-GeoFormatTypes = "0.1.1"
+GeoFormatTypes = "0.2"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ version = "0.3.1"
 DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GDAL = "add2ef01-049f-52c4-9ee2-e494f65e021a"
+GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 
 [compat]
 DataStreams = "0.4.2"
 GDAL = "1.0.2"
 GeoInterface = "0.4, 0.5"
+GeoFormatTypes = "0.1.1"
 julia = "1"
 
 [extras]

--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -1,9 +1,13 @@
 module ArchGDAL
 
-    import GDAL, GeoInterface
+    import GDAL, GeoInterface, GeoFormatTypes
     import DataStreams: Data
     import GeoInterface: coordinates, geotype
+    import Base: convert
+
     using Dates
+    
+    const GFT = GeoFormatTypes
 
     include("utils.jl")
     include("types.jl")

--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -32,6 +32,7 @@ module ArchGDAL
     include("base/display.jl")
     include("datastreams.jl")
     include("geointerface.jl")
+    include("convert.jl")
 
     mutable struct DriverManager
         function DriverManager()

--- a/src/context.jl
+++ b/src/context.jl
@@ -202,7 +202,7 @@ for gdalfunc in (
         :gdalbuildvrt, :gdaldem, :gdalgrid, :gdalnearblack, :gdalrasterize,
         :gdaltranslate, :gdalvectortranslate, :gdalwarp, :getband,
         :getcolortable, :getfeature, :getgeom, :getlayer, :getmaskband,
-        :getoverview, :getpart, :getspatialref, :intersection, :importEPSG,
+        :getoverview, :getpart, :getspatialref, :importCRS, :intersection, :importEPSG,
         :importEPSGA, :importESRI, :importPROJ4, :importWKT, :importXML,
         :importURL, :lineargeom, :newspatialref, :nextfeature, :pointalongline,
         :pointonsurface, :polygonfromedges, :polygonize, :read, :sampleoverview,

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,0 +1,46 @@
+# This file contains friendly type-pyracy on `convert` for GeoFormatTypes.jl types
+
+# Geometry conversions. 
+#
+# Convert to Geometry, then to the target format.
+# The Geom trait is needed to separate out convert for CRS for WellKnownText
+# and GML, which may contain both. It is handled in GeoFormatTypes.
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
+    convert(target, convert(Geometry, source))
+
+Base.convert(::Type{<:Geometry}, source::GFT.AbstractWellKnownText) = 
+    fromWKT(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.WellKnownBinary) = 
+    fromWKB(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.GeoJSON) = 
+    fromJSON(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.GML) = 
+    fromGML(GFT.val(source))
+
+Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
+    GFT.WellKnownText(GFT.Geom(), toWKT(source))
+Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
+    GFT.WellKnownBinary(GFT.Geom(), toWKB(source))
+Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry) = 
+    GFT.GeoJSON(toJSON(source))
+Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry) = 
+    GFT.GML(GFT.Geom(), toGML(source))
+Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) = 
+    GFT.KML(toKML(source))
+
+
+# CRS conversions
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.CRS, source::GFT.GeoFormat) =
+    unsafe_convertcrs(target, importCRS(source))
+
+unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref) = 
+    GFT.CoordSys(toMICoordSys(crsref))
+unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref) = 
+    GFT.ProjString(toPROJ4(crsref))
+unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref) = 
+    GFT.WellKnownText(GFT.CRS(), toWKT(crsref))
+unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref) =
+    GFT.ESRIWellKnownText(toWKT(morphtoESRI!(crsref)))
+unsafe_convertcrs(::Type{<:GFT.GML}, crsref) = 
+    GFT.GML(toXML(crsref))
+

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -14,7 +14,7 @@ Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.FormatMode,Type{GFT.
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
-Convert any GeoFormat geometry data to an ArchGDAL Gemoetry type
+Convert `GeoFormat` geometry data to an ArchGDAL `Geometry` type
 """
 Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText) = 
     fromWKT(GFT.val(source))
@@ -28,7 +28,7 @@ Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML) =
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
-Convert AbstractGeometry data to any gemoetry GeoFormat 
+Convert `AbstractGeometry` data to any gemoetry `GeoFormat` 
 """
 Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
     GFT.WellKnownText(GFT.Geom(), toWKT(source))
@@ -45,7 +45,7 @@ Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) =
 """
     convert(target::Type{GeoFormat}, mode::CRS, source::GeoFormat)
 
-Convert any GeoFormat crs data to another another GeoFormat type.
+Convert `GeoFormat` crs data to another another `GeoFormat` crs type.
 """
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.CRS,Type{GFT.CRS}}, 
              source::GFT.GeoFormat) =

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,22 +1,36 @@
 # This file contains friendly type-pyracy on `convert` for GeoFormatTypes.jl types
 
-# Geometry conversions. 
-#
-# Convert to Geometry, then to the target format.
-# The Geom trait is needed to separate out convert for CRS for WellKnownText
-# and GML, which may contain both. It is handled in GeoFormatTypes.
-Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
-    convert(target, convert(Geometry, source))
+"""
+    convert(::Type{<:AbstractGeometry}, mode::Geom source::GeoFormat)
 
-Base.convert(::Type{<:Geometry}, source::GFT.AbstractWellKnownText) = 
+Convert a GeoFromat object to Geometry, then to the target format.
+The Geom trait is needed to separate out convert for CRS for WellKnownText
+and GML, which may contain both. It is handled in GeoFormatTypes.
+"""
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::Type{GFT.Geom}, source::GFT.GeoFormat) =
+    convert(target, convert(AbstractGeometry, source))
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
+    convert(target, convert(AbstractGeometry, source))
+
+"""
+    convert(::Type{<:AbstractGeometry}, source::GeoFormat)
+
+Convert any GeoFormat geometry data to an ArchGDAL Gemoetry type
+"""
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText) = 
     fromWKT(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.WellKnownBinary) = 
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.WellKnownBinary) = 
     fromWKB(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.GeoJSON) = 
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GeoJSON) = 
     fromJSON(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.GML) = 
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML) = 
     fromGML(GFT.val(source))
 
+"""
+    convert(::Type{<:AbstractGeometry}, source::GeoFormat)
+
+Convert AbstractGeometry data to any gemoetry GeoFormat 
+"""
 Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
     GFT.WellKnownText(GFT.Geom(), toWKT(source))
 Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
@@ -29,7 +43,13 @@ Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) =
     GFT.KML(toKML(source))
 
 
-# CRS conversions
+"""
+    convert(target::Type{GeoFormat}, mode::CRS, source::GeoFormat)
+
+Convert any GeoFormat crs data to another another GeoFormat type.
+"""
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::Type{GFT.CRS}, source::GFT.GeoFormat) =
+    unsafe_convertcrs(target, importCRS(source))
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.CRS, source::GFT.GeoFormat) =
     unsafe_convertcrs(target, importCRS(source))
 
@@ -40,7 +60,7 @@ unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref) =
 unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref) = 
     GFT.WellKnownText(GFT.CRS(), toWKT(crsref))
 unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref) =
-    GFT.ESRIWellKnownText(toWKT(morphtoESRI!(crsref)))
+    GFT.ESRIWellKnownText(GFT.CRS(), toWKT(morphtoESRI!(crsref)))
 unsafe_convertcrs(::Type{<:GFT.GML}, crsref) = 
     GFT.GML(toXML(crsref))
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -5,11 +5,10 @@
 
 Convert a GeoFromat object to Geometry, then to the target format.
 The Geom trait is needed to separate out convert for CRS for WellKnownText
-and GML, which may contain both. It is handled in GeoFormatTypes.
+and GML, which may contain both.
 """
-Base.convert(target::Type{<:GFT.GeoFormat}, mode::Type{GFT.Geom}, source::GFT.GeoFormat) =
-    convert(target, convert(AbstractGeometry, source))
-Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.FormatMode,Type{GFT.FormatMode}}, 
+             source::GFT.GeoFormat) =
     convert(target, convert(AbstractGeometry, source))
 
 """
@@ -48,9 +47,8 @@ Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) =
 
 Convert any GeoFormat crs data to another another GeoFormat type.
 """
-Base.convert(target::Type{<:GFT.GeoFormat}, mode::Type{GFT.CRS}, source::GFT.GeoFormat) =
-    unsafe_convertcrs(target, importCRS(source))
-Base.convert(target::Type{<:GFT.GeoFormat}, mode::GFT.CRS, source::GFT.GeoFormat) =
+Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.CRS,Type{GFT.CRS}}, 
+             source::GFT.GeoFormat) =
     unsafe_convertcrs(target, importCRS(source))
 
 unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref) = 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1,3 +1,32 @@
+
+# This is friendly type-pyracy on `convert` for GeoFormatTypes types
+Base.convert(::Type{<:Geometry}, source::GFT.AbstractWellKnownText) = 
+    fromWKT(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.WellKnownBinary) = 
+    fromWKB(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.GeoJSON) = 
+    fromJSON(GFT.val(source))
+Base.convert(::Type{<:Geometry}, source::GFT.GML) = 
+    fromGML(GFT.val(source))
+
+Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
+    GFT.WellKnownText(GFT.Geom(), toWKT(source))
+Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
+    GFT.WellKnownBinary(GFT.Geom(), toWKB(source))
+Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry) = 
+    GFT.GeoJSON(toJSON(source))
+Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry) = 
+    GFT.GML(GFT.Geom(), toGML(source))
+Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) = 
+    GFT.KML(toKML(source))
+
+# Convert to Geometry, then to the target format. There may be
+# a more optimal method, but this is a simple, high-level first pass.
+# The Geom trait is needed to separate out convert for CRS for WellKnownText
+# and GML, which may contain both. It is handled in GeoFormatTypes.
+Base.convert(format::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
+    convert(format, convert(Geometry, source))
+
 """
     fromWKB(data)
 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1,32 +1,4 @@
 
-# This is friendly type-pyracy on `convert` for GeoFormatTypes types
-Base.convert(::Type{<:Geometry}, source::GFT.AbstractWellKnownText) = 
-    fromWKT(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.WellKnownBinary) = 
-    fromWKB(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.GeoJSON) = 
-    fromJSON(GFT.val(source))
-Base.convert(::Type{<:Geometry}, source::GFT.GML) = 
-    fromGML(GFT.val(source))
-
-Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
-    GFT.WellKnownText(GFT.Geom(), toWKT(source))
-Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
-    GFT.WellKnownBinary(GFT.Geom(), toWKB(source))
-Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry) = 
-    GFT.GeoJSON(toJSON(source))
-Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry) = 
-    GFT.GML(GFT.Geom(), toGML(source))
-Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) = 
-    GFT.KML(toKML(source))
-
-# Convert to Geometry, then to the target format. There may be
-# a more optimal method, but this is a simple, high-level first pass.
-# The Geom trait is needed to separate out convert for CRS for WellKnownText
-# and GML, which may contain both. It is handled in GeoFormatTypes.
-Base.convert(format::Type{<:GFT.GeoFormat}, mode::GFT.Geom, source::GFT.GeoFormat) =
-    convert(format, convert(Geometry, source))
-
 """
     fromWKB(data)
 

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -1,16 +1,21 @@
 """
 Import format and run function `f` on the result.
 """
-importCRS(f::Function, sourceformat::GFT.GeoFormat) = begin
-    obj = importCRS(sourceformat)
-    try f(obj) finally destroy(obj) end
-end
-importCRS(x::GFT.EPSG) = importEPSG(GFT.val(x))
-importCRS(x::GFT.AbstractWellKnownText) = importWKT(GFT.val(x))
-importCRS(x::GFT.ESRIWellKnownText) = importESRI(GFT.val(x))
-importCRS(x::GFT.ProjString) = importPROJ4(GFT.val(x))
-importCRS(x::GFT.GML) = importXML(GFT.val(x))
-importCRS(x::GFT.KML) = importCRS(EPSG(4326))
+importCRS(x::GFT.GeoFormat) = importCRS!(newspatialref(), x)
+unsafe_importCRS(x::GFT.GeoFormat) = importCRS!(unsafe_newspatialref(), x)
+
+importCRS!(spref::AbstractSpatialRef, x::GFT.EPSG) =
+    importEPSG!(spref, GFT.val(x))
+importCRS!(spref::AbstractSpatialRef, x::GFT.AbstractWellKnownText) =
+    importWKT!(spref, GFT.val(x))
+importCRS!(spref::AbstractSpatialRef, x::GFT.ESRIWellKnownText) =
+    importESRI!(spref, GFT.val(x))
+importCRS!(spref::AbstractSpatialRef, x::GFT.ProjString) =
+    importPROJ4!(spref, GFT.val(x))
+importCRS!(spref::AbstractSpatialRef, x::GFT.GML) =
+    importXML!(spref, GFT.val(x))
+importCRS!(spref::AbstractSpatialRef, x::GFT.KML) =
+    importCRS!(spref, GFT.EPSG(4326))
 
 """
     reproject(points, sourceproj::GeoFormat, destproj::GeoFormat)
@@ -47,7 +52,7 @@ function reproject(geom::AbstractGeometry, crs::GFT.GeoFormat, targetcrs::GFT.Ge
         transform!(geom, transform)
     end
 end
-function reproject(geoms::AbstractArray{<:AbstractGeometry}, crs::GFT.GeoFormat, 
+function reproject(geoms::AbstractArray{<:AbstractGeometry}, crs::GFT.GeoFormat,
                    targetcrs::GFT.GeoFormat)
     crs2transform(crs, targetcrs) do transform
         transform!.(geoms, Ref(transform))

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -42,14 +42,17 @@ reproject(geom::GFT.GeoFormat, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
     convert(typeof(geom), reproject(convert(Geometry, geom), crs, targetcrs))
 
 # Geometries
-reproject(geom::AbstractGeometry, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
+function reproject(geom::AbstractGeometry, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat)
     crs2transform(crs, targetcrs) do transform
         transform!(geom, transform)
     end
-reproject(geoms::AbstractArray{<:AbstractGeometry}, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
+end
+function reproject(geoms::AbstractArray{<:AbstractGeometry}, crs::GFT.GeoFormat, 
+                   targetcrs::GFT.GeoFormat)
     crs2transform(crs, targetcrs) do transform
         transform!.(geoms, Ref(transform))
     end
+end
 
 """
     crs2transform(f, crs::GeoFormat, targetcrs::GeoFormat)
@@ -58,7 +61,7 @@ Run the function on a coord transform generated from
 two crs definitions. These can be in any GeoFormatTypes format
 that holds a coordinate reference system.
 """
-crs2transform(f, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
+function crs2transform(f::Function, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat)
     importCRS(crs) do crs_ref
         importCRS(targetcrs) do targetcrs_ref
             createcoordtrans(crs_ref, targetcrs_ref) do transform
@@ -66,6 +69,7 @@ crs2transform(f, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
             end
         end
     end
+end
 
 """
     newspatialref(wkt::AbstractString = "")

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -1,32 +1,16 @@
 """
 Import format and run function `f` on the result.
-
-The name could be improved?
 """
-importcrs(f::Function, sourceformat::GFT.GeoFormat) = begin
-    obj = importcrs(sourceformat)
+importCRS(f::Function, sourceformat::GFT.GeoFormat) = begin
+    obj = importCRS(sourceformat)
     try f(obj) finally destroy(obj) end
 end
-importcrs(x::GFT.EPSG) = importEPSG(GFT.val(x))
-importcrs(x::GFT.AbstractWellKnownText) = importWKT(GFT.val(x))
-importcrs(x::GFT.ESRIWellKnownText) = importESRI(GFT.val(x))
-importcrs(x::GFT.ProjString) = importPROJ4(GFT.val(x))
-importcrs(x::GFT.GML) = importXML(GFT.val(x))
-importcrs(x::GFT.KML) = importEPSG(EPSG(4327))
-importcrs(x::GFT.GeoJSON) = importEPSG(EPSG(4327)) # TODO check GeoJSON standard
-
-Base.convert(target::Type{GFT.GeoFormat}, mode::GFT.CRS, input::GFT.GeoFormat) =
-    unsafe_convert(target, mode, importcrs(input))
-
-unsafe_convert(::Type{GFT.CoordSys}, mode::GFT.CRS, srs::Ref) = GFT.CoordSys(toMICoordSys(srs))
-unsafe_convert(::Type{GFT.ProjString}, mode::GFT.CRS, srs::Ref) = GFT.ProjString(toPROJ4(srs))
-unsafe_convert(::Type{GFT.WellKnownText}, mode::GFT.CRS, srs::Ref) = GFT.WellKnownText(toWKT(srs))
-unsafe_convert(::Type{GFT.ESRIWellKnownText}, mode::GFT.CRS, srs::Ref) =
-    GFT.ESRIWellKnownText(toWKT(morphtoESRI!(srs)))
-unsafe_convert(::Type{GFT.GML}, mode::GFT.CRS, srs::Ref) = GFT.GML(toXML(srs))
-
-# These should be better integrated with geometry packages or follow some standard
-const ReprojectCoord = Union{<:NTuple{2,<:Number},<:NTuple{3,<:Number},AbstractVector{<:Number}}
+importCRS(x::GFT.EPSG) = importEPSG(GFT.val(x))
+importCRS(x::GFT.AbstractWellKnownText) = importWKT(GFT.val(x))
+importCRS(x::GFT.ESRIWellKnownText) = importESRI(GFT.val(x))
+importCRS(x::GFT.ProjString) = importPROJ4(GFT.val(x))
+importCRS(x::GFT.GML) = importXML(GFT.val(x))
+importCRS(x::GFT.KML) = importCRS(EPSG(4326))
 
 """
     reproject(points, sourceproj::GeoFormat, destproj::GeoFormat)
@@ -43,6 +27,9 @@ Reproject points to a different coordinate reference system and/or format.
 reproject([(118, 34), (119, 35)], EPSG(2025), EPSG(4326))
 """
 reproject(x, crs::GFT.GeoFormat, targetcrs::Nothing) = x
+
+# These should be better integrated with geometry packages or follow some standard
+const ReprojectCoord = Union{<:NTuple{2,<:Number},<:NTuple{3,<:Number},AbstractVector{<:Number}}
 
 # Vector/Tuple coordinate(s)
 reproject(coord::ReprojectCoord, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
@@ -72,8 +59,8 @@ two crs definitions. These can be in any GeoFormatTypes format
 that holds a coordinate reference system.
 """
 crs2transform(f, crs::GFT.GeoFormat, targetcrs::GFT.GeoFormat) =
-    importcrs(crs) do crs_ref
-        importcrs(targetcrs) do targetcrs_ref
+    importCRS(crs) do crs_ref
+        importCRS(targetcrs) do targetcrs_ref
             createcoordtrans(crs_ref, targetcrs_ref) do transform
                 f(transform)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("remotefiles.jl")
 @testset "ArchGDAL" begin
     cd(dirname(@__FILE__)) do
         isdir("tmp") || mkpath("tmp")
+        include("test_convert.jl")
         include("test_datastreams.jl")
         include("test_gdal_tutorials.jl")
         include("test_geometry.jl")

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -1,0 +1,53 @@
+
+@testset "convert point format" begin
+    point = AG.createpoint(100, 70)
+    json = convert(GFT.GeoJSON, point)
+    kml = convert(GFT.KML, point)
+    gml = convert(GFT.GML, point)
+    wkb = convert(GFT.WellKnownBinary, point) 
+    wkt = convert(GFT.WellKnownText, point) 
+    @test json.val == AG.toJSON(point)
+    @test kml.val == AG.toKML(point)
+    @test gml.val == AG.toGML(point)
+    @test wkb.val == AG.toWKB(point)
+    @test wkt.val == AG.toWKT(point)
+    @test convert(GFT.GeoJSON, json) == convert(GFT.GeoJSON, wkb) == 
+          convert(GFT.GeoJSON, wkt) == convert(GFT.GeoJSON, gml) == json
+    @test convert(GFT.KML, gml) == convert(GFT.KML, wkt)
+end
+
+
+@testset "convert crs format" begin
+    @testset "PROJ4 Format" begin
+        proj4326 = "+proj=longlat +datum=WGS84 +no_defs"
+        proj26912 = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
+        AG.importPROJ4(proj4326) do spatialref
+            spatialref2 = AG.importPROJ4(proj26912)
+            @test AG.toPROJ4(spatialref2) == proj26912
+            AG.importPROJ4!(spatialref2, AG.toPROJ4(spatialref))
+            @test AG.toPROJ4(spatialref2) == proj4326
+        end
+    end
+
+    @testset "WKT Format" begin
+        wkt4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
+        wkt26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]"
+        AG.importWKT(wkt4326) do spatialref
+            spatialref2 = AG.importWKT(wkt26912)
+            @test AG.toWKT(spatialref2) == wkt26912
+            AG.importWKT!(spatialref2, AG.toWKT(spatialref))
+            @test AG.toWKT(spatialref2) == wkt4326
+        end
+    end
+
+    @testset "ESRI Format" begin
+        esri4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]"
+        esri26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
+        AG.importESRI(esri4326) do spatialref
+            spatialref2 = AG.importESRI(esri26912)
+            @test AG.toWKT(spatialref2) == esri26912
+            AG.importESRI!(spatialref2, AG.toWKT(spatialref))
+            @test AG.toWKT(spatialref2) == esri4326
+        end
+    end
+end

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -2,6 +2,8 @@ using Test
 import ArchGDAL; const AG = ArchGDAL
 import GeoFormatTypes; const GFT = GeoFormatTypes
 
+# Tests high level convert methods
+
 @testset "convert point format" begin
     point = AG.createpoint(100, 70)
     json = convert(GFT.GeoJSON, point)
@@ -19,15 +21,10 @@ import GeoFormatTypes; const GFT = GeoFormatTypes
     @test convert(GFT.KML, gml) == convert(GFT.KML, wkt)
 end
 
-
 @testset "convert crs format" begin
-    wkt4326 = GFT.WellKnownText(GFT.CRS, "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]")
-    wkt26912 = GFT.WellKnownText(GFT.CRS, "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]")
     proj4326 = GFT.ProjString("+proj=longlat +datum=WGS84 +no_defs")
-    proj26912 = GFT.ProjString("+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs")
-    esri4326 = GFT.ESRIWellKnownText(GFT.CRS, "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]")
-    esri26912 = GFT.ESRIWellKnownText(GFT.CRS, "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]")
-    convert(GFT.ProjString, GFT.CRS(), wkt26912)
-    convert(GFT.WellKnownText, GFT.CRS(), proj26912)
-    convert(GFT.ESRIWellKnownText, GFT.CRS(), proj26912)
+    @test convert(GFT.ProjString, GFT.CRS(), 
+                  convert(GFT.WellKnownText, GFT.CRS(), 
+                          convert(GFT.ESRIWellKnownText, GFT.CRS(), 
+                                  GFT.EPSG(4326)))) == proj4326
 end

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -1,3 +1,6 @@
+using Test
+import ArchGDAL; const AG = ArchGDAL
+import GeoFormatTypes; const GFT = GeoFormatTypes
 
 @testset "convert point format" begin
     point = AG.createpoint(100, 70)
@@ -18,36 +21,13 @@ end
 
 
 @testset "convert crs format" begin
-    @testset "PROJ4 Format" begin
-        proj4326 = "+proj=longlat +datum=WGS84 +no_defs"
-        proj26912 = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
-        AG.importPROJ4(proj4326) do spatialref
-            spatialref2 = AG.importPROJ4(proj26912)
-            @test AG.toPROJ4(spatialref2) == proj26912
-            AG.importPROJ4!(spatialref2, AG.toPROJ4(spatialref))
-            @test AG.toPROJ4(spatialref2) == proj4326
-        end
-    end
-
-    @testset "WKT Format" begin
-        wkt4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
-        wkt26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]"
-        AG.importWKT(wkt4326) do spatialref
-            spatialref2 = AG.importWKT(wkt26912)
-            @test AG.toWKT(spatialref2) == wkt26912
-            AG.importWKT!(spatialref2, AG.toWKT(spatialref))
-            @test AG.toWKT(spatialref2) == wkt4326
-        end
-    end
-
-    @testset "ESRI Format" begin
-        esri4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]"
-        esri26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
-        AG.importESRI(esri4326) do spatialref
-            spatialref2 = AG.importESRI(esri26912)
-            @test AG.toWKT(spatialref2) == esri26912
-            AG.importESRI!(spatialref2, AG.toWKT(spatialref))
-            @test AG.toWKT(spatialref2) == esri4326
-        end
-    end
+    wkt4326 = GFT.WellKnownText(GFT.CRS, "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]")
+    wkt26912 = GFT.WellKnownText(GFT.CRS, "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]")
+    proj4326 = GFT.ProjString("+proj=longlat +datum=WGS84 +no_defs")
+    proj26912 = GFT.ProjString("+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs")
+    esri4326 = GFT.ESRIWellKnownText(GFT.CRS, "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]")
+    esri26912 = GFT.ESRIWellKnownText(GFT.CRS, "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]")
+    convert(GFT.ProjString, GFT.CRS(), wkt26912)
+    convert(GFT.WellKnownText, GFT.CRS(), proj26912)
+    convert(GFT.ESRIWellKnownText, GFT.CRS(), proj26912)
 end

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -42,6 +42,7 @@ const GI = GeoFormatTypes
             @test AG.reproject([coord], GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [[47.348801, -122.598135]]
             coord = (1120351.57, 741921.42)
             @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
+        end
     end
 end
 

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -1,6 +1,8 @@
 using Test
-import GeoInterface
-import ArchGDAL; const AG = ArchGDAL
+import GeoInterface, GeoFormatTypes, ArchGDAL 
+const AG = ArchGDAL
+const GFT = GeoFormatTypes
+const GI = GeoFormatTypes
 
 @testset "Reproject a Geometry" begin
     @testset "Method 1" begin
@@ -24,6 +26,22 @@ import ArchGDAL; const AG = ArchGDAL
                 @test ys ≈ [-126.863475, -126.863475]
                 @test zs ≈ [0.0, 0.0]
         end end end
+    end
+
+    @testset "Use reproject" begin
+        @testset "reciprocal reprojection of wkt" begin
+            wktpoint = GFT.WellKnownText(GFT.Geom(), "POINT (1120351.57 741921.42)")
+            result = GFT.WellKnownText(GFT.Geom(), "POINT (47.3488013802885 -122.598135130878)")
+            @test AG.reproject(wktpoint, GFT.EPSG(2927), GFT.EPSG(4326)) == result
+            @test convert(AG.Geometry, AG.reproject(result, GFT.EPSG(4326), GFT.EPSG(2927))) |> 
+                GeoInterface.coordinates ≈ [1120351.57, 741921.42]
+        end
+        @testset "reproject vector, vector of vector, or tuple" begin
+            coord = [1120351.57, 741921.42]
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
+            @test AG.reproject([coord], GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [[47.348801, -122.598135]]
+            coord = (1120351.57, 741921.42)
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
     end
 end
 

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -3,7 +3,6 @@ import GeoInterface, GeoFormatTypes, GDAL, ArchGDAL;
 const AG = ArchGDAL
 const GFT = GeoFormatTypes
 
-
 @testset "Incomplete GeoInterface geometries" begin
     @test_logs (:warn, "unknown geometry type") GeoInterface.geotype(AG.creategeom(GDAL.wkbCircularString))
     @test_logs (:warn, "unknown geometry type") GeoInterface.geotype(AG.creategeom(GDAL.wkbCompoundCurve))

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -98,25 +98,6 @@ end
     @test AG.toJSON(point) == "{ \"type\": \"Point\", \"coordinates\": [ 100.0, 70.0 ] }"
 end
 
-
-
-@testset "convert point format" begin
-    point = AG.createpoint(100, 70)
-    json = convert(GFT.GeoJSON, point)
-    kml = convert(GFT.KML, point)
-    gml = convert(GFT.GML, point)
-    wkb = convert(GFT.WellKnownBinary, point) 
-    wkt = convert(GFT.WellKnownText, point) 
-    @test GFT.val(json) == AG.toJSON(point)
-    @test GFT.val(kml) == AG.toKML(point)
-    @test GFT.val(gml) == AG.toGML(point) # This isn't actually tested above
-    @test GFT.val(wkb) == AG.toWKB(point)
-    @test GFT.val(wkt) == AG.toWKT(point)
-    @test convert(GFT.GeoJSON, json) == json
-    @test convert(GFT.GeoJSON, wkb) == convert(GFT.GeoJSON, wkt) == convert(GFT.GeoJSON, gml)
-    @test convert(GFT.KML, gml) == convert(GFT.KML, wkt)
-end
-
 @testset "Testing construction of complex geometries" begin
     @test AG.toWKT(AG.createlinestring([1.,2.,3.], [4.,5.,6.])) == "LINESTRING (1 4,2 5,3 6)"
     AG.createlinestring([1.,2.,3.], [4.,5.,6.]) do geom

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -108,7 +108,6 @@ end
         @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
         AG.setpoint!(geom, 1, 10, 10)
         @test AG.toWKT(geom) == "LINESTRING (1 4,10 10,3 6)"
-        # Test using convert
         @test GFT.val(convert(GFT.WellKnownText, geom)) == AG.toWKT(geom)  
     end
     AG.createlinestring([1.,2.,3.], [4.,5.,6.], [7.,8.,9.]) do geom

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -3,50 +3,79 @@ import GDAL
 import ArchGDAL; const AG = ArchGDAL
 
 @testset "Test Formats for Spatial Reference Systems" begin
-    @testset "PROJ4 Format" begin
-        proj4326 = "+proj=longlat +datum=WGS84 +no_defs"
-        proj26912 = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
-        AG.importPROJ4(proj4326) do spatialref
-            spatialref2 = AG.importPROJ4(proj26912)
-            @test AG.toPROJ4(spatialref2) == proj26912
-            AG.importPROJ4!(spatialref2, AG.toPROJ4(spatialref))
-            @test AG.toPROJ4(spatialref2) == proj4326
-        end
-    end
-
-    @testset "WKT Format" begin
-        wkt4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
-        wkt26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]"
-        AG.importWKT(wkt4326) do spatialref
-            spatialref2 = AG.importWKT(wkt26912)
-            @test AG.toWKT(spatialref2) == wkt26912
-            AG.importWKT!(spatialref2, AG.toWKT(spatialref))
-            @test AG.toWKT(spatialref2) == wkt4326
-        end
-    end
-
-    @testset "ESRI Format" begin
-        esri4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]"
-        esri26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
-        AG.importESRI(esri4326) do spatialref
-            spatialref2 = AG.importESRI(esri26912)
-            @test AG.toWKT(spatialref2) == esri26912
-            AG.importESRI!(spatialref2, AG.toWKT(spatialref))
-            @test AG.toWKT(spatialref2) == esri4326
-        end
-    end
-
-    @testset "XML Format" begin
-        xml4326 = """<gml:GeographicCRS gml:id="ogrcrs1">
-          <gml:srsName>GCS_WGS_1984</gml:srsName>
+    proj4326 = "+proj=longlat +datum=WGS84 +no_defs"
+    proj26912 = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
+    wkt4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
+    wkt26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"26912\"]]"
+    esri4326 = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433],AXIS[\"Longitude\",EAST],AXIS[\"Latitude\",NORTH]]"
+    esri26912 = "PROJCS[\"NAD83 / UTM zone 12N\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101,AUTHORITY[\"EPSG\",\"7019\"]],AUTHORITY[\"EPSG\",\"6269\"]],PRIMEM[\"Greenwich\",0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-111],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]"
+    xml4326 = """<gml:GeographicCRS gml:id="ogrcrs1">
+      <gml:srsName>GCS_WGS_1984</gml:srsName>
+      <gml:usesEllipsoidalCS>
+        <gml:EllipsoidalCS gml:id="ogrcrs2">
+          <gml:csName>ellipsoidal</gml:csName>
+          <gml:csID>
+            <gml:name codeSpace="urn:ogc:def:cs:EPSG::">6402</gml:name>
+          </gml:csID>
+          <gml:usesAxis>
+            <gml:CoordinateSystemAxis gml:id="ogrcrs3" gml:uom="urn:ogc:def:uom:EPSG::9102">
+              <gml:name>Geodetic latitude</gml:name>
+              <gml:axisID>
+                <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9901</gml:name>
+              </gml:axisID>
+              <gml:axisAbbrev>Lat</gml:axisAbbrev>
+              <gml:axisDirection>north</gml:axisDirection>
+            </gml:CoordinateSystemAxis>
+          </gml:usesAxis>
+          <gml:usesAxis>
+            <gml:CoordinateSystemAxis gml:id="ogrcrs4" gml:uom="urn:ogc:def:uom:EPSG::9102">
+              <gml:name>Geodetic longitude</gml:name>
+              <gml:axisID>
+                <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9902</gml:name>
+              </gml:axisID>
+              <gml:axisAbbrev>Lon</gml:axisAbbrev>
+              <gml:axisDirection>east</gml:axisDirection>
+            </gml:CoordinateSystemAxis>
+          </gml:usesAxis>
+        </gml:EllipsoidalCS>
+      </gml:usesEllipsoidalCS>
+      <gml:usesGeodeticDatum>
+        <gml:GeodeticDatum gml:id="ogrcrs5">
+          <gml:datumName>D_WGS_1984</gml:datumName>
+          <gml:usesPrimeMeridian>
+            <gml:PrimeMeridian gml:id="ogrcrs6">
+              <gml:meridianName>Greenwich</gml:meridianName>
+              <gml:greenwichLongitude>
+                <gml:angle uom="urn:ogc:def:uom:EPSG::9102">0</gml:angle>
+              </gml:greenwichLongitude>
+            </gml:PrimeMeridian>
+          </gml:usesPrimeMeridian>
+          <gml:usesEllipsoid>
+            <gml:Ellipsoid gml:id="ogrcrs7">
+              <gml:ellipsoidName>WGS_1984</gml:ellipsoidName>
+              <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6378137</gml:semiMajorAxis>
+              <gml:secondDefiningParameter>
+                <gml:inverseFlattening uom="urn:ogc:def:uom:EPSG::9201">298.257223563</gml:inverseFlattening>
+              </gml:secondDefiningParameter>
+            </gml:Ellipsoid>
+          </gml:usesEllipsoid>
+        </gml:GeodeticDatum>
+      </gml:usesGeodeticDatum>
+    </gml:GeographicCRS>
+    """
+    xml26912 = """<gml:ProjectedCRS gml:id="ogrcrs8">
+      <gml:srsName>NAD_1983_UTM_Zone_12N</gml:srsName>
+      <gml:baseCRS>
+        <gml:GeographicCRS gml:id="ogrcrs9">
+          <gml:srsName>GCS_North_American_1983</gml:srsName>
           <gml:usesEllipsoidalCS>
-            <gml:EllipsoidalCS gml:id="ogrcrs2">
+            <gml:EllipsoidalCS gml:id="ogrcrs10">
               <gml:csName>ellipsoidal</gml:csName>
               <gml:csID>
                 <gml:name codeSpace="urn:ogc:def:cs:EPSG::">6402</gml:name>
               </gml:csID>
               <gml:usesAxis>
-                <gml:CoordinateSystemAxis gml:id="ogrcrs3" gml:uom="urn:ogc:def:uom:EPSG::9102">
+                <gml:CoordinateSystemAxis gml:id="ogrcrs11" gml:uom="urn:ogc:def:uom:EPSG::9102">
                   <gml:name>Geodetic latitude</gml:name>
                   <gml:axisID>
                     <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9901</gml:name>
@@ -56,7 +85,7 @@ import ArchGDAL; const AG = ArchGDAL
                 </gml:CoordinateSystemAxis>
               </gml:usesAxis>
               <gml:usesAxis>
-                <gml:CoordinateSystemAxis gml:id="ogrcrs4" gml:uom="urn:ogc:def:uom:EPSG::9102">
+                <gml:CoordinateSystemAxis gml:id="ogrcrs12" gml:uom="urn:ogc:def:uom:EPSG::9102">
                   <gml:name>Geodetic longitude</gml:name>
                   <gml:axisID>
                     <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9902</gml:name>
@@ -68,10 +97,10 @@ import ArchGDAL; const AG = ArchGDAL
             </gml:EllipsoidalCS>
           </gml:usesEllipsoidalCS>
           <gml:usesGeodeticDatum>
-            <gml:GeodeticDatum gml:id="ogrcrs5">
-              <gml:datumName>D_WGS_1984</gml:datumName>
+            <gml:GeodeticDatum gml:id="ogrcrs13">
+              <gml:datumName>D_North_American_1983</gml:datumName>
               <gml:usesPrimeMeridian>
-                <gml:PrimeMeridian gml:id="ogrcrs6">
+                <gml:PrimeMeridian gml:id="ogrcrs14">
                   <gml:meridianName>Greenwich</gml:meridianName>
                   <gml:greenwichLongitude>
                     <gml:angle uom="urn:ogc:def:uom:EPSG::9102">0</gml:angle>
@@ -79,131 +108,103 @@ import ArchGDAL; const AG = ArchGDAL
                 </gml:PrimeMeridian>
               </gml:usesPrimeMeridian>
               <gml:usesEllipsoid>
-                <gml:Ellipsoid gml:id="ogrcrs7">
-                  <gml:ellipsoidName>WGS_1984</gml:ellipsoidName>
+                <gml:Ellipsoid gml:id="ogrcrs15">
+                  <gml:ellipsoidName>GRS_1980</gml:ellipsoidName>
                   <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6378137</gml:semiMajorAxis>
                   <gml:secondDefiningParameter>
-                    <gml:inverseFlattening uom="urn:ogc:def:uom:EPSG::9201">298.257223563</gml:inverseFlattening>
+                    <gml:inverseFlattening uom="urn:ogc:def:uom:EPSG::9201">298.257222101</gml:inverseFlattening>
                   </gml:secondDefiningParameter>
                 </gml:Ellipsoid>
               </gml:usesEllipsoid>
             </gml:GeodeticDatum>
           </gml:usesGeodeticDatum>
         </gml:GeographicCRS>
-        """
-        xml26912 = """<gml:ProjectedCRS gml:id="ogrcrs8">
-          <gml:srsName>NAD_1983_UTM_Zone_12N</gml:srsName>
-          <gml:baseCRS>
-            <gml:GeographicCRS gml:id="ogrcrs9">
-              <gml:srsName>GCS_North_American_1983</gml:srsName>
-              <gml:usesEllipsoidalCS>
-                <gml:EllipsoidalCS gml:id="ogrcrs10">
-                  <gml:csName>ellipsoidal</gml:csName>
-                  <gml:csID>
-                    <gml:name codeSpace="urn:ogc:def:cs:EPSG::">6402</gml:name>
-                  </gml:csID>
-                  <gml:usesAxis>
-                    <gml:CoordinateSystemAxis gml:id="ogrcrs11" gml:uom="urn:ogc:def:uom:EPSG::9102">
-                      <gml:name>Geodetic latitude</gml:name>
-                      <gml:axisID>
-                        <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9901</gml:name>
-                      </gml:axisID>
-                      <gml:axisAbbrev>Lat</gml:axisAbbrev>
-                      <gml:axisDirection>north</gml:axisDirection>
-                    </gml:CoordinateSystemAxis>
-                  </gml:usesAxis>
-                  <gml:usesAxis>
-                    <gml:CoordinateSystemAxis gml:id="ogrcrs12" gml:uom="urn:ogc:def:uom:EPSG::9102">
-                      <gml:name>Geodetic longitude</gml:name>
-                      <gml:axisID>
-                        <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9902</gml:name>
-                      </gml:axisID>
-                      <gml:axisAbbrev>Lon</gml:axisAbbrev>
-                      <gml:axisDirection>east</gml:axisDirection>
-                    </gml:CoordinateSystemAxis>
-                  </gml:usesAxis>
-                </gml:EllipsoidalCS>
-              </gml:usesEllipsoidalCS>
-              <gml:usesGeodeticDatum>
-                <gml:GeodeticDatum gml:id="ogrcrs13">
-                  <gml:datumName>D_North_American_1983</gml:datumName>
-                  <gml:usesPrimeMeridian>
-                    <gml:PrimeMeridian gml:id="ogrcrs14">
-                      <gml:meridianName>Greenwich</gml:meridianName>
-                      <gml:greenwichLongitude>
-                        <gml:angle uom="urn:ogc:def:uom:EPSG::9102">0</gml:angle>
-                      </gml:greenwichLongitude>
-                    </gml:PrimeMeridian>
-                  </gml:usesPrimeMeridian>
-                  <gml:usesEllipsoid>
-                    <gml:Ellipsoid gml:id="ogrcrs15">
-                      <gml:ellipsoidName>GRS_1980</gml:ellipsoidName>
-                      <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6378137</gml:semiMajorAxis>
-                      <gml:secondDefiningParameter>
-                        <gml:inverseFlattening uom="urn:ogc:def:uom:EPSG::9201">298.257222101</gml:inverseFlattening>
-                      </gml:secondDefiningParameter>
-                    </gml:Ellipsoid>
-                  </gml:usesEllipsoid>
-                </gml:GeodeticDatum>
-              </gml:usesGeodeticDatum>
-            </gml:GeographicCRS>
-          </gml:baseCRS>
-          <gml:definedByConversion>
-            <gml:Conversion gml:id="ogrcrs16">
-              <gml:coordinateOperationName>Transverse_Mercator</gml:coordinateOperationName>
-              <gml:usesMethod xlink:href="urn:ogc:def:method:EPSG::9807" />
-              <gml:usesValue>
-                <gml:value uom="urn:ogc:def:uom:EPSG::9102">0</gml:value>
-                <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8801" />
-              </gml:usesValue>
-              <gml:usesValue>
-                <gml:value uom="urn:ogc:def:uom:EPSG::9102">-111</gml:value>
-                <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8802" />
-              </gml:usesValue>
-              <gml:usesValue>
-                <gml:value uom="urn:ogc:def:uom:EPSG::9001">0.9996</gml:value>
-                <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8805" />
-              </gml:usesValue>
-              <gml:usesValue>
-                <gml:value uom="urn:ogc:def:uom:EPSG::9001">500000</gml:value>
-                <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8806" />
-              </gml:usesValue>
-              <gml:usesValue>
-                <gml:value uom="urn:ogc:def:uom:EPSG::9001">0</gml:value>
-                <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8807" />
-              </gml:usesValue>
-            </gml:Conversion>
-          </gml:definedByConversion>
-          <gml:usesCartesianCS>
-            <gml:CartesianCS gml:id="ogrcrs17">
-              <gml:csName>Cartesian</gml:csName>
-              <gml:csID>
-                <gml:name codeSpace="urn:ogc:def:cs:EPSG::">4400</gml:name>
-              </gml:csID>
-              <gml:usesAxis>
-                <gml:CoordinateSystemAxis gml:id="ogrcrs18" gml:uom="urn:ogc:def:uom:EPSG::9001">
-                  <gml:name>Easting</gml:name>
-                  <gml:axisID>
-                    <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9906</gml:name>
-                  </gml:axisID>
-                  <gml:axisAbbrev>E</gml:axisAbbrev>
-                  <gml:axisDirection>east</gml:axisDirection>
-                </gml:CoordinateSystemAxis>
-              </gml:usesAxis>
-              <gml:usesAxis>
-                <gml:CoordinateSystemAxis gml:id="ogrcrs19" gml:uom="urn:ogc:def:uom:EPSG::9001">
-                  <gml:name>Northing</gml:name>
-                  <gml:axisID>
-                    <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9907</gml:name>
-                  </gml:axisID>
-                  <gml:axisAbbrev>N</gml:axisAbbrev>
-                  <gml:axisDirection>north</gml:axisDirection>
-                </gml:CoordinateSystemAxis>
-              </gml:usesAxis>
-            </gml:CartesianCS>
-          </gml:usesCartesianCS>
-        </gml:ProjectedCRS>
-        """
+      </gml:baseCRS>
+      <gml:definedByConversion>
+        <gml:Conversion gml:id="ogrcrs16">
+          <gml:coordinateOperationName>Transverse_Mercator</gml:coordinateOperationName>
+          <gml:usesMethod xlink:href="urn:ogc:def:method:EPSG::9807" />
+          <gml:usesValue>
+            <gml:value uom="urn:ogc:def:uom:EPSG::9102">0</gml:value>
+            <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8801" />
+          </gml:usesValue>
+          <gml:usesValue>
+            <gml:value uom="urn:ogc:def:uom:EPSG::9102">-111</gml:value>
+            <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8802" />
+          </gml:usesValue>
+          <gml:usesValue>
+            <gml:value uom="urn:ogc:def:uom:EPSG::9001">0.9996</gml:value>
+            <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8805" />
+          </gml:usesValue>
+          <gml:usesValue>
+            <gml:value uom="urn:ogc:def:uom:EPSG::9001">500000</gml:value>
+            <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8806" />
+          </gml:usesValue>
+          <gml:usesValue>
+            <gml:value uom="urn:ogc:def:uom:EPSG::9001">0</gml:value>
+            <gml:valueOfParameter xlink:href="urn:ogc:def:parameter:EPSG::8807" />
+          </gml:usesValue>
+        </gml:Conversion>
+      </gml:definedByConversion>
+      <gml:usesCartesianCS>
+        <gml:CartesianCS gml:id="ogrcrs17">
+          <gml:csName>Cartesian</gml:csName>
+          <gml:csID>
+            <gml:name codeSpace="urn:ogc:def:cs:EPSG::">4400</gml:name>
+          </gml:csID>
+          <gml:usesAxis>
+            <gml:CoordinateSystemAxis gml:id="ogrcrs18" gml:uom="urn:ogc:def:uom:EPSG::9001">
+              <gml:name>Easting</gml:name>
+              <gml:axisID>
+                <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9906</gml:name>
+              </gml:axisID>
+              <gml:axisAbbrev>E</gml:axisAbbrev>
+              <gml:axisDirection>east</gml:axisDirection>
+            </gml:CoordinateSystemAxis>
+          </gml:usesAxis>
+          <gml:usesAxis>
+            <gml:CoordinateSystemAxis gml:id="ogrcrs19" gml:uom="urn:ogc:def:uom:EPSG::9001">
+              <gml:name>Northing</gml:name>
+              <gml:axisID>
+                <gml:name codeSpace="urn:ogc:def:axis:EPSG::">9907</gml:name>
+              </gml:axisID>
+              <gml:axisAbbrev>N</gml:axisAbbrev>
+              <gml:axisDirection>north</gml:axisDirection>
+            </gml:CoordinateSystemAxis>
+          </gml:usesAxis>
+        </gml:CartesianCS>
+      </gml:usesCartesianCS>
+    </gml:ProjectedCRS>
+    """
+
+    @testset "PROJ4 Format" begin
+        AG.importPROJ4(proj4326) do spatialref
+            spatialref2 = AG.importPROJ4(proj26912)
+            @test AG.toPROJ4(spatialref2) == proj26912
+            AG.importPROJ4!(spatialref2, AG.toPROJ4(spatialref))
+            @test AG.toPROJ4(spatialref2) == proj4326
+        end
+    end
+
+    @testset "WKT Format" begin
+        AG.importWKT(wkt4326) do spatialref
+            spatialref2 = AG.importWKT(wkt26912)
+            @test AG.toWKT(spatialref2) == wkt26912
+            AG.importWKT!(spatialref2, AG.toWKT(spatialref))
+            @test AG.toWKT(spatialref2) == wkt4326
+        end
+    end
+
+    @testset "ESRI Format" begin
+        AG.importESRI(esri4326) do spatialref
+            spatialref2 = AG.importESRI(esri26912)
+            @test AG.toWKT(spatialref2) == esri26912
+            AG.importESRI!(spatialref2, AG.toWKT(spatialref))
+            @test AG.toWKT(spatialref2) == esri4326
+        end
+    end
+
+    @testset "XML Format" begin
         AG.importXML(xml4326) do spatialref
             spatialref2 = AG.importXML(xml26912)
             @test startswith(AG.toXML(spatialref2), "<gml:ProjectedCRS")
@@ -223,6 +224,15 @@ import ArchGDAL; const AG = ArchGDAL
         #     AG.importURL!(spatialref2, url4326)
         #     @test AG.toWKT(spatialref2) == proj4326
         # end
+    end
+
+    @testset "generic importCRS" begin
+        @test AG.toWKT(AG.importCRS(GFT.WellKnownText(GFT.CRS(), wkt4326))) == AG.toWKT(AG.importWKT(wkt4326))
+        @test AG.toWKT(AG.importCRS(GFT.ESRIWellKnownText(GFT.CRS(), wkt4326))) == AG.toWKT(AG.importESRI(wkt4326))
+        @test AG.toWKT(AG.importCRS(GFT.ProjString(proj4326))) == AG.toWKT(AG.importPROJ4(proj4326))
+        @test AG.toWKT(AG.importCRS(GFT.EPSG(4326))) == AG.toWKT(AG.importEPSG(4326))
+        @test AG.toWKT(AG.importCRS(GFT.GML(xml4326))) == AG.toWKT(AG.importXML(xml4326))
+        @test AG.toWKT(AG.importCRS(GFT.KML(""))) == AG.toWKT(AG.importEPSG(4326))
     end
 end
 


### PR DESCRIPTION
No tests yet, but things like `reproject` do work for any format types, which is pretty powerful allready. 

I'm not really familiar with the details of these formats or GDAL methods, so input on how to actually test these things and finish the PR will be needed. 

My intent (and knowledge) is more around generalising the structure of these package and the ecosystem so we can do all kinds of transformations without needing all the method permutations everywhere. 

For GeoData.jl this PR allows us to do `GDALarray(filepath; reproject=EPSGcode(4326))` where you can pass in anything for reproject and GeoData doesn't need to know what it is, but your lat/lon coords will just work.

The type wrappers are coming from https://github.com/rafaqz/GeoFormatTypes.jl