### PR TITLE
add an Array constructor

### DIFF
--- a/src/raster/array.jl
+++ b/src/raster/array.jl
@@ -86,3 +86,4 @@ _dropint() = ()
 _bandindices(band::Integer) = Cint[band]
 _bandindices(bands::AbstractArray) = Cint[b for b in bands]
 
+Array(dataset::Dataset) = read(dataset)

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -60,6 +60,14 @@ AG.registerdrivers() do
                 @test band[755, 2107] == 0xff
             end
         end
+        @testset "Array constructor" begin
+            buffer = Array(ds)
+            typeof(buffer) <: Array{UInt8,3}
+            total = sum(buffer[:, :, 1:1])
+            count = sum(buffer[:, :, 1:1] .> 0)
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
     end
 end
 


### PR DESCRIPTION
Adds an `Array` constructor for `Dataset` to avoid having to call the `AG.read` and special case Ag.Dataset. Somehow I deleted this in the other pull request. 