### PR TITLE
add docstrings to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ jobs:
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate()'
+        - julia --project=docs/ test/remotefiles.jl
         - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,11 +11,12 @@ makedocs(
         "Raster Data" => "rasters.md",
         "Geometric Operations" => "geometries.md",
         "Spatial Projections" => "projections.md",
-        "Interactive versus Scoped Objects" => "memory.md"
-        # "Working with Spatialite" => "spatialite.md"
+        # "Working with Spatialite" => "spatialite.md",
+        "Interactive versus Scoped Objects" => "memory.md",
+        "Design Considerations" => "considerations.md",
+        "API Reference" => "reference.md",
         # "Naming Conventions" => "conventions.md", # table between GDAL, GDAL.jl, and ArchGDAL.jl
     ]
-    
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 using Documenter, ArchGDAL
 
+# make sure you have run the tests before such that the test files are present
 makedocs(
     modules = [ArchGDAL],
     format = Documenter.HTML(),

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,8 @@ makedocs(
     modules = [ArchGDAL],
     format = Documenter.HTML(),
     sitename = "ArchGDAL.jl",
+    workdir = joinpath(@__DIR__, "..", "test"),
+    strict = true,
     pages = [
         "index.md",
         "GDAL Datasets" => "datasets.md",

--- a/docs/src/considerations.md
+++ b/docs/src/considerations.md
@@ -11,7 +11,7 @@ Although GDAL provides a unified data model for different data formats, there ar
 `ArchGDAL.jl` provides mechanisms for setting GDAL's configuration options, and does not maintain its own list of sanctioned options for each driver. Although work is underway to make this an easier experience for the user, it remains the responsibility of the user to check that a particular configuration exists and works for their choice of drivers.
 
 Here's a collection of references for developers who are interested:
-- https://trac.osgeo.org/gdal/wiki/ConfigOptions
-- https://github.com/mapbox/rasterio/pull/665
-- https://github.com/mapbox/rasterio/issues/875
-- https://mapbox.github.io/rasterio/topics/configuration.html
+- [https://trac.osgeo.org/gdal/wiki/ConfigOptions](https://trac.osgeo.org/gdal/wiki/ConfigOptions)
+- [https://github.com/mapbox/rasterio/pull/665](https://github.com/mapbox/rasterio/pull/665)
+- [https://github.com/mapbox/rasterio/issues/875](https://github.com/mapbox/rasterio/issues/875)
+- [https://rasterio.readthedocs.io/en/latest/topics/configuration.html](https://rasterio.readthedocs.io/en/latest/topics/configuration.html)

--- a/docs/src/datasets.md
+++ b/docs/src/datasets.md
@@ -14,7 +14,7 @@ ArchGDAL.read(filename) do dataset
 end
 ```
 
-We defer the discussion on `ArchGDAL.read(filename)` to the section on [Working with Files](@ref).
+We defer the discussion on [`ArchGDAL.read(filename)`](@ref) to the section on [Working with Files](@ref).
 
 ## Vector Datasets
 In this section, we work with the [`data/point.geojson`](https://github.com/yeesian/ArchGDALDatasets/blob/307f8f0e584a39a050c042849004e6a2bd674f99/data/point.geojson) dataset:
@@ -31,15 +31,15 @@ The display indicates
 
 You can also programmatically retrieve them using
 * `typeof(dataset)`: the **type** of the object (`GDAL Dataset`)
-* `ArchGDAL.filelist(dataset)`: the **files** that it corresponds to (`["data/point.geojson"]`)
-* `ArchGDAL.nlayer(dataset)`: the **number of layers** in the dataset (`1`)
-* `driver = ArchGDAL.getdriver(dataset)`: the **driver** used to open it
-* `ArchGDAL.shortname(driver)`: the **short name** of a driver (`"GeoJSON"`)
-* `ArchGDAL.longname(driver)`: the **long name** of a driver (`"GeoJSON"`)
-* `layer = ArchGDAL.getlayer(dataset, i)`: the `i`-th layer in the dataset.
-* `ArchGDAL.getgeomtype(layer)`: the **geometry type** for `layer` (i.e. `wkbPoint`)
-* `ArchGDAL.getname(layer)`: the **name** of `layer` (i.e. `point`)
-* `ArchGDAL.nfeature(layer)`: the **number of features** in the `layer` (i.e. `4`)
+* [`ArchGDAL.filelist(dataset)`](@ref): the **files** that it corresponds to (`["data/point.geojson"]`)
+* [`ArchGDAL.nlayer(dataset)`](@ref): the **number of layers** in the dataset (`1`)
+* `driver = `[`ArchGDAL.getdriver(dataset)`](@ref): the **driver** used to open it
+* [`ArchGDAL.shortname(driver)`](@ref): the **short name** of a driver (`"GeoJSON"`)
+* [`ArchGDAL.longname(driver)`](@ref): the **long name** of a driver (`"GeoJSON"`)
+* `layer = `[`ArchGDAL.getlayer(dataset, i)`](@ref): the `i`-th layer in the dataset.
+* [`ArchGDAL.getgeomtype(layer)`](@ref): the **geometry type** for `layer` (i.e. `wkbPoint`)
+* [`ArchGDAL.getname(layer)`](@ref): the **name** of `layer` (i.e. `point`)
+* [`ArchGDAL.nfeature(layer)`](@ref): the **number of features** in the `layer` (i.e. `4`)
 
 For more on working with features and vector data, see the Section on [Feature Data](@ref).
 
@@ -57,30 +57,30 @@ The display indicates
 
 You can also programmatically retrieve them using
 * `typeof(dataset)`: the **type** of the object (`GDAL Dataset`)
-* `ArchGDAL.filelist(dataset)`: the **files** that it corresponds to (`["gdalworkshop/world.tif"]`)
-* `ArchGDAL.nraster(dataset)`: the **number of rasters** (`3`)
-* `ArchGDAL.width(dataset)` the width (`2048` pixels)
-* `ArchGDAL.height(dataset)` the height (`1024` pixels)
-* `driver = ArchGDAL.getdriver(dataset)`: the **driver** used to open it
-* `ArchGDAL.shortname(driver)`: the **short name** of a driver (`"GTiff"`)
-* `ArchGDAL.longname(driver)`: the **long name** of a driver (`"GeoTIFF"`)
-* `band = ArchGDAL.getband(dataset, i)`: the `i`-th raster band
-* `i = ArchGDAL.indexof(band)`: the **index** of the raster band.
-* `ArchGDAL.accessflag(band)`: the **access flag** (i.e. `GA_ReadOnly`)
-* `ArchGDAL.getname(ArchGDAL.getcolorinterp(band))`: the **color channel** (e.g. `Red`)
-* `ArchGDAL.width(band)` the **width** of the raster band (`2048` pixels)
-* `ArchGDAL.height(band)` the **height** of the raster band (`1024` pixels)
-* `ArchGDAL.pixeltype(band)`: the **pixel type** of the raster band (i.e. `UInt8`)
+* [`ArchGDAL.filelist(dataset)`](@ref): the **files** that it corresponds to (`["gdalworkshop/world.tif"]`)
+* [`ArchGDAL.nraster(dataset)`](@ref): the **number of rasters** (`3`)
+* [`ArchGDAL.width(dataset)`](@ref): the width (`2048` pixels)
+* [`ArchGDAL.height(dataset)`](@ref): the height (`1024` pixels)
+* `driver = `[`ArchGDAL.getdriver(dataset)`](@ref): the **driver** used to open it
+* [`ArchGDAL.shortname(driver)`](@ref): the **short name** of a driver (`"GTiff"`)
+* [`ArchGDAL.longname(driver)`](@ref): the **long name** of a driver (`"GeoTIFF"`)
+* `band = `[`ArchGDAL.getband(dataset, i)`](@ref): the `i`-th raster band
+* `i = `[`ArchGDAL.indexof(band)`](@ref): the **index** of the raster band.
+* [`ArchGDAL.accessflag(band)`](@ref): the **access flag** (i.e. `GA_ReadOnly`)
+* [`ArchGDAL.getname(ArchGDAL.getcolorinterp(band))`](@ref): the **color channel** (e.g. `Red`)
+* [`ArchGDAL.width(band)`](@ref): the **width** of the raster band (`2048` pixels)
+* [`ArchGDAL.height(band)`](@ref): the **height** of the raster band (`1024` pixels)
+* [`ArchGDAL.pixeltype(band)`](@ref): the **pixel type** of the raster band (i.e. `UInt8`)
 
 For more on working with raster data, see the Section on [Raster Data](@ref).
 
 ## Working with Files
 We provide the following methods for working with files:
 
-* `ArchGDAL.copy()`: creates a copy of a dataset. This is often used with a virtual source dataset allowing configuration of band types, and other information without actually duplicating raster data.
-* `ArchGDAL.create()`: creates a new dataset.
-* `ArchGDAL.read()`: opens a dataset in read-only mode.
-* `ArchGDAL.update()`: opens a dataset with the possibility of updating it. If you open a dataset object with update access, it is not recommended to open a new dataset on the same underlying file.
+* [`ArchGDAL.copy`](@ref): creates a copy of a dataset. This is often used with a virtual source dataset allowing configuration of band types, and other information without actually duplicating raster data.
+* [`ArchGDAL.create`](@ref): creates a new dataset.
+* [`ArchGDAL.read`](@ref): opens a dataset in read-only mode.
+* `ArchGDAL.update`: opens a dataset with the possibility of updating it. If you open a dataset object with update access, it is not recommended to open a new dataset on the same underlying file.
 
 In GDAL, datasets are closed by calling `GDAL.close()`. This will result in proper cleanup, and flushing of any pending writes. Forgetting to call `GDAL.close()` on a dataset opened in update mode in a popular format like `GTiff` will likely result in being unable to open it afterwards.
 

--- a/docs/src/datasets.md
+++ b/docs/src/datasets.md
@@ -1,5 +1,9 @@
 # Data Model
 
+```@setup datasets
+using ArchGDAL
+```
+
 ## GDAL Datasets
 
 The following code demonstrates the general workflow for reading in a dataset:
@@ -14,14 +18,9 @@ We defer the discussion on `ArchGDAL.read(filename)` to the section on [Working 
 
 ## Vector Datasets
 In this section, we work with the [`data/point.geojson`](https://github.com/yeesian/ArchGDALDatasets/blob/307f8f0e584a39a050c042849004e6a2bd674f99/data/point.geojson) dataset:
-```julia
-julia> dataset = ArchGDAL.read("data/point.geojson")
-GDAL Dataset (Driver: GeoJSON/GeoJSON)
-File(s):
-  data/point.geojson
 
-Number of feature layers: 1
-  Layer 0: point (wkbPoint)
+```@example datasets
+dataset = ArchGDAL.read("data/point.geojson")
 ```
 
 The display indicates
@@ -46,17 +45,8 @@ For more on working with features and vector data, see the Section on [Feature D
 
 ## Raster Datasets
 In this section, we work with the [`gdalworkshop/world.tif`](https://github.com/yeesian/ArchGDALDatasets/blob/307f8f0e584a39a050c042849004e6a2bd674f99/gdalworkshop/world.tif) dataset:
-```julia
-julia> dataset = AG.read("gdalworkshop/world.tif")
-GDAL Dataset (Driver: GTiff/GeoTIFF)
-File(s):
-  gdalworkshop/world.tif
-
-Dataset (width x height): 2048 x 1024 (pixels)
-Number of raster bands: 3
-  [GA_ReadOnly] Band 1 (Red): 2048 x 1024 (UInt8)
-  [GA_ReadOnly] Band 2 (Green): 2048 x 1024 (UInt8)
-  [GA_ReadOnly] Band 3 (Blue): 2048 x 1024 (UInt8)
+```@example datasets
+dataset = ArchGDAL.read("gdalworkshop/world.tif")
 ```
 
 The display indicates

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -12,6 +12,7 @@ dataset = ArchGDAL.read("data/point.geojson")
 
 ## Feature Layers
 
+Retrieve a layer from a dataset using [`ArchGDAL.getlayer`](@ref)
 ```@example features
 layer = ArchGDAL.getlayer(dataset, 0)
 ```
@@ -22,23 +23,23 @@ The display provides
 * the **fields** in the dataset, and their brief summary.
 
 You can also programmatically retrieve them using
-* `ArchGDAL.getname(layer)`: the **name** of the feature layer
-* `ArchGDAL.nfeature(layer)`: the **number of features** in the layer
-* `featuredefn = ArchGDAL.layerdefn(layer)`: the **schema** of the layer features
-* `ArchGDAL.nfield(featuredefn)`: the **number of fields**
-* `ArchGDAL.ngeom(featuredefn)`: the **number of geometries**
-* `ArchGDAL.getfielddefn(featuredefn, i)`: the definition for the `i`-th field
-* `ArchGDAL.getgeomdefn(featuredefn, i)`: the definition for the `i`-th geometry
+* [`ArchGDAL.getname(layer)`](@ref): the **name** of the feature layer
+* [`ArchGDAL.nfeature(layer)`](@ref): the **number of features** in the layer
+* `featuredefn = `[`ArchGDAL.layerdefn(layer)`](@ref): the **schema** of the layer features
+* [`ArchGDAL.nfield(featuredefn)`](@ref): the **number of fields**
+* [`ArchGDAL.ngeom(featuredefn)`](@ref): the **number of geometries**
+* [`ArchGDAL.getfielddefn(featuredefn, i)`](@ref): the definition for the `i`-th field
+* [`ArchGDAL.getgeomdefn(featuredefn, i)`](@ref): the definition for the `i`-th geometry
 
 ### Field Definitions
 
 Each `fielddefn` defines an attribute of a feature, and supports the following:
-* `ArchGDAL.getname(fielddefn)`: the name of the field (`"FID"` or `"pointname"`)
-* `ArchGDAL.gettype(fielddefn)`: the type of the field (`OFTReal` or `OFTString`)
+* [`ArchGDAL.getname(fielddefn)`](@ref): the name of the field (`"FID"` or `"pointname"`)
+* [`ArchGDAL.gettype(fielddefn)`](@ref): the type of the field (`OFTReal` or `OFTString`)
 
 Each `geomdefn` defines an attribute of a geometry, and supports the following:
-* `ArchGDAL.getname(geomdefn)`: the name of the geometry (`""` in this case)
-* `ArchGDAL.gettype(geomdefn)`: the type of the geometry (`wkbPoint`)
+* [`ArchGDAL.getname(geomdefn)`](@ref): the name of the geometry (`""` in this case)
+* [`ArchGDAL.gettype(geomdefn)`](@ref): the type of the geometry (`wkbPoint`)
 
 ## Individual Features
 We can examine an individual feature
@@ -49,9 +50,9 @@ end
 ```
 
 You can programmatically retrieve the information using
-* `ArchGDAL.nfield(feature)`: the **number of fields** (`2`)
-* `ArchGDAL.ngeom(feature)`: the **number of geometries** (`1`)
+* [`ArchGDAL.nfield(feature)`](@ref): the **number of fields** (`2`)
+* [`ArchGDAL.ngeom(feature)`](@ref): the **number of geometries** (`1`)
 * `ArchGDAL.getfield(feature, i)`: the `i`-th field (`0.0` and `"a"`)
-* `ArchGDAL.getgeom(feature, i)`: the `i`-th geometry (the WKT display `POINT`)
+* [`ArchGDAL.getgeom(feature, i)`](@ref): the `i`-th geometry (the WKT display `POINT`)
 
 More information on geometries can be found in [Geometric Operations](@ref).

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -1,25 +1,19 @@
 # Feature Data
 
+```@setup features
+using ArchGDAL
+```
+
 In this section, we revisit the [`data/point.geojson`](https://github.com/yeesian/ArchGDALDatasets/blob/307f8f0e584a39a050c042849004e6a2bd674f99/data/point.geojson) dataset.
 
-```julia
-julia> dataset = AG.read("data/point.geojson")
-GDAL Dataset (Driver: GeoJSON/GeoJSON)
-File(s):
-  data/point.geojson
-
-Number of feature layers: 1
-  Layer 0: point (wkbPoint)
+```@example features
+dataset = ArchGDAL.read("data/point.geojson")
 ```
 
 ## Feature Layers
 
-```julia
-julia> layer = ArchGDAL.getlayer(dataset, 0)
-Layer: point
-  Geometry 0 (): [wkbPoint], POINT (100 0), POINT (100.2785 0.0893), ...
-     Field 0 (FID): [OFTReal], 2.0, 3.0, 0.0, 3.0
-     Field 1 (pointname): [OFTString], point-a, point-b, a, b
+```@example features
+layer = ArchGDAL.getlayer(dataset, 0)
 ```
 
 The display provides
@@ -48,14 +42,10 @@ Each `geomdefn` defines an attribute of a geometry, and supports the following:
 
 ## Individual Features
 We can examine an individual feature
-```julia
-julia> ArchGDAL.getfeature(layer, 2) do feature
-           print(feature)
-       end
-Feature
-  (index 0) geom => POINT
-  (index 0) FID => 0.0
-  (index 1) pointname => a
+```@example features
+ArchGDAL.getfeature(layer, 2) do feature
+    print(feature)
+end
 ```
 
 You can programmatically retrieve the information using

--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -8,7 +8,7 @@ const AG = ArchGDAL
 In this section, we consider some of the common kinds of geometries that arises in applications. These include `Point`, `LineString`, `Polygon`, `GeometryCollection`, `MultiPolygon`, `MultiPoint`, and `MultiLineString`. For brevity in the examples, we will use the prefix `const AG = ArchGDAL`.
 
 ## Geometry Creation
-To create geometries of different types.
+To create geometries of different types, 
 
 ```@example geometries
 point = AG.createpoint(1.0, 2.0)
@@ -62,93 +62,93 @@ end
 ```
 
 They can also be constructed from other data formats such as:
-* Well-Known Binary (WKB): `AG.fromWKB([0x01,0x01,...,0x27,0x41])`
-* Well-Known Text (WKT): `AG.fromWKT("POINT (1 2)")`
-* JavaScript Object Notation (JSON): `AG.fromJSON("""{"type":"Point","coordinates":[1,2]}""")`
+* Well-Known Binary (WKB): [`ArchGDAL.fromWKB`](@ref)`([0x01,0x01,...,0x27,0x41])`
+* Well-Known Text (WKT): [`ArchGDAL.fromWKT("POINT (1 2)")`](@ref)
+* JavaScript Object Notation (JSON): [`ArchGDAL.fromJSON("""{"type":"Point","coordinates":[1,2]}""")`](@ref)
 
 ## Geometry Modification
 The following methods are commonly used for retrieving elements of a geometry.
 
-* `AG.getcoorddim(geom)`: dimension of the coordinates. Returns `0` for an empty point
-* `AG.getspatialref(geom)`
-* `AG.getx(geom, i)`
-* `AG.gety(geom, i)`
-* `AG.getz(geom, i)`
-* `AG.getpoint(geom, i)`
-* `AG.getgeom(geom, i)`
+* [`ArchGDAL.getcoorddim(geom)`](@ref): dimension of the coordinates. Returns `0` for an empty point
+* [`ArchGDAL.getspatialref(geom)`](@ref)
+* [`ArchGDAL.getx(geom, i)`](@ref)
+* [`ArchGDAL.gety(geom, i)`](@ref)
+* [`ArchGDAL.getz(geom, i)`](@ref)
+* [`ArchGDAL.getpoint(geom, i)`](@ref)
+* [`ArchGDAL.getgeom(geom, i)`](@ref)
 
 The following methods are commonly used for modifying or adding to a geometry.
-* `AG.setcoorddim!(geom, dim)`
-* `AG.setpointcount!(geom, n)`
-* `AG.setpoint!(geom, i, x, y)`
-* `AG.setpoint!(geom, i, x, y, z)`
-* `AG.addpoint!(geom, x, y)`
-* `AG.addpoint!(geom, x, y, z)`
-* `AG.addgeom!(geom1, geom2)`
-* `AG.removegeom!(geom, i)`
-* `AG.removeallgeoms!(geom)`
+* [`ArchGDAL.setcoorddim!(geom, dim)`](@ref)
+* [`ArchGDAL.setpointcount!(geom, n)`](@ref)
+* [`ArchGDAL.setpoint!(geom, i, x, y)`](@ref)
+* [`ArchGDAL.setpoint!(geom, i, x, y, z)`](@ref)
+* [`ArchGDAL.addpoint!(geom, x, y)`](@ref)
+* [`ArchGDAL.addpoint!(geom, x, y, z)`](@ref)
+* [`ArchGDAL.addgeom!(geom1, geom2)`](@ref)
+* [`ArchGDAL.removegeom!(geom, i)`](@ref)
+* [`ArchGDAL.removeallgeoms!(geom)`](@ref)
 
 ## Unary Operations
 The following is an non-exhaustive list of unary operations available for geometries.
 
 ### Attributes
 
-* `AG.geomdim(geom)`: `0` for points, `1` for lines and `2` for surfaces
-* `AG.getcoorddim(geom)`: dimension of the coordinates. Returns `0` for an empty point
-* `AG.envelope(geom)`: the bounding envelope for this geometry
-* `AG.envelope3d(geom)`: the bounding envelope for this geometry
-* `AG.wkbsize(geom)`: size (in bytes) of related binary representation
-* `AG.getgeomtype(geom)`: geometry type code (in `OGRwkbGeometryType`)
-* `AG.geomname(geom)`: WKT name for geometry type
-* `AG.getspatialref(geom)`: spatial reference system. May be `NULL`
-* `AG.geomlength(geom)`: the length of the geometry, or `0.0` for unsupported types
-* `AG.geomarea(geom)`: the area of the geometry, or `0.0` for unsupported types
+* [`ArchGDAL.geomdim(geom)`](@ref): `0` for points, `1` for lines and `2` for surfaces
+* [`ArchGDAL.getcoorddim(geom)`](@ref): dimension of the coordinates. Returns `0` for an empty point
+* [`ArchGDAL.envelope(geom)`](@ref): the bounding envelope for this geometry
+* [`ArchGDAL.envelope3d(geom)`](@ref): the bounding envelope for this geometry
+* [`ArchGDAL.wkbsize(geom)`](@ref): size (in bytes) of related binary representation
+* [`ArchGDAL.getgeomtype(geom)`](@ref): geometry type code (in `OGRwkbGeometryType`)
+* [`ArchGDAL.geomname(geom)`](@ref): WKT name for geometry type
+* [`ArchGDAL.getspatialref(geom)`](@ref): spatial reference system. May be `NULL`
+* [`ArchGDAL.geomlength(geom)`](@ref): the length of the geometry, or `0.0` for unsupported types
+* [`ArchGDAL.geomarea(geom)`](@ref): the area of the geometry, or `0.0` for unsupported types
 
 ### Predicates
 The following predicates return a `Bool`.
 
-* `AG.isempty(geom)`
-* `AG.isvalid(geom)`
-* `AG.issimple(geom)`
-* `AG.isring(geom)`
-* `AG.hascurvegeom(geom, nonlinear::Bool)`
+* [`ArchGDAL.isempty(geom)`](@ref)
+* [`ArchGDAL.isvalid(geom)`](@ref)
+* [`ArchGDAL.issimple(geom)`](@ref)
+* [`ArchGDAL.isring(geom)`](@ref)
+* [`ArchGDAL.hascurvegeom(geom, nonlinear::Bool)`](@ref)
 
 ### Immutable Operations
 The following methods do not modify `geom`.
 
-* `AG.clone(geom)`: a copy of the geometry with the original spatial reference system.
-* `AG.forceto(geom, targettype)`: force the provided geometry to the specified geometry type.
-* `AG.simplify(geom, tol)`: Compute a simplified geometry.
-* `AG.simplifypreservetopology(geom, tol)`: Simplify the geometry while preserving topology.
-* `AG.delaunaytriangulation(geom, tol, onlyedges)`: a delaunay triangulation of the vertices of the geometry.
-* `AG.boundary(geom)`: the boundary of the geometry
-* `AG.convexhull(geom)`: the convex hull of the geometry.
-* `AG.buffer(geom, dist, quadsegs)`: a polygon containing the region within the buffer distance of the original geometry.
-* `AG.union(geom)`: the union of the geometry using cascading
-* `AG.pointonsurface(geom)`: Returns a point guaranteed to lie on the surface.
-* `AG.centroid(geom)`: Compute the geometry centroid. It is not necessarily within the geometry.
-* `AG.pointalongline(geom, distance)`: Fetch point at given distance along curve.
-* `AG.polygonize(geom)`: Polygonizes a set of sparse edges.
+* [`ArchGDAL.clone(geom)`](@ref): a copy of the geometry with the original spatial reference system.
+* [`ArchGDAL.forceto(geom, targettype)`](@ref): force the provided geometry to the specified geometry type.
+* [`ArchGDAL.simplify(geom, tol)`](@ref): Compute a simplified geometry.
+* [`ArchGDAL.simplifypreservetopology(geom, tol)`](@ref): Simplify the geometry while preserving topology.
+* [`ArchGDAL.delaunaytriangulation(geom, tol, onlyedges)`](@ref): a delaunay triangulation of the vertices of the geometry.
+* [`ArchGDAL.boundary(geom)`](@ref): the boundary of the geometry
+* [`ArchGDAL.convexhull(geom)`](@ref): the convex hull of the geometry.
+* [`ArchGDAL.buffer(geom, dist, quadsegs)`](@ref): a polygon containing the region within the buffer distance of the original geometry.
+* [`ArchGDAL.union(geom)`](@ref): the union of the geometry using cascading
+* [`ArchGDAL.pointonsurface(geom)`](@ref): Returns a point guaranteed to lie on the surface.
+* [`ArchGDAL.centroid(geom)`](@ref): Compute the geometry centroid. It is not necessarily within the geometry.
+* [`ArchGDAL.pointalongline(geom, distance)`](@ref): Fetch point at given distance along curve.
+* [`ArchGDAL.polygonize(geom)`](@ref): Polygonizes a set of sparse edges.
 
 ### Mutable Operations
 The following methods modifies the first argument `geom`.
 
-* `AG.setcoorddim!(geom, dim)`: sets the explicit coordinate dimension.
-* `AG.flattento2d!(geom)`: Convert geometry to strictly 2D.
-* `AG.closerings!(geom)`: Force rings to be closed by adding the start point to the end.
-* `AG.transform!(geom, coordtransform)`: Apply coordinate transformation to geometry.
-* `AG.segmentize!(geom, maxlength)`: Modify the geometry such it has no segment longer than the given distance.
-* `AG.empty!(geom)`: Clear geometry information.
+* [`ArchGDAL.setcoorddim!(geom, dim)`](@ref): sets the explicit coordinate dimension.
+* [`ArchGDAL.flattento2d!(geom)`](@ref): Convert geometry to strictly 2D.
+* [`ArchGDAL.closerings!(geom)`](@ref): Force rings to be closed by adding the start point to the end.
+* [`ArchGDAL.transform!(geom, coordtransform)`](@ref): Apply coordinate transformation to geometry.
+* [`ArchGDAL.segmentize!(geom, maxlength)`](@ref): Modify the geometry such it has no segment longer than the given distance.
+* [`ArchGDAL.empty!(geom)`](@ref): Clear geometry information.
 
 ### Export Formats
 
-* `AG.toWKB(geom)`
-* `AG.toISOWKB(geom)`
-* `AG.toWKT(geom)`
-* `AG.toISOWKT(geom)`
-* `AG.toGML(geom)`
-* `AG.toKML(geom)`
-* `AG.toJSON(geom)`
+* [`ArchGDAL.toWKB(geom)`](@ref)
+* [`ArchGDAL.toISOWKB(geom)`](@ref)
+* [`ArchGDAL.toWKT(geom)`](@ref)
+* [`ArchGDAL.toISOWKT(geom)`](@ref)
+* [`ArchGDAL.toGML(geom)`](@ref)
+* [`ArchGDAL.toKML(geom)`](@ref)
+* [`ArchGDAL.toJSON(geom)`](@ref)
 
 ## Binary Operations
 The following is an non-exhaustive list of binary operations available for geometries.
@@ -156,25 +156,25 @@ The following is an non-exhaustive list of binary operations available for geome
 ### Predicates
 The following predicates return a `Bool`.
 
-* `AG.intersects(g1, g2)`
-* `AG.equals(g1, g2)`
-* `AG.disjoint(g1, g2)`
-* `AG.touches(g1, g2)`
-* `AG.crosses(g1, g2)`
-* `AG.within(g1, g2)`
-* `AG.contains(g1, g2)`
-* `AG.overlaps(g1, g2)`
+* [`ArchGDAL.intersects(g1, g2)`](@ref)
+* [`ArchGDAL.equals(g1, g2)`](@ref)
+* [`ArchGDAL.disjoint(g1, g2)`](@ref)
+* [`ArchGDAL.touches(g1, g2)`](@ref)
+* [`ArchGDAL.crosses(g1, g2)`](@ref)
+* [`ArchGDAL.within(g1, g2)`](@ref)
+* [`ArchGDAL.contains(g1, g2)`](@ref)
+* [`ArchGDAL.overlaps(g1, g2)`](@ref)
 
 ### Immutable Operations
 The following methods do not mutate the input geomteries `g1` and `g2`.
 
-* `AG.intersection(g1, g2)`
-* `AG.union(g1, g2)`
-* `AG.difference(g1, g2)`
-* `AG.symdifference(g1, g2)`
+* [`ArchGDAL.intersection(g1, g2)`](@ref)
+* [`ArchGDAL.union(g1, g2)`](@ref)
+* [`ArchGDAL.difference(g1, g2)`](@ref)
+* [`ArchGDAL.symdifference(g1, g2)`](@ref)
 
 ### Mutable Operations
 The following method modifies the first argument `g1`.
 
-* `AG.addgeom!(g1, g2)`
+* [`ArchGDAL.addgeom!(g1, g2)`](@ref)
 

--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -1,11 +1,16 @@
 # Geometric Operations
 
+```@setup geometries
+using ArchGDAL
+const AG = ArchGDAL
+```
+
 In this section, we consider some of the common kinds of geometries that arises in applications. These include `Point`, `LineString`, `Polygon`, `GeometryCollection`, `MultiPolygon`, `MultiPoint`, and `MultiLineString`. For brevity in the examples, we will use the prefix `const AG = ArchGDAL`.
 
 ## Geometry Creation
 To create geometries of different types.
 
-```julia
+```@example geometries
 point = AG.createpoint(1.0, 2.0)
 linestring = AG.createlinestring([(i,i+1) for i in 1.0:3.0])
 linearring = AG.createlinearring([(0.,0.), (0.,1.), (1.,1.)])
@@ -17,37 +22,43 @@ multipolygon = AG.createmultipolygon([[[(0.,0.), (0.,j), (j,j)]] for j in 1.0:-0
 ```
 
 Alternatively, they can be assembled from their components.
-```julia
+```@example geometries
 point = AG.createpoint()
-    AG.addpoint!(point, 1.0, 2.0)
+AG.addpoint!(point, 1.0, 2.0)
+
 linestring = AG.createlinestring()
-    for i in 1.0:3.0
-        AG.addpoint!(linestring, i, i+1)
-    end
+for i in 1.0:3.0
+    AG.addpoint!(linestring, i, i+1)
+end
+
 linearring = AG.createlinearring()
-    for i in 1.0:3.0
-        AG.addpoint!(linearring, i, i+1)
-    end
+for i in 1.0:3.0
+    AG.addpoint!(linearring, i, i+1)
+end
+
 polygon = AG.createpolygon()
-    for j in 1.0:-0.1:0.9
-        ring = AG.createlinearring([(0.,0.), (0.,j), (j,j)])
-        AG.addgeom!(polygon, ring)
-    end
+for j in 1.0:-0.1:0.9
+    ring = AG.createlinearring([(0.,0.), (0.,j), (j,j)])
+    AG.addgeom!(polygon, ring)
+end
+
 multipoint = AG.createmultipoint()
-    for i in 1.0:3.0
-        pt = AG.createpoint(i, i+1)
-        AG.addgeom!(multipoint, pt)
-    end
+for i in 1.0:3.0
+    pt = AG.createpoint(i, i+1)
+    AG.addgeom!(multipoint, pt)
+end
+
 multilinestring = AG.createmultilinestring()
-    for j in 1.0:5.0:6.0
-        line = AG.createlinestring([(i,i+1) for i in j:j+3])
-        AG.addgeom!(multilinestring, line)
-    end
+for j in 1.0:5.0:6.0
+    line = AG.createlinestring([(i,i+1) for i in j:j+3])
+    AG.addgeom!(multilinestring, line)
+end
+
 multipolygon = AG.createmultipolygon()
-    for j in 1.0:-0.1:0.9
-        poly = AG.createpolygon([(0.,0.), (0.,j), (j,j)])
-        AG.addgeom!(multipolygon, poly)
-    end
+for j in 1.0:-0.1:0.9
+    poly = AG.createpolygon([(0.,0.), (0.,j), (j,j)])
+    AG.addgeom!(multipolygon, poly)
+end
 ```
 
 They can also be constructed from other data formats such as:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,3 +25,20 @@ To test if it is installed correctly,
 ```julia
 pkg> test ArchGDAL
 ```
+
+To load the package,
+
+```julia
+julia> using ArchGDAL
+```
+
+In the documentation `AG` is often used as a shorthand for `ArchGDAL`. To use this shorthand you can use:
+```julia
+using ArchGDAL
+const AG = ArchGDAL
+```
+
+## Contents
+
+```@contents
+```

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -115,15 +115,15 @@ result = ArchGDAL.<method>(args...)
 
 !!! note
 
-    Users are allowed to mix both "interactive" and "scoped" objects. As long as they do not manually call `ArchGDAL.destroy()` on any object, ArchGDAL is designed to avoid the pitfalls of GDAL memory management (e.g. in [PythonGotchas](https://trac.osgeo.org/gdal/wiki/PythonGotchas)).
+    Users are allowed to mix both "interactive" and "scoped" objects. As long as they do not manually call `ArchGDAL.destroy()` on any object, ArchGDAL is designed to avoid the pitfalls of GDAL memory management (e.g. in [Python Gotchas](https://gdal.org/api/python_gotchas.html)).
 
 ## References
 Here's a collection of references for developers who are interested.
 
-- http://docs.julialang.org/en/release-0.4/manual/calling-c-and-fortran-code/
-- https://github.com/JuliaLang/julia/issues/7721
-- https://github.com/JuliaLang/julia/issues/11207
-- https://trac.osgeo.org/gdal/wiki/PythonGotchas
-- https://lists.osgeo.org/pipermail/gdal-dev/2010-September/026027.html
-- https://sgillies.net/2013/12/17/teaching-python-gis-users-to-be-more-rational.html
-- https://pcjericks.github.io/py-gdalogr-cookbook/gotchas.html#features-and-geometries-have-a-relationship-you-don-t-want-to-break
+- [https://docs.julialang.org/en/v1.3/manual/calling-c-and-fortran-code/](https://docs.julialang.org/en/v1.3/manual/calling-c-and-fortran-code/)
+- [https://github.com/JuliaLang/julia/issues/7721](https://github.com/JuliaLang/julia/issues/7721)
+- [https://github.com/JuliaLang/julia/issues/11207](https://github.com/JuliaLang/julia/issues/11207)
+- [https://gdal.org/api/python_gotchas.html](https://gdal.org/api/python_gotchas.html)
+- [https://lists.osgeo.org/pipermail/gdal-dev/2010-September/026027.html](https://lists.osgeo.org/pipermail/gdal-dev/2010-September/026027.html)
+- [https://sgillies.net/2013/12/17/teaching-python-gis-users-to-be-more-rational.html](https://sgillies.net/2013/12/17/teaching-python-gis-users-to-be-more-rational.html)
+- [https://pcjericks.github.io/py-gdalogr-cookbook/gotchas.html#features-and-geometries-have-a-relationship-you-don-t-want-to-break](https://pcjericks.github.io/py-gdalogr-cookbook/gotchas.html#features-and-geometries-have-a-relationship-you-don-t-want-to-break)

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -1,4 +1,10 @@
 # Spatial Projections
+
+```@setup projections
+using ArchGDAL
+const AG = ArchGDAL
+```
+
 (This is based entirely on the [GDAL/OSR Tutorial](http://www.gdal.org/osr_tutorial.html) and [Python GDAL/OGR Cookbook](https://pcjericks.github.io/py-gdalogr-cookbook/projection.html).)
 
 The `ArchGDAL.SpatialRef`, and `ArchGDAL.CoordTransform` types are lightweight wrappers around GDAL objects that represent coordinate systems (projections and datums) and provide services to transform between them. These services are loosely modeled on the OpenGIS Coordinate Transformations specification, and use the same Well Known Text format for describing coordinate systems.
@@ -11,12 +17,12 @@ There are two primary kinds of coordinate systems. The first is geographic (posi
 * **Projected Coordinate Systems**: A projected coordinate system (such as UTM, Lambert Conformal Conic, etc) requires and underlying geographic coordinate system as well as a definition for the projection transform used to translate between linear positions (in meters or feet) and angular long/lat positions.
 
 ## Creating Spatial References
-```julia
-julia> spatialref = ArchGDAL.importEPSG(2927)
-Spatial Reference System: +proj=lcc +lat_1=47.33333333333334  ... defs
+```@example projections
+spatialref = ArchGDAL.importEPSG(2927)
+```
 
-julia> print(ArchGDAL.toPROJ4(spatialref))
-+proj=lcc +lat_1=47.33333333333334 +lat_2=45.83333333333334 +lat_0=45.33333333333334 +lon_0=-120.5 +x_0=500000.0001016001 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs
+```@example projections
+ArchGDAL.toPROJ4(spatialref)
 ```
 
 The details of how to interpret the results can be found in http://proj4.org/usage/projections.html.
@@ -39,23 +45,23 @@ We currently support a few export formats too:
 * `ArchGDAL.toXML(spref)`: converts into XML format to the extent possible.
 
 ## Reprojecting a Geometry
-```julia
-julia> source = ArchGDAL.importEPSG(2927)
-Spatial Reference System: +proj=lcc +lat_1=47.33333333333334  ... defs
+```@example projections
+source = ArchGDAL.importEPSG(2927)
+```
 
-julia> target = ArchGDAL.importEPSG(4326)
-Spatial Reference System: +proj=longlat +datum=WGS84 +no_defs
+```@example projections
+target = ArchGDAL.importEPSG(4326)
+```
 
-julia> ArchGDAL.createcoordtrans(source, target) do transform
-           point = ArchGDAL.fromWKT("POINT (1120351.57 741921.42)")
-           println("Before: $(ArchGDAL.toWKT(point))")
-           ArchGDAL.transform!(point, transform)
-           println("After: $(ArchGDAL.toWKT(point))")
-       end
-Before: POINT (1120351.57 741921.42)
-After: POINT (-122.598135130878 47.3488013802885)
+```@example projections
+ArchGDAL.createcoordtrans(source, target) do transform
+    point = ArchGDAL.fromWKT("POINT (1120351.57 741921.42)")
+    println("Before: $(ArchGDAL.toWKT(point))")
+    ArchGDAL.transform!(point, transform)
+    println("After: $(ArchGDAL.toWKT(point))")
+end
 ```
 
 ## References
 
-Some background on OpenGIS coordinate systems and services can be found in the Simple Features for COM, and Spatial Reference Systems Abstract Model documents available from the [Open Geospatial Consortium](http://www.opengeospatial.org/). The [GeoTIFF Projections Transform List](http://geotiff.maptools.org/proj_list/) may also be of assistance in understanding formulations of projections in WKT. The [EPSG](http://www.epsg.org/) Geodesy web page is also a useful resource. You may also consult the [OGC WKT Coordinate System Issues](http://www.gdal.org/wktproblems.html) page.
+Some background on OpenGIS coordinate systems and services can be found in the Simple Features for COM, and Spatial Reference Systems Abstract Model documents available from the [Open Geospatial Consortium](https://www.opengeospatial.org/). The [GeoTIFF Projections Transform List](http://geotiff.maptools.org/proj_list/) may also be of assistance in understanding formulations of projections in WKT. The [EPSG](http://www.epsg.org/) Geodesy web page is also a useful resource. You may also consult the [OGC WKT Coordinate System Issues](https://gdal.org/tutorials/wktproblems.html) page.

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -29,20 +29,20 @@ The details of how to interpret the results can be found in http://proj4.org/usa
 
 In the above example, we constructed a `SpatialRef` object from the [EPSG Code 2927](http://spatialreference.org/ref/epsg/2927/). There are a variety of other formats from which `SpatialRef`s can be constructed, such as
 
-* `ArchGDAL.importEPSG(::Int)`: based on the [EPSG code](http://spatialreference.org/ref/epsg/)
-* `ArchGDAL.importEPSGA(::Int)`: based on the EPSGA code
-* `ArchGDAL.importESRI(::String)`: based on ESRI projection codes
-* `ArchGDAL.importPROJ4(::String)` based on the PROJ.4 string ([reference](http://proj4.org/usage/projections.html))
-* `ArchGDAL.importURL(::String)`: download from a given URL and feed it into `SetFromUserInput` for you.
-* `ArchGDAL.importWKT(::String)`: WKT string
-* `ArchGDAL.importXML(::String)`: XML format (GML only currently)
+* [`ArchGDAL.importEPSG(::Int)`](@ref): based on the [EPSG code](http://spatialreference.org/ref/epsg/)
+* [`ArchGDAL.importEPSGA(::Int)`](@ref): based on the EPSGA code
+* [`ArchGDAL.importESRI(::String)`](@ref): based on ESRI projection codes
+* [`ArchGDAL.importPROJ4(::String)` based on the PROJ.4 string ([reference](http://proj4.org/usage/projections.html))
+* [`ArchGDAL.importURL(::String)`](@ref): download from a given URL and feed it into `SetFromUserInput` for you.
+* [`ArchGDAL.importWKT(::String)`](@ref): WKT string
+* [`ArchGDAL.importXML(::String)`](@ref): XML format (GML only currently)
 
 We currently support a few export formats too:
 
-* `ArchGDAL.toMICoordSys(spref)`: Mapinfo style CoordSys format.
-* `ArchGDAL.toPROJ4(spref)`: coordinate system in PROJ.4 format.
-* `ArchGDAL.toWKT(spref)`: nicely formatted WKT string for display to a person.
-* `ArchGDAL.toXML(spref)`: converts into XML format to the extent possible.
+* [`ArchGDAL.toMICoordSys(spref)`](@ref): Mapinfo style CoordSys format.
+* [`ArchGDAL.toPROJ4(spref)`](@ref): coordinate system in PROJ.4 format.
+* [`ArchGDAL.toWKT(spref)`](@ref): nicely formatted WKT string for display to a person.
+* [`ArchGDAL.toXML(spref)`](@ref): converts into XML format to the extent possible.
 
 ## Reprojecting a Geometry
 ```@example projections

--- a/docs/src/rasters.md
+++ b/docs/src/rasters.md
@@ -18,28 +18,28 @@ band = ArchGDAL.getband(dataset, 1)
 ```
 
 You can programmatically retrieve the information in the header using
-* `ArchGDAL.accessflag(band)`: the access flag for this band. (`GA_ReadOnly`)
-* `colorinterp = ArchGDAL.getcolorinterp(band)`: color interpretation of the values in the band (`GCI_RedBand`)
-* `ArchGDAL.getname(colorinterp)`: name (string) corresponding to color interpretation (`"Red"`)
-* `ArchGDAL.width(band)`: width (pixels) of the band (`2048`)
-* `ArchGDAL.height(band)`: height (pixels) of the band (`1024`)
-* `ArchGDAL.indexof(band)`: the index of the band (1+) within its dataset, or 0 if unknown. (`1`)
-* `ArchGDAL.pixeltype(band)`: pixel data type for this band. (`UInt8`)
+* [`ArchGDAL.accessflag(band)`](@ref): the access flag for this band. (`GA_ReadOnly`)
+* `colorinterp = `[`ArchGDAL.getcolorinterp(band)`](@ref): color interpretation of the values in the band (`GCI_RedBand`)
+* [`ArchGDAL.getname(colorinterp)`](@ref): name (string) corresponding to color interpretation (`"Red"`)
+* [`ArchGDAL.width(band)`](@ref): width (pixels) of the band (`2048`)
+* [`ArchGDAL.height(band)`](@ref): height (pixels) of the band (`1024`)
+* [`ArchGDAL.indexof(band)`](@ref): the index of the band (1+) within its dataset, or 0 if unknown. (`1`)
+* [`ArchGDAL.pixeltype(band)`](@ref): pixel data type for this band. (`UInt8`)
 
 You can get additional attribute information using
-* `ArchGDAL.getscale(band)`: the scale in `units = (px * scale) + offset` (`1.0`)
-* `ArchGDAL.getoffset(band)`: the offset in `units = (px * scale) + offset` (`0.0`)
-* `ArchGDAL.getunittype(band)`: name for the units, e.g. "m" (meters) or "ft" (feet). (`""`)
-* `ArchGDAL.getnodatavalue(band)`: a special marker value used to mark pixels that are not valid data. (`-1.0e10`)
-* `(x,y) = ArchGDAL.blocksize(band)`: the "natural" block size of this band (`(256,256)`)
+* [`ArchGDAL.getscale(band)`](@ref): the scale in `units = (px * scale) + offset` (`1.0`)
+* [`ArchGDAL.getoffset(band)`](@ref): the offset in `units = (px * scale) + offset` (`0.0`)
+* [`ArchGDAL.getunittype(band)`](@ref): name for the units, e.g. "m" (meters) or "ft" (feet). (`""`)
+* [`ArchGDAL.getnodatavalue(band)`](@ref): a special marker value used to mark pixels that are not valid data. (`-1.0e10`)
+* `(x,y) = `[`ArchGDAL.blocksize(band)`](@ref): the "natural" block size of this band (`(256,256)`)
 
 !!! note
 
     GDAL contains a concept of the natural block size of rasters so that applications can organized data access efficiently for some file formats. The natural block size is the block size that is most efficient for accessing the format. For many formats this is simple a whole scanline. However, for tiled images this will typically be the tile size.
 
 Finally, you can obtain overviews:
-* `ArchGDAL.noverview(band)`: the number of overview layers available, zero if none. (`7`)
-* `ArchGDAL.getoverview(band, i)`: returns the `i`-th overview in the raster band. Each overview is itself a raster band, e.g.
+* [`ArchGDAL.noverview(band)`](@ref): the number of overview layers available, zero if none. (`7`)
+* [`ArchGDAL.getoverview(band, i)`](@ref): returns the `i`-th overview in the raster band. Each overview is itself a raster band, e.g.
 
 ```@example rasters
 ArchGDAL.getoverview(band, 2)
@@ -61,7 +61,7 @@ The general operative method for reading in raster values from a `dataset` or `b
     
     To convert to a format used by the Images.jl ecosystem, you can either create a view using `PermutedDimsArray(A, (3,2,1))` or create a permuted copy using `permutedims(A, (3,2,1))`. The resulting arrays will have `(bands, rows, cols)` dimensions.
 
-You can also specify the subset of rows and columns (provided as `UnitRange`s) to read:
+You can also specify the subset of rows and columns (provided as `UnitRange`s like `2:9`) to read:
 
 * `ArchGDAL.read(dataset, indices, rows, cols)`
 * `ArchGDAL.read(dataset, i, rows, cols)`

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,57 @@
+# API Reference
+
+## General
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["ArchGDAL.jl", "display.jl", "iterators.jl", "gcp.jl", "types.jl", "utils.jl"]
+```
+
+## [GDAL Datasets](@id API-GDAL-Datasets)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["dataset.jl"]
+```
+
+## [Feature Data](@id API-Feature-Data)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["feature.jl", "featuredefn.jl", "featurelayer.jl", "fielddefn.jl", "geometry.jl", "styletable.jl", "context.jl"]
+```
+
+## [Raster Data](@id API-Raster-Data)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["array.jl", "colortable.jl", "rasterattributetable.jl", "rasterband.jl", "rasterio.jl"]
+```
+
+## [Spatial projections](@id API-Spatial-projections)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["spatialref.jl"]
+```
+
+## [Utilities](@id API-Utilities)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["utilities.jl"]
+```
+
+## [Format Drivers](@id API-Format-Drivers)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["driver.jl"]
+```
+
+## [GeoInterface](@id API-GeoInterface)
+
+```@autodocs
+Modules = [ArchGDAL]
+Pages   = ["geointerface.jl"]
+```

--- a/docs/src/spatialite.md
+++ b/docs/src/spatialite.md
@@ -1,6 +1,6 @@
 # Working with Spatialite
 
-Here is an example of how you can work with a SQLite Database in ArchGDAL.jl, and follows the tutorial in http://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html.
+Here is an example of how you can work with a SQLite Database in ArchGDAL.jl, and follows the tutorial in [http://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html](http://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html).
 
 We will work with the following database:
 

--- a/docs/src/spatialite.md
+++ b/docs/src/spatialite.md
@@ -1,3 +1,9 @@
+```
+#=
+This piece of documentation is currently commented out until the GDAL build provided by GDAL.jl provides spatialite support.
+Currently it already includes sqlite support, so everything up to X(Geometry) works, but then it doesn't recognize that function.
+The reason this is commented out is because Documenter.jl would still run the examples here and give warnings that they didn't work.
+
 # Working with Spatialite
 
 Here is an example of how you can work with a SQLite Database in ArchGDAL.jl, and follows the tutorial in [http://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html](http://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html).
@@ -264,3 +270,5 @@ We'll not explain in detail this kind of collections, because it will be simply 
 * the `GLength()` function applied to a `MULTILINESTRING` returns the sum of individual lengths for each `LINESTRING` composing the collection.
 * the `Area()` function applied to a `MULTIPOLYGON` returns the sum of individual areas for each `POLYGON` in the collection.
 * the `Centroid()` function returns the *average centroid* when applied to a `MULTIPOLYGON`.
+=#
+```

--- a/src/context.jl
+++ b/src/context.jl
@@ -66,6 +66,8 @@ function createfeature(f::Function, featuredefn::FeatureDefn)
 end
 
 """
+    addfielddefn!(layer::AbstractFeatureLayer, name, etype::OGRFieldType; <keyword arguments>)
+
 Create a new field on a layer.
 
 This function should not be called while there are feature objects in existence
@@ -133,6 +135,8 @@ function addfielddefn(
 end
 
 """
+    writegeomdefn!(layer::AbstractFeatureLayer, name, etype::OGRwkbGeometryType, approx=false)
+
 Write a new geometry field on a layer.
 
 This function should not be called while there are feature objects in existence

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -1,4 +1,6 @@
 """
+    copywholeraster(source::AbstractDataset, dest::AbstractDataset; <keyword arguments>)
+
 Copy all dataset raster data.
 
 This function copies the complete raster contents of one dataset to another
@@ -30,6 +32,8 @@ function copywholeraster(
 end
 
 """
+    unsafe_copy(dataset::AbstractDataset; [filename, [driver, [<keyword arguments>]]])
+
 Create a copy of a dataset.
 
 This method will attempt to create a copy of a raster dataset with the
@@ -96,6 +100,8 @@ function unsafe_copy(
 end
 
 """
+    copy(dataset::AbstractDataset; [filename, [driver, [<keyword arguments>]]])
+
 Create a copy of a dataset.
 
 This method will attempt to create a copy of a raster dataset with the
@@ -151,6 +157,8 @@ function copy(
 end
 
 """
+    write(dataset::AbstractDataset, filename::AbstractString; kwargs...)
+
 Writes the dataset to the designated filename.
 """
 function write(dataset::AbstractDataset, filename::AbstractString; kwargs...)
@@ -158,6 +166,8 @@ function write(dataset::AbstractDataset, filename::AbstractString; kwargs...)
 end
 
 """
+    unsafe_create(filename::AbstractString; driver, width, height, nbands, dtype, options)
+
 Create a new dataset.
 
 What argument values are legal for particular drivers is driver specific, and
@@ -207,6 +217,8 @@ function unsafe_create(
 end
 
 """
+    create(filename::AbstractString; driver, width, height, nbands, dtype, options)
+
 Create a new dataset.
 
 ### Parameters
@@ -263,6 +275,8 @@ function create(
 end
 
 """
+    unsafe_read(filename; flags=OF_ReadOnly, alloweddrivers, options, siblingfiles)
+
 Open a raster file as a GDALDataset.
 
 This function will try to open the passed file, or virtual dataset name by
@@ -289,6 +303,7 @@ driver on how to access a dataset. It should be in UTF-8 encoding.
                    returned, if GDALOpenEx() is called from the same thread.
     - Verbose error: GDAL_OF_VERBOSE_ERROR. If set, a failed attempt to open the
                    file will lead to an error message to be reported.
+* `options`: additional format dependent options.
 
 ### Additional Remarks
 Several recommendations:
@@ -329,6 +344,8 @@ function unsafe_read(
 end
 
 """
+    read(filename; flags=OF_ReadOnly, alloweddrivers, options, siblingfiles)
+
 Open a raster file
 
 ### Parameters
@@ -376,23 +393,45 @@ end
 unsafe_update(filename::AbstractString; flags = OF_Update, kwargs...) =
     unsafe_read(filename; flags = OF_Update | flags, kwargs...)
 
-"Fetch raster width in pixels."
+"""
+    width(dataset::AbstractDataset)
+
+Fetch raster width in pixels.
+"""
 width(dataset::AbstractDataset) = GDAL.gdalgetrasterxsize(dataset.ptr)
 
-"Fetch raster height in pixels."
+"""
+    height(dataset::AbstractDataset)
+
+Fetch raster height in pixels.
+"""
 height(dataset::AbstractDataset) = GDAL.gdalgetrasterysize(dataset.ptr)
 
-"Fetch the number of raster bands on this dataset."
+"""
+    nraster(dataset::AbstractDataset)
+
+Fetch the number of raster bands on this dataset.
+"""
 nraster(dataset::AbstractDataset) = GDAL.gdalgetrastercount(dataset.ptr)
 
-"Fetch the number of feature layers on this dataset."
+"""
+    nlayer(dataset::AbstractDataset)
+
+Fetch the number of feature layers on this dataset.
+"""
 nlayer(dataset::AbstractDataset) = GDAL.gdaldatasetgetlayercount(dataset.ptr)
 
-"Fetch the driver that the dataset was created with"
+"""
+    getdriver(dataset::AbstractDataset)
+
+Fetch the driver that the dataset was created with
+"""
 getdriver(dataset::AbstractDataset) =
     Driver(GDAL.gdalgetdatasetdriver(dataset.ptr))
 
 """
+    filelist(dataset::AbstractDataset)
+
 Fetch files forming dataset.
 
 Returns a list of files believed to be part of this dataset. If it returns an
@@ -406,6 +445,8 @@ the path used to originally open the dataset. The strings will be UTF-8 encoded
 filelist(dataset::AbstractDataset) = GDAL.gdalgetfilelist(dataset.ptr)
 
 """
+    getlayer(dataset::AbstractDataset, i::Integer)
+
 Fetch the layer at index `i` (between `0` and `nlayer(dataset)-1`)
 
 The returned layer remains owned by the GDALDataset and should not be deleted by
@@ -418,6 +459,8 @@ unsafe_getlayer(dataset::AbstractDataset, i::Integer) =
     FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i))
 
 """
+    getlayer(dataset::AbstractDataset, name::AbstractString)
+
 Fetch the feature layer corresponding to the given name.
 
 The returned layer remains owned by the GDALDataset and should not be deleted by
@@ -434,6 +477,8 @@ unsafe_getlayer(dataset::AbstractDataset, name::AbstractString) =
     FeatureLayer(GDAL.gdaldatasetgetlayerbyname(dataset.ptr, name))
 
 """
+    deletelayer!(dataset::AbstractDataset, i::Integer)
+
 Delete the indicated layer (at index i; between `0` to `nlayer()-1`)
 
 ### Returns
@@ -447,6 +492,8 @@ function deletelayer!(dataset::AbstractDataset, i::Integer)
 end
 
 """
+    testcapability(dataset::AbstractDataset, capability::AbstractString)
+
 Test if capability is available. `true` if capability available otherwise `false`.
 
 One of the following dataset capability names can be passed into this function,
@@ -476,7 +523,7 @@ function listcapability(
         dataset::AbstractDataset,
         capabilities = (GDAL.ODsCCreateLayer,
                         GDAL.ODsCDeleteLayer,
-                        GDAL.ODsCCreateGeomFieldAfterCreateLayer, 
+                        GDAL.ODsCCreateGeomFieldAfterCreateLayer,
                         GDAL.ODsCCurveGeometries,
                         GDAL.ODsCTransactions,
                         GDAL.ODsCEmulatedTransactions)
@@ -487,6 +534,8 @@ function listcapability(
 end
 
 """
+    unsafe_executesql(dataset::AbstractDataset, query::AbstractString; dialect, spatialfilter)
+
 Execute an SQL statement against the data store.
 
 The result of an SQL query is either NULL for statements that are in error, or
@@ -529,6 +578,8 @@ function unsafe_executesql(
 end
 
 """
+    releaseresultset(dataset::AbstractDataset, layer::FeatureLayer)
+
 Release results of ExecuteSQL().
 
 This function should only be used to deallocate OGRLayers resulting from an
@@ -544,7 +595,11 @@ function releaseresultset(dataset::AbstractDataset, layer::FeatureLayer)
     destroy(layer)
 end
 
-"Fetch a band object for a dataset from its index"
+"""
+    getband(dataset::AbstractDataset, i::Integer)
+
+Fetch a band object for a dataset from its index.
+"""
 getband(dataset::AbstractDataset, i::Integer) =
     IRasterBand(GDAL.gdalgetrasterband(dataset.ptr, i), ownedby = dataset)
 
@@ -552,6 +607,8 @@ unsafe_getband(dataset::AbstractDataset, i::Integer) =
     RasterBand(GDAL.gdalgetrasterband(dataset.ptr, i))
 
 """
+    getgeotransform!(dataset::AbstractDataset, transform::Vector{Cdouble})
+
 Fetch the affine transformation coefficients.
 
 Fetches the coefficients for transforming between pixel/line (P,L) raster
@@ -586,7 +643,11 @@ end
 getgeotransform(dataset::AbstractDataset) =
     getgeotransform!(dataset, Array{Cdouble}(undef, 6))
 
-"Set the affine transformation coefficients."
+"""
+    setgeotransform!(dataset::AbstractDataset, transform::Vector{Cdouble})
+
+Set the affine transformation coefficients.
+"""
 function setgeotransform!(dataset::AbstractDataset, transform::Vector{Cdouble})
     @assert length(transform) == 6
     result = GDAL.gdalsetgeotransform(dataset.ptr, pointer(transform))
@@ -594,10 +655,16 @@ function setgeotransform!(dataset::AbstractDataset, transform::Vector{Cdouble})
     return dataset
 end
 
-"Get number of GCPs for this dataset. Zero if there are none."
+"""
+    ngcp(dataset::AbstractDataset)
+
+Get number of GCPs for this dataset. Zero if there are none.
+"""
 ngcp(dataset::AbstractDataset) = GDAL.gdalgetgcpcount(dataset.ptr)
 
 """
+    getproj(dataset::AbstractDataset)
+
 Fetch the projection definition string for this dataset in OpenGIS WKT format.
 
 It should be suitable for use with the OGRSpatialReference class. When a
@@ -606,7 +673,11 @@ returned.
 """
 getproj(dataset::AbstractDataset) = GDAL.gdalgetprojectionref(dataset.ptr)
 
-"Set the projection reference string for this dataset."
+"""
+    setproj!(dataset::AbstractDataset, projstring::AbstractString)
+
+Set the projection reference string for this dataset.
+"""
 function setproj!(dataset::AbstractDataset, projstring::AbstractString)
     result = GDAL.gdalsetprojection(dataset.ptr, projstring)
     @cplerr result "Could not set projection"
@@ -614,7 +685,9 @@ function setproj!(dataset::AbstractDataset, projstring::AbstractString)
 end
 
 """
-Build raster overview(s).
+    buildoverviews!(dataset::AbstractDataset, overviewlist::Vector{Cint}; bandlist, resampling="NEAREST",
+        progressfunc, progressdata)
+        Build raster overview(s).
 
 If the operation is unsupported for the indicated dataset, then CE_Failure is
 returned, and CPLGetLastErrorNo() will return CPLE_NotSupported.

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -1,10 +1,20 @@
-"Fetch driver by index"
+"""
+    getdriver(i::Integer)
+
+Fetch driver by index.
+"""
 getdriver(i::Integer) = Driver(GDAL.gdalgetdriver(i))
 
-"Fetch a driver based on the short name (such as `GTiff`)."
+"""
+    getdriver(name::AbstractString)
+
+Fetch a driver based on the short name (such as `GTiff`).
+"""
 getdriver(name::AbstractString) = Driver(GDAL.gdalgetdriverbyname(name))
 
 """
+    destroy(drv::Driver)
+
 Destroy a `GDALDriver`.
 
 This is roughly equivalent to deleting the driver, but is guaranteed to take
@@ -16,32 +26,62 @@ function destroy(drv::Driver)
     drv.ptr = C_NULL
 end
 
-"Register a driver for use."
+"""
+    register(drv::Driver)
+
+Register a driver for use.
+"""
 register(drv::Driver) = GDAL.gdalregisterdriver(drv.ptr)
 
-"Deregister the passed drv."
+"""
+    deregister(drv::Driver)
+
+Deregister the passed driver.
+"""
 deregister(drv::Driver) = GDAL.gdalderegisterdriver(drv.ptr)
 
-"Return the list of creation options of the driver [an XML string]"
+"""
+    options(drv::Driver)
+
+Return the list of creation options of the driver [an XML string].
+"""
 options(drv::Driver) = GDAL.gdalgetdrivercreationoptionlist(drv.ptr)
 
 driveroptions(name::AbstractString) = options(getdriver(name))
 
-"Return the short name of a driver (e.g. `GTiff`)"
+"""
+    shortname(drv::Driver)
+
+Return the short name of a driver (e.g. `GTiff`).
+"""
 shortname(drv::Driver) = GDAL.gdalgetdrivershortname(drv.ptr)
 
-"Return the long name of a driver (e.g. `GeoTIFF`), or empty string."
+"""
+    longname(drv::Driver)
+
+Return the long name of a driver (e.g. `GeoTIFF`), or empty string.
+"""
 longname(drv::Driver) = GDAL.gdalgetdriverlongname(drv.ptr)
 
-"Fetch the number of registered drivers."
+"""
+    ndriver()
+
+Fetch the number of registered drivers.
+"""
 ndriver() = GDAL.gdalgetdrivercount()
 
-"Returns a listing of all registered drivers"
+"""
+    listdrivers()
+
+Returns a listing of all registered drivers.
+"""
 listdrivers() = Dict{String,String}([
     shortname(getdriver(i)) => longname(getdriver(i)) for i in 0:(ndriver()-1)
 ])
 
 """
+    identifydriver(filename::AbstractString)
+
 Identify the driver that can open a raster file.
 
 This function will try to identify the driver that can open the passed filename
@@ -53,6 +93,8 @@ identifydriver(filename::AbstractString) =
     Driver(GDAL.gdalidentifydriver(filename, C_NULL))
 
 """
+    validate(drv::Driver, options::Vector{<:AbstractString})
+
 Validate the list of creation options that are handled by a drv.
 
 This is a helper method primarily used by `create()` and `copy()` to
@@ -78,15 +120,21 @@ in the list of creation options are compatible with the capabilities declared
 by the `GDAL_DMD_CREATIONOPTIONLIST` metadata item. In case of incompatibility
 a (non fatal) warning will be emited and ``false`` will be returned.
 """
-validate(drv::Driver, options::Vector{T}) where {T <: AbstractString} = 
+validate(drv::Driver, options::Vector{T}) where {T <: AbstractString} =
     Bool(GDAL.gdalvalidatecreationoptions(drv.ptr, options))
 
-"Copy all the files associated with a dataset."
+"""
+    copyfiles(drv::Driver, new::AbstractString, old::AbstractString)
+    copyfiles(drvname::AbstractString, new::AbstractString, old::AbstractString)
+
+Copy all the files associated with a dataset.
+"""
+function copyfiles end
+
 function copyfiles(drv::Driver, new::AbstractString, old::AbstractString)
     result = GDAL.gdalcopydatasetfiles(drv.ptr, new, old)
     @cplerr result "Failed to copy dataset files"
 end
 
-"Copy all the files associated with a dataset."
 copyfiles(drvname::AbstractString, new::AbstractString, old::AbstractString) =
     copyfiles(getdriver(drvname), new, old)

--- a/src/gcp.jl
+++ b/src/gcp.jl
@@ -1,4 +1,6 @@
 """
+    invgeotransform!(gt_in::Vector{Cdouble}, gt_out::Vector{Cdouble})
+
 Invert Geotransform.
 
 This function will invert a standard 3x2 set of GeoTransform coefficients. This
@@ -21,6 +23,8 @@ invgeotransform(gt_in::Vector{Cdouble}) =
     invgeotransform!(gt_in, Array{Cdouble}(undef, 6))
 
 """
+    applygeotransform(geotransform::Vector{Cdouble}, pixel::Cdouble, line::Cdouble)
+
 Apply GeoTransform to x/y coordinate.
 
 Applies the following computation, converting a (pixel,line) coordinate into a
@@ -44,9 +48,11 @@ function applygeotransform(
     geo_y = geo_x + sizeof(Cdouble)
     GDAL.gdalapplygeotransform(pointer(geotransform), pixel, line, geo_x, geo_y)
     geo_xy
-end 
+end
 
 """
+    composegeotransform!(gt1::Vector{Float64}, gt2::Vector{Float64}, gtout::Vector{Float64})
+
 Compose two geotransforms.
 
 The resulting geotransform is the equivelent to `padfGT1` and then `padfGT2`

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -1,4 +1,6 @@
 """
+    unsafe_clone(feature::Feature)
+
 Duplicate feature.
 
 The newly created feature is owned by the caller, and will have its own
@@ -7,6 +9,8 @@ reference to the OGRFeatureDefn.
 unsafe_clone(feature::Feature) = Feature(GDAL.ogr_f_clone(feature.ptr))
 
 """
+    destroy(feature::Feature)
+
 Destroy the feature passed in.
 
 The feature is deleted, but within the context of the GDAL/OGR heap. This is
@@ -21,6 +25,8 @@ function destroy(feature::Feature)
 end
 
 """
+    setgeom!(feature::Feature, geom::AbstractGeometry)
+
 Set feature geometry.
 
 This method updates the features geometry, and operate exactly as
@@ -40,7 +46,11 @@ function setgeom!(feature::Feature, geom::AbstractGeometry)
     @ogrerr result "OGRErr $result: Failed to set feature geometry."
 end
 
-"Returns a clone of the geometry corresponding to the feature."
+"""
+    getgeom(feature::Feature)
+
+Returns a clone of the geometry corresponding to the feature.
+"""
 function getgeom(feature::Feature)
     result = GDAL.ogr_f_getgeometryref(feature.ptr)
     if result == C_NULL
@@ -60,6 +70,8 @@ function unsafe_getgeom(feature::Feature)
 end
 
 """
+    nfield(feature::Feature)
+
 Fetch number of fields on this feature.
 
 This will always be the same as the field count for the OGRFeatureDefn.
@@ -67,6 +79,8 @@ This will always be the same as the field count for the OGRFeatureDefn.
 nfield(feature::Feature) = GDAL.ogr_f_getfieldcount(feature.ptr)
 
 """
+    getfielddefn(feature::Feature, i::Integer)
+
 Fetch definition for this field.
 
 ### Parameters
@@ -81,6 +95,8 @@ getfielddefn(feature::Feature, i::Integer) =
     IFieldDefnView(GDAL.ogr_f_getfielddefnref(feature.ptr, i))
 
 """
+    findfieldindex(feature::Feature, name::AbstractString)
+
 Fetch the field index given field name.
 
 ### Parameters
@@ -96,7 +112,10 @@ This is a cover for the `OGRFeatureDefn::GetFieldIndex()` method.
 findfieldindex(feature::Feature, name::AbstractString) =
     GDAL.ogr_f_getfieldindex(feature.ptr, name)
 
-"""Test if a field has ever been assigned a value or not.
+"""
+    isfieldset(feature::Feature, i::Integer)
+
+Test if a field has ever been assigned a value or not.
 
 ### Parameters
 * `feature`: the feature that owned the field.
@@ -106,6 +125,8 @@ isfieldset(feature::Feature, i::Integer) =
     Bool(GDAL.ogr_f_isfieldset(feature.ptr, i))
 
 """
+    unsetfield!(feature::Feature, i::Integer)
+
 Clear a field, marking it as unset.
 
 ### Parameters
@@ -131,7 +152,10 @@ unsetfield!(feature::Feature, i::Integer) =
 #           Cint),arg1,arg2)
 # end
 
-"""Fetch field value as integer.
+"""
+    asint(feature::Feature, i::Integer)
+
+Fetch field value as integer.
 
 ### Parameters
 * `feature`: the feature that owned the field.
@@ -140,7 +164,10 @@ unsetfield!(feature::Feature, i::Integer) =
 asint(feature::Feature, i::Integer) =
     GDAL.ogr_f_getfieldasinteger(feature.ptr, i)
 
-"""Fetch field value as integer 64 bit.
+"""
+    asint64(feature::Feature, i::Integer)
+
+Fetch field value as integer 64 bit.
 
 ### Parameters
 * `feature`: the feature that owned the field.
@@ -149,7 +176,10 @@ asint(feature::Feature, i::Integer) =
 asint64(feature::Feature, i::Integer) =
     GDAL.ogr_f_getfieldasinteger64(feature.ptr, i)
 
-"""Fetch field value as a double.
+"""
+    asdouble(feature::Feature, i::Integer)
+
+Fetch field value as a double.
 
 ### Parameters
 * `feature`: the feature that owned the field.
@@ -159,6 +189,8 @@ asdouble(feature::Feature, i::Integer) =
     GDAL.ogr_f_getfieldasdouble(feature.ptr, i)
 
 """
+    asstring(feature::Feature, i::Integer)
+
 Fetch field value as a string.
 
 ### Parameters
@@ -169,14 +201,15 @@ asstring(feature::Feature, i::Integer) =
     GDAL.ogr_f_getfieldasstring(feature.ptr, i)
 
 """
-    OGR_F_GetFieldAsIntegerList(OGRFeatureH hFeat,
-                                int iField,
-                                int * pnCount) -> const int *
+    asintlist(feature::Feature, i::Integer)
+
 Fetch field value as a list of integers.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
 * `pnCount`: an integer to put the list count (number of integers) into.
+
 ### Returns
 the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief. If *pnCount is zero on return the returned
@@ -189,14 +222,15 @@ function asintlist(feature::Feature, i::Integer)
 end
 
 """
-    OGR_F_GetFieldAsInteger64List(OGRFeatureH hFeat,
-                                  int iField,
-                                  int * pnCount) -> const GIntBig *
+    asint64list(feature::Feature, i::Integer)
+
 Fetch field value as a list of 64 bit integers.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
 * `pnCount`: an integer to put the list count (number of integers) into.
+
 ### Returns
 the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief. If *pnCount is zero on return the returned
@@ -209,14 +243,15 @@ function asint64list(feature::Feature, i::Integer)
 end
 
 """
-    OGR_F_GetFieldAsDoubleList(OGRFeatureH hFeat,
-                               int iField,
-                               int * pnCount) -> const double *
+    asdoublelist(feature::Feature, i::Integer)
+
 Fetch field value as a list of doubles.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
 * `pnCount`: an integer to put the list count (number of doubles) into.
+
 ### Returns
 the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief. If *pnCount is zero on return the returned
@@ -229,12 +264,14 @@ function asdoublelist(feature::Feature, i::Integer)
 end
 
 """
-    OGR_F_GetFieldAsStringList(OGRFeatureH hFeat,
-                               int iField) -> char **
+    asstringlist(feature::Feature, i::Integer)
+
 Fetch field value as a list of strings.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
+
 ### Returns
 the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief.
@@ -243,14 +280,14 @@ asstringlist(feature::Feature, i::Integer) =
     GDAL.ogr_f_getfieldasstringlist(feature.ptr, i)
 
 """
-    OGR_F_GetFieldAsBinary(OGRFeatureH hFeat,
-                           int iField,
-                           int * pnBytes) -> GByte *
+    asbinary(feature::Feature, i::Integer)
+
 Fetch field value as binary.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
-* `pnBytes`: location to place count of bytes returned.
+
 ### Returns
 the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief.
@@ -262,26 +299,14 @@ function asbinary(feature::Feature, i::Integer)
 end
 
 """
-    OGR_F_GetFieldAsDateTime(OGRFeatureH hFeat,
-                             int iField,
-                             int * pnYear,
-                             int * pnMonth,
-                             int * pnDay,
-                             int * pnHour,
-                             int * pnMinute,
-                             int * pnSecond,
-                             int * pnTZFlag) -> int
+    asdatetime(feature::Feature, i::Integer)
+
 Fetch field value as date and time.
+
 ### Parameters
 * `hFeat`: handle to the feature that owned the field.
 * `iField`: the field to fetch, from 0 to GetFieldCount()-1.
-* `pnYear`: (including century)
-* `pnMonth`: (1-12)
-* `pnDay`: (1-31)
-* `pnHour`: (0-23)
-* `pnMinute`: (0-59)
-* `pnSecond`: (0-59)
-* `pnTZFlag`: (0=unknown, 1=localtime, 100=GMT, see data model for details)
+
 ### Returns
 `true` on success or `false` on failure.
 """
@@ -360,7 +385,15 @@ getfield(feature::Feature, name::AbstractString) =
     getfield(feature, findfieldindex(feature, name))
 
 """
-Set field to integer value.
+    setfield!(feature::Feature, i::Integer, value)
+    setfield!(feature::Feature, i::Integer, value::DateTime, tzflag::Int = 0)
+
+Set a feature's `i`-th field to `value`.
+
+The following types for `value` are accepted: `Int32`, `Int64`, `Float64`, `AbstractString`,
+or a `Vector` with those in it, as well as `Vector{UInt8}`. For `DateTime` values, an
+additional keyword argument `tzflag` is accepted (0=unknown, 1=localtime, 100=GMT, see data
+model for details).
 
 OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
 fields will be assigned a string representation of the value, but not
@@ -372,135 +405,43 @@ field types may be unaffected.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 * `value`: the value to assign.
 """
+function setfield! end
+
 function setfield!(feature::Feature, i::Integer, value::Cint)
     GDAL.ogr_f_setfieldinteger(feature.ptr, i, value)
     return feature
 end
 
-"""
-Set field to 64 bit integer value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `feature`: handle to the feature that owned the field.
-* `i`: the field to fetch, from 0 to GetFieldCount()-1.
-* `value`: the value to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::Int64)
     GDAL.ogr_f_setfieldinteger64(feature.ptr, i, value)
     return feature
 end
 
-"""
-Set field to double value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `feature`: handle to the feature that owned the field.
-* `i`: the field to fetch, from 0 to GetFieldCount()-1.
-* `value`: the value to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::Cdouble)
     GDAL.ogr_f_setfielddouble(feature.ptr, i, value)
     return feature
 end
 
-"""
-Set field to string value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `feature`: handle to the feature that owned the field.
-* `i`: the field to fetch, from 0 to GetFieldCount()-1.
-* `value`: the value to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::AbstractString)
     GDAL.ogr_f_setfieldstring(feature.ptr, i, value)
     return feature
 end
 
-"""
-Set field to list of integers value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `nCount`: the number of values in the list being assigned.
-* `panValues`: the values to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::Vector{Cint})
     GDAL.ogr_f_setfieldintegerlist(feature.ptr, i, length(value), value)
     return feature
 end
 
-"""
-Set field to list of 64 bit integers value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `nCount`: the number of values in the list being assigned.
-* `panValues`: the values to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::Vector{GDAL.GIntBig})
     GDAL.ogr_f_setfieldinteger64list(feature.ptr, i, length(value), value)
     return feature
 end
 
-"""
-Set field to list of doubles value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `nCount`: the number of values in the list being assigned.
-* `padfValues`: the values to assign.
-"""
 function setfield!(feature::Feature, i::Integer, value::Vector{Cdouble})
     GDAL.ogr_f_setfielddoublelist(feature.ptr, i, length(value), value)
     return feature
 end
 
-"""
-Set field to list of strings value.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `papszValues`: the values to assign.
-"""
 function setfield!(
         feature::Feature,
         i::Integer,
@@ -525,44 +466,11 @@ end
 #           Ptr{OGRField}),arg1,arg2,arg3)
 # end
 
-"""
-Set field to binary data.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `nBytes`: the number of bytes in pabyData array.
-* `pabyData`: the data to apply.
-"""
 function setfield!(feature::Feature, i::Integer, value::Vector{GDAL.GByte})
     GDAL.ogr_f_setfieldbinary(feature.ptr, i, sizeof(value), value)
     return feature
 end
 
-"""
-Set field to datetime.
-
-OFTInteger, OFTInteger64 and OFTReal fields will be set directly. OFTString
-fields will be assigned a string representation of the value, but not
-necessarily taking into account formatting constraints on this field. Other
-field types may be unaffected.
-
-### Parameters
-* `hFeat`: handle to the feature that owned the field.
-* `iField`: the field to set, from 0 to GetFieldCount()-1.
-* `nYear`: (including century)
-* `nMonth`: (1-12)
-* `nDay`: (1-31)
-* `nHour`: (0-23)
-* `nMinute`: (0-59)
-* `nSecond`: (0-59)
-* `nTZFlag`: (0=unknown, 1=localtime, 100=GMT, see data model for details)
-"""
 function setfield!(feature::Feature, i::Integer, dt::DateTime, tzflag::Int = 0)
     GDAL.ogr_f_setfielddatetime(
         feature.ptr,
@@ -579,6 +487,8 @@ function setfield!(feature::Feature, i::Integer, dt::DateTime, tzflag::Int = 0)
 end
 
 """
+    ngeom(feature::Feature)
+
 Fetch number of geometry fields on this feature.
 
 This will always be the same as the geometry field count for OGRFeatureDefn.
@@ -586,6 +496,8 @@ This will always be the same as the geometry field count for OGRFeatureDefn.
 ngeom(feature::Feature) = GDAL.ogr_f_getgeomfieldcount(feature.ptr)
 
 """
+    getgeomdefn(feature::Feature, i::Integer)
+
 Fetch definition for this geometry field.
 
 ### Parameters
@@ -600,6 +512,8 @@ getgeomdefn(feature::Feature, i::Integer) =
     IGeomFieldDefnView(GDAL.ogr_f_getgeomfielddefnref(feature.ptr, i))
 
 """
+    findgeomindex(feature::Feature, name::AbstractString="")
+
 Fetch the geometry field index given geometry field name.
 
 ### Parameters
@@ -616,6 +530,8 @@ findgeomindex(feature::Feature, name::AbstractString="") =
     GDAL.ogr_f_getgeomfieldindex(feature.ptr, name)
 
 """
+    getgeom(feature::Feature, i::Integer)
+
 Returns a clone of the feature geometry at index `i`.
 
 ### Parameters
@@ -641,6 +557,8 @@ function unsafe_getgeom(feature::Feature, i::Integer)
 end
 
 """
+    setgeom!(feature::Feature, i::Integer, geom::AbstractGeometry)
+
 Set feature geometry of a specified geometry field.
 
 This function updates the features geometry, and operate exactly as
@@ -663,6 +581,8 @@ function setgeom!(feature::Feature, i::Integer, geom::AbstractGeometry)
 end
 
 """
+    getfid(feature::Feature)
+
 Get feature identifier.
 
 ### Returns
@@ -671,6 +591,8 @@ feature id or `OGRNullFID` (`-1`) if none has been assigned.
 getfid(feature::Feature) = GDAL.ogr_f_getfid(feature.ptr)
 
 """
+    setfid!(feature::Feature, i::Integer)
+
 Set the feature identifier.
 
 ### Parameters
@@ -687,31 +609,15 @@ function setfid!(feature::Feature, i::Integer)
 end
 
 """
+    setfrom!(feature1::Feature, feature2::Feature, forgiving::Bool = false)
+    setfrom!(feature1::Feature, feature2::Feature, indices::Vector{Cint}, forgiving::Bool = false)
+
 Set one feature from another.
 
 ### Parameters
 * `feature1`: handle to the feature to set to.
 * `feature2`: handle to the feature from which geometry, and field values
     will be copied.
-* `forgiving`: `true` if the operation should continue despite lacking output
-    fields matching some of the source fields.
-
-### Returns
-OGRERR_NONE if the operation succeeds, even if some values are not transferred,
-otherwise an error code.
-"""
-function setfrom!(feature1::Feature, feature2::Feature, forgiving::Bool = false)
-    result = GDAL.ogr_f_setfrom(feature1.ptr, feature2.ptr, forgiving)
-    @ogrerr result "OGRErr $result: Failed to set feature"
-    return feature1
-end
-
-"""
-Set one feature from another.
-
-### Parameters
-* `feature1`: the feature to set to.
-* `feature2`: the feature from which geometry and field values will be copied
 * `indices`: indices of the destination feature's fields stored at the
     corresponding index of the source feature's fields. A value of `-1` should
     be used to ignore the source's field. The array should not be NULL and be
@@ -723,6 +629,14 @@ Set one feature from another.
 OGRERR_NONE if the operation succeeds, even if some values are not transferred,
 otherwise an error code.
 """
+function setfrom! end
+
+function setfrom!(feature1::Feature, feature2::Feature, forgiving::Bool = false)
+    result = GDAL.ogr_f_setfrom(feature1.ptr, feature2.ptr, forgiving)
+    @ogrerr result "OGRErr $result: Failed to set feature"
+    return feature1
+end
+
 function setfrom!(
         feature1::Feature,
         feature2::Feature,
@@ -736,10 +650,16 @@ function setfrom!(
 end
 
 
-"Fetch style string for this feature."
+"""
+    getstylestring(feature::Feature)
+
+Fetch style string for this feature.
+"""
 getstylestring(feature::Feature) = GDAL.ogr_f_getstylestring(feature.ptr)
 
 """
+    setstylestring!(feature::Feature, style::AbstractString)
+
 Set feature style string.
 
 This method operate exactly as `setstylestringdirectly!()` except that
@@ -750,13 +670,18 @@ function setstylestring!(feature::Feature, style::AbstractString)
     return feature
 end
 
-"OGR_F_GetStyleTable(OGRFeatureH hFeat) -> OGRStyleTableH"
+"""
+    getstyletable(feature::Feature)
+
+Fetch style table for this feature.
+"""
 getstyletable(feature::Feature) =
     StyleTable(GDAL.ogr_f_getstyletable(feature.ptr))
 
 """
-    OGR_F_SetStyleTable(OGRFeatureH hFeat,
-                        OGRStyleTableH hStyleTable) -> void
+    setstyletable!(feature::Feature, styletable::StyleTable)
+
+Set the style table for this feature.
 """
 function setstyletable!(feature::Feature, styletable::StyleTable)
     GDAL.ogr_f_setstyletable(feature.ptr, styletable.ptr)
@@ -764,6 +689,8 @@ function setstyletable!(feature::Feature, styletable::StyleTable)
 end
 
 """
+    getnativedata(feature::Feature)
+
 Returns the native data for the feature.
 
 The native data is the representation in a "natural" form that comes from the
@@ -783,6 +710,8 @@ are not captured otherwise by the OGR abstraction.
 getnativedata(feature::Feature) = GDAL.ogr_f_getnativedata(feature.ptr)
 
 """
+    setnativedata!(feature::Feature, data::AbstractString)
+
 Sets the native data for the feature.
 
 The native data is the representation in a "natural" form that comes from the
@@ -796,6 +725,8 @@ function setnativedata!(feature::Feature, data::AbstractString)
 end
 
 """
+    getmediatype(feature::Feature)
+
 Returns the native media type for the feature.
 
 The native media type is the identifier for the format of the native data. It
@@ -805,6 +736,8 @@ e.g. \"application/vnd.geo+json\" for JSON.
 getmediatype(feature::Feature) = GDAL.ogr_f_getnativemediatype(feature.ptr)
 
 """
+    setmediatype!(feature::Feature, mediatype::AbstractString)
+
 Sets the native media type for the feature.
 
 The native media type is the identifier for the format of the native data. It
@@ -817,6 +750,8 @@ function setmediatype!(feature::Feature, mediatype::AbstractString)
 end
 
 """
+    fillunsetwithdefault!(feature::Feature; notnull = true, options = StringList(C_NULL))
+
 Fill unset fields with default values that might be defined.
 
 ### Parameters
@@ -833,6 +768,8 @@ function fillunsetwithdefault!(
 end
 
 """
+    validate(feature::Feature, flags::Integer, emiterror::Bool)
+
 Validate that a feature meets constraints of its schema.
 
 The scope of test is specified with the nValidateFlags parameter.

--- a/src/ogr/featuredefn.jl
+++ b/src/ogr/featuredefn.jl
@@ -1,4 +1,6 @@
 """
+    unsafe_createfeaturedefn(name::AbstractString)
+
 Create a new feature definition object to hold field definitions.
 
 The `FeatureDefn` maintains a reference count, but this starts at zero, and
@@ -8,6 +10,8 @@ unsafe_createfeaturedefn(name::AbstractString) =
     FeatureDefn(GDAL.ogr_fd_create(name))
 
 """
+    reference(featuredefn::FeatureDefn)
+
 Increments the reference count in the FeatureDefn by one.
 
 The count is used to track the number of `Feature`s referencing this definition.
@@ -17,10 +21,18 @@ The updated reference count.
 """
 reference(featuredefn::FeatureDefn) = GDAL.ogr_fd_reference(featuredefn.ptr)
 
-"Decrements the reference count by one, and returns the updated count."
+"""
+    dereference(featuredefn::FeatureDefn)
+
+Decrements the reference count by one, and returns the updated count.
+"""
 dereference(featuredefn::FeatureDefn) = GDAL.ogr_fd_dereference(featuredefn.ptr)
 
-"Fetch the current reference count."
+"""
+    nreference(featuredefn::AbstractFeatureDefn)
+
+Fetch the current reference count.
+"""
 nreference(featuredefn::AbstractFeatureDefn) =
     GDAL.ogr_fd_getreferencecount(featuredefn.ptr)
 
@@ -37,17 +49,31 @@ function destroy(featuredefn::IFeatureDefnView)
     return featuredefn
 end
 
-"Drop a reference, and destroy if unreferenced."
+"""
+    release(featuredefn::FeatureDefn)
+
+Drop a reference, and destroy if unreferenced.
+"""
 release(featuredefn::FeatureDefn) = GDAL.ogr_fd_release(featuredefn.ptr)
 
-"Get name of the OGRFeatureDefn passed as an argument."
+"""
+    getname(featuredefn::AbstractFeatureDefn)
+
+Get name of the OGRFeatureDefn passed as an argument.
+"""
 getname(featuredefn::AbstractFeatureDefn) = GDAL.ogr_fd_getname(featuredefn.ptr)
 
-"Fetch number of fields on the passed feature definition."
+"""
+    nfield(featuredefn::AbstractFeatureDefn)
+
+Fetch number of fields on the passed feature definition.
+"""
 nfield(featuredefn::AbstractFeatureDefn) =
     GDAL.ogr_fd_getfieldcount(featuredefn.ptr)
 
 """
+    getfielddefn(featuredefn::FeatureDefn, i::Integer)
+
 Fetch field definition of the passed feature definition.
 
 ### Parameters
@@ -65,6 +91,8 @@ getfielddefn(featuredefn::IFeatureDefnView, i::Integer) =
     IFieldDefnView(GDAL.ogr_fd_getfielddefn(featuredefn.ptr, i))
 
 """
+    findfieldindex(featuredefn::AbstractFeatureDefn, name::AbstractString)
+
 Find field by name.
 
 ### Returns
@@ -77,6 +105,8 @@ findfieldindex(featuredefn::AbstractFeatureDefn, name::AbstractString) =
     GDAL.ogr_fd_getfieldindex(featuredefn.ptr, name)
 
 """
+    addfielddefn!(featuredefn::FeatureDefn, fielddefn::FieldDefn)
+
 Add a new field definition to the passed feature definition.
 
 To add a new field definition to a layer definition, do not use this function
@@ -92,6 +122,8 @@ function addfielddefn!(featuredefn::FeatureDefn, fielddefn::FieldDefn)
 end
 
 """
+    deletefielddefn!(featuredefn::FeatureDefn, i::Integer)
+
 Delete an existing field definition.
 
 To delete an existing field definition from a layer definition, do not use this
@@ -107,6 +139,8 @@ function deletefielddefn!(featuredefn::FeatureDefn, i::Integer)
 end
 
 """
+    reorderfielddefns!(featuredefn::FeatureDefn, indices::Vector{Cint})
+
 Reorder the field definitions in the array of the feature definition.
 
 To reorder the field definitions in a layer definition, do not use this function
@@ -119,7 +153,7 @@ existence based on this OGRFeatureDefn.
 * **fd**: handle to the feature definition.
 * **indices**: an array of `GetFieldCount()` elements which is a permutation of
     `[0, GetFieldCount()-1]`. `indices` is such that, for each field definition
-    at position `i` after reordering, its position before reordering was 
+    at position `i` after reordering, its position before reordering was
     `indices[i]`.
 """
 function reorderfielddefns!(featuredefn::FeatureDefn, indices::Vector{Cint})
@@ -127,9 +161,11 @@ function reorderfielddefns!(featuredefn::FeatureDefn, indices::Vector{Cint})
     @ogrerr result "Failed to reorder $indices in the feature definition"
     return featuredefn
 end
-    
+
 
 """
+    getgeomtype(featuredefn::AbstractFeatureDefn)
+
 Fetch the geometry base type of the passed feature definition.
 
 For layers without any geometry field, this method returns `wkbNone`.
@@ -146,6 +182,8 @@ getgeomtype(featuredefn::AbstractFeatureDefn) =
     GDAL.ogr_fd_getgeomtype(featuredefn.ptr)
 
 """
+    setgeomtype!(featuredefn::FeatureDefn, etype::OGRwkbGeometryType)
+
 Assign the base geometry type for the passed layer (same as the fd).
 
 All geometry objects using this type must be of the defined type or a derived
@@ -158,31 +196,53 @@ function setgeomtype!(featuredefn::FeatureDefn, etype::OGRwkbGeometryType)
     return featuredefn
 end
 
-"Determine whether the geometry can be omitted when fetching features."
+"""
+    isgeomignored(featuredefn::AbstractFeatureDefn)
+
+Determine whether the geometry can be omitted when fetching features.
+"""
 isgeomignored(featuredefn::AbstractFeatureDefn) =
     Bool(GDAL.ogr_fd_isgeometryignored(featuredefn.ptr))
 
-"Set whether the geometry can be omitted when fetching features."
+"""
+    setgeomignored!(featuredefn::FeatureDefn, ignore::Bool)
+
+Set whether the geometry can be omitted when fetching features.
+"""
 function setgeomignored!(featuredefn::FeatureDefn, ignore::Bool)
     GDAL.ogr_fd_setgeometryignored(featuredefn.ptr, ignore)
     return featuredefn
 end
 
-"Determine whether the style can be omitted when fetching features."
+"""
+    isstyleignored(featuredefn::AbstractFeatureDefn)
+
+Determine whether the style can be omitted when fetching features.
+"""
 isstyleignored(featuredefn::AbstractFeatureDefn) =
     Bool(GDAL.ogr_fd_isstyleignored(featuredefn.ptr))
 
-"Set whether the style can be omitted when fetching features."
+"""
+    setstyleignored!(featuredefn::FeatureDefn, ignore::Bool)
+
+Set whether the style can be omitted when fetching features.
+"""
 function setstyleignored!(featuredefn::FeatureDefn, ignore::Bool)
     GDAL.ogr_fd_setstyleignored(featuredefn.ptr, ignore)
     return featuredefn
 end
 
-"Fetch number of geometry fields on the passed feature definition."
+"""
+    ngeom(featuredefn::AbstractFeatureDefn)
+
+Fetch number of geometry fields on the passed feature definition.
+"""
 ngeom(featuredefn::AbstractFeatureDefn) =
     GDAL.ogr_fd_getgeomfieldcount(featuredefn.ptr)
 
 """
+    getgeomdefn(featuredefn::FeatureDefn, i::Integer = 0)
+
 Fetch geometry field definition of the passed feature definition.
 
 ### Parameters
@@ -199,6 +259,8 @@ getgeomdefn(featuredefn::IFeatureDefnView, i::Integer = 0) =
     IGeomFieldDefnView(GDAL.ogr_fd_getgeomfielddefn(featuredefn.ptr, i))
 
 """
+    findgeomindex(featuredefn::AbstractFeatureDefn, name::AbstractString = "")
+
 Find geometry field by name.
 
 The geometry field index of the first geometry field matching the passed field
@@ -211,6 +273,8 @@ findgeomindex(featuredefn::AbstractFeatureDefn, name::AbstractString = "") =
     GDAL.ogr_fd_getgeomfieldindex(featuredefn.ptr, name)
 
 """
+    addgeomdefn!(featuredefn::FeatureDefn, geomfielddefn::AbstractGeomFieldDefn)
+
 Add a new field definition to the passed feature definition.
 
 To add a new geometry field definition to a layer definition, do not use this
@@ -233,6 +297,8 @@ function addgeomdefn!(
 end
 
 """
+    deletegeomdefn!(featuredefn::FeatureDefn, i::Integer)
+
 Delete an existing geometry field definition.
 
 To delete an existing field definition from a layer definition, do not use this
@@ -247,7 +313,11 @@ function deletegeomdefn!(featuredefn::FeatureDefn, i::Integer)
     return featuredefn
 end
 
-"Test if the feature definition is identical to the other one."
+"""
+    issame(featuredefn1::AbstractFeatureDefn, featuredefn2::AbstractFeatureDefn)
+
+Test if the feature definition is identical to the other one.
+"""
 function issame(
         featuredefn1::AbstractFeatureDefn,
         featuredefn2::AbstractFeatureDefn
@@ -255,7 +325,10 @@ function issame(
     return Bool(GDAL.ogr_fd_issame(featuredefn1.ptr, featuredefn2.ptr))
 end
 
-"""Returns the new feature object with null fields and no geometry
+"""
+    unsafe_createfeature(featuredefn::AbstractFeatureDefn)
+
+Returns the new feature object with null fields and no geometry
 
 Note that the OGRFeature will increment the reference count of it's defining
 OGRFeatureDefn. Destruction of the OGRFeatureDefn before destruction of all
@@ -267,6 +340,10 @@ function unsafe_createfeature(featuredefn::AbstractFeatureDefn)
     return Feature(GDALFeature(GDAL.ogr_f_create(featuredefn.ptr)))
 end
 
-"Fetch feature definition."
+"""
+    getfeaturedefn(feature::Feature)
+
+Fetch feature definition.
+"""
 getfeaturedefn(feature::Feature) =
     IFeatureDefnView(GDAL.ogr_f_getdefnref(feature.ptr))

--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -12,15 +12,15 @@ function destroy(layer::IFeatureLayer)
 end
 
 """
+    createlayer(name, dataset, geom, spatialref, options)
+
 This function attempts to create a new layer on the dataset with the indicated
 `name`, `spatialref`, and geometry type.
 
-### Parameters
+### Keyword Arguments
 * `name`: the name for the new layer. This should ideally not match any
     existing layer on the datasource. Defaults to an empty string.
-
-### Keyword Arguments
-* `dataset`: the dataset
+* `dataset`: the dataset. Defaults to creating a new in memory dataset.
 * `geom`: the geometry type for the layer. Use wkbUnknown (default) if
     there are no constraints on the types geometry to be written.
 * `spatialref`: the coordinate system to use for the new layer.
@@ -53,6 +53,8 @@ function unsafe_createlayer(;
 end
 
 """
+    copy(layer, dataset, name, options)
+
 Copy an existing layer.
 
 This method creates a new layer, duplicate the field definitions of the source
@@ -88,13 +90,25 @@ function unsafe_copy(
         options))
 end
 
-"Return the layer name."
+"""
+    getname(layer::AbstractFeatureLayer)
+
+Return the layer name.
+"""
 getname(layer::AbstractFeatureLayer) = GDAL.ogr_l_getname(layer.ptr)
 
-"Return the layer geometry type."
+"""
+    getgeomtype(layer::AbstractFeatureLayer)
+
+Return the layer geometry type.
+"""
 getgeomtype(layer::AbstractFeatureLayer) = GDAL.ogr_l_getgeomtype(layer.ptr)
 
-"Returns the current spatial filter for this layer."
+"""
+    getspatialfilter(layer::AbstractFeatureLayer)
+
+Returns the current spatial filter for this layer.
+"""
 function getspatialfilter(layer::AbstractFeatureLayer)
     result = GDALGeometry(GDAL.ogr_l_getspatialfilter(Ptr{Cvoid}(layer.ptr)))
     if result == C_NULL
@@ -106,7 +120,11 @@ function getspatialfilter(layer::AbstractFeatureLayer)
     end
 end
 
-"Returns a clone of the spatial reference system for this layer."
+"""
+    getspatialref(layer::AbstractFeatureLayer)
+
+Returns a clone of the spatial reference system for this layer.
+"""
 function getspatialref(layer::AbstractFeatureLayer)
     result = GDAL.ogr_l_getspatialref(layer.ptr)
     if result == C_NULL
@@ -130,6 +148,8 @@ function unsafe_getspatialref(layer::AbstractFeatureLayer)
 end
 
 """
+    setspatialfilter!(layer::AbstractFeatureLayer, geom::Geometry)
+
 Set a new spatial filter for the layer, using the geom.
 
 This method set the geometry to be used as a spatial filter when fetching
@@ -169,6 +189,8 @@ function clearspatialfilter!(layer::AbstractFeatureLayer)
 end
 
 """
+    setspatialfilter!(layer::AbstractFeatureLayer, xmin, ymin, xmax, ymax)
+
 Set a new rectangular spatial filter for the layer.
 
 This method set rectangle to be used as a spatial filter when fetching features
@@ -195,6 +217,8 @@ function setspatialfilter!(
 end
 
 """
+    setspatialfilter!(layer::AbstractFeatureLayer, i::Integer, geom::AbstractGeometry)
+
 Set a new spatial filter.
 
 This method set the geometry to be used as a spatial filter when fetching
@@ -235,6 +259,8 @@ function clearspatialfilter!(layer::AbstractFeatureLayer, i::Integer)
 end
 
 """
+    setspatialfilter!(layer::AbstractFeatureLayer, i::Integer, xmin, ymin, xmax, ymax)
+
 Set a new rectangular spatial filter.
 
 ### Parameters
@@ -258,6 +284,8 @@ function setspatialfilter!(
 end
 
 """
+    setattributefilter!(layer::AbstractFeatureLayer, query::AbstractString)
+
 Set a new attribute query.
 
 This method sets the attribute query string to be used when fetching features
@@ -294,6 +322,8 @@ function clearattributefilter!(layer::AbstractFeatureLayer)
 end
 
 """
+    resetreading!(layer::AbstractFeatureLayer)
+
 Reset feature reading to start on the first feature.
 
 This affects `nextfeature()`.
@@ -304,6 +334,8 @@ function resetreading!(layer::AbstractFeatureLayer)
 end
 
 """
+    unsafe_nextfeature(layer::AbstractFeatureLayer)
+
 Fetch the next available feature from this layer.
 
 ### Parameters
@@ -333,6 +365,8 @@ function unsafe_nextfeature(layer::AbstractFeatureLayer)
 end
 
 """
+    setnextbyindex!(layer::AbstractFeatureLayer, i::Integer)
+
 Move read cursor to the `i`-th feature in the current resultset.
 
 This method allows positioning of a layer such that the `nextfeature()` call
@@ -360,6 +394,8 @@ function setnextbyindex!(layer::AbstractFeatureLayer, i::Integer)
 end
 
 """
+    unsafe_getfeature(layer::AbstractFeatureLayer, i::Integer)
+
 Return a feature (now owned by the caller) by its identifier or NULL on failure.
 
 ### Parameters
@@ -389,6 +425,8 @@ unsafe_getfeature(layer::AbstractFeatureLayer, i::Integer) =
     Feature(GDALFeature(GDAL.ogr_l_getfeature(layer.ptr, i)))
 
 """
+    setfeature!(layer::AbstractFeatureLayer, feature::Feature)
+
 Rewrite an existing feature.
 
 This function will write a feature to the layer, based on the feature id within
@@ -407,6 +445,8 @@ function setfeature!(layer::AbstractFeatureLayer, feature::Feature)
 end
 
 """
+    addfeature!(layer::AbstractFeatureLayer, feature::Feature)
+
 Write a new feature within a layer.
 
 ### Remarks
@@ -433,6 +473,8 @@ function addfeature(f::Function, layer::AbstractFeatureLayer)
 end
 
 """
+    unsafe_createfeature(layer::AbstractFeatureLayer)
+
 Create and returns a new feature based on the layer definition.
 
 The newly feature is owned by the layer (it will increase the number of features
@@ -452,6 +494,8 @@ function createfeature(f::Function, layer::AbstractFeatureLayer)
 end
 
 """
+    deletefeature!(layer::AbstractFeatureLayer, i::Integer)
+
 Delete feature with fid `i` from layer.
 
 ### Remarks
@@ -469,6 +513,8 @@ function deletefeature!(layer::AbstractFeatureLayer, i::Integer)
 end
 
 """
+    layerdefn(layer::AbstractFeatureLayer)
+
 Returns a view of the schema information for this layer.
 
 ### Remarks
@@ -478,6 +524,8 @@ layerdefn(layer::AbstractFeatureLayer) =
     IFeatureDefnView(GDAL.ogr_l_getlayerdefn(layer.ptr))
 
 """
+    findfieldindex(layer::AbstractFeatureLayer, field::AbstractString, exactmatch::Bool)
+
 Find the index of the field in a layer, or -1 if the field doesn't exist.
 
 If `exactmatch` is set to `false` and the field doesn't exists in the given form
@@ -493,6 +541,8 @@ function findfieldindex(
 end
 
 """
+    nfeature(layer::AbstractFeatureLayer, force::Bool = false)
+
 Fetch the feature count in this layer, or `-1` if the count is not known.
 
 ### Parameters
@@ -503,13 +553,24 @@ Fetch the feature count in this layer, or `-1` if the count is not known.
 nfeature(layer::AbstractFeatureLayer, force::Bool = false) =
     GDAL.ogr_l_getfeaturecount(layer.ptr, force)
 
-"Fetch number of geometry fields on the feature layer."
+"""
+    ngeom(layer::AbstractFeatureLayer)
+
+Fetch number of geometry fields on the feature layer.
+"""
 ngeom(layer::AbstractFeatureLayer) = ngeom(layerdefn(layer))
 
-"Fetch number of fields on the feature layer."
+"""
+    nfield(layer::AbstractFeatureLayer)
+
+Fetch number of fields on the feature layer.
+"""
 nfield(layer::AbstractFeatureLayer) = nfield(layerdefn(layer))
 
 """
+    envelope(layer::AbstractFeatureLayer, force::Bool = false)
+    envelope(layer::AbstractFeatureLayer, i::Integer, force::Bool = false)
+
 Fetch the extent of this layer.
 
 Returns the extent (MBR) of the data in the layer. If `force` is `false`, and it
@@ -550,6 +611,8 @@ function envelope(layer::AbstractFeatureLayer, force::Bool = false)
 end
 
 """
+    testcapability(layer::AbstractFeatureLayer, capability::AbstractString)
+
 Test if this layer supported the named capability.
 
 ### Parameters
@@ -676,6 +739,8 @@ end
 # )
 
 """
+    addfielddefn!(layer::AbstractFeatureLayer, field::AbstractFieldDefn, approx = false)
+
 Create a new field on a layer.
 
 ### Parameters
@@ -713,6 +778,8 @@ function addfielddefn!(
 end
 
 """
+    addgeomdefn!(layer::AbstractFeatureLayer, field::AbstractGeomFieldDefn, approx = false)
+
 Create a new geometry field on a layer.
 
 ### Parameters
@@ -922,6 +989,8 @@ end
 # end
 
 """
+    reference(layer::AbstractFeatureLayer)
+
 Increment layer reference count.
 
 ### Returns
@@ -930,6 +999,8 @@ The reference count after incrementing.
 reference(layer::AbstractFeatureLayer) = GDAL.ogr_l_reference(layer.ptr)
 
 """
+    dereference(layer::AbstractFeatureLayer)
+
 Decrement layer reference count.
 
 ### Returns
@@ -937,7 +1008,11 @@ The reference count after decrementing.
 """
 dereference(layer::AbstractFeatureLayer) = GDAL.ogr_l_dereference(layer.ptr)
 
-"The current reference count for the layer object itself."
+"""
+    nreference(layer::AbstractFeatureLayer)
+
+The current reference count for the layer object itself.
+"""
 nreference(layer::AbstractFeatureLayer) = GDAL.ogr_l_getrefcount(layer.ptr)
 
 # """
@@ -971,14 +1046,24 @@ nreference(layer::AbstractFeatureLayer) = GDAL.ogr_l_getrefcount(layer.ptr)
 # getfeaturesread(layer::AbstractFeatureLayer) =
 #     GDAL.ogr_l_getfeaturesread(layer.ptr)
 
-"The name of the FID column in the database, or \"\" if not supported."
+"""
+    fidcolumnname(layer::AbstractFeatureLayer)
+
+The name of the FID column in the database, or \"\" if not supported.
+"""
 fidcolumnname(layer::AbstractFeatureLayer) = GDAL.ogr_l_getfidcolumn(layer.ptr)
 
-"The name of the geometry column in the database, or \"\" if not supported."
+"""
+    geomcolumnname(layer::AbstractFeatureLayer)
+
+The name of the geometry column in the database, or \"\" if not supported.
+"""
 geomcolumnname(layer::AbstractFeatureLayer) =
     GDAL.ogr_l_getgeometrycolumn(layer.ptr)
 
 """
+    setignoredfields!(layer::AbstractFeatureLayer, fieldnames)
+
 Set which fields can be omitted when retrieving features from the layer.
 
 ### Parameters

--- a/src/ogr/fielddefn.jl
+++ b/src/ogr/fielddefn.jl
@@ -1,4 +1,6 @@
 """
+    unsafe_createfielddefn(name::AbstractString, etype::OGRFieldType)
+
 Create a new field definition.
 
 By default, fields have no width, precision, are nullable and not ignored.
@@ -37,6 +39,8 @@ function settype!(fielddefn::FieldDefn, etype::OGRFieldType)
 end
 
 """
+    getsubtype(fielddefn::AbstractFieldDefn)
+
 Fetch subtype of this field.
 
 ### Parameters
@@ -49,6 +53,8 @@ getsubtype(fielddefn::AbstractFieldDefn) =
     GDAL.ogr_fld_getsubtype(fielddefn.ptr)
 
 """
+    setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)
+
 Set the subtype of this field.
 
 This should never be done to an OGRFieldDefn that is already part of an
@@ -64,6 +70,8 @@ function setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)
 end
 
 """
+    getjustify(fielddefn::AbstractFieldDefn)
+
 Get the justification for this field.
 
 Note: no driver is know to use the concept of field justification.
@@ -72,6 +80,8 @@ getjustify(fielddefn::AbstractFieldDefn) =
     GDAL.ogr_fld_getjustify(fielddefn.ptr)
 
 """
+    setjustify!(fielddefn::FieldDefn, ejustify::OGRJustification)
+
 Set the justification for this field.
 
 Note: no driver is know to use the concept of field justification.
@@ -81,7 +91,10 @@ function setjustify!(fielddefn::FieldDefn, ejustify::OGRJustification)
     return fielddefn
 end
 
-"""Get the formatting width for this field.
+"""
+    getwidth(fielddefn::AbstractFieldDefn)
+
+Get the formatting width for this field.
 
 ### Returns
 the width, zero means no specified width.
@@ -89,6 +102,8 @@ the width, zero means no specified width.
 getwidth(fielddefn::AbstractFieldDefn) = GDAL.ogr_fld_getwidth(fielddefn.ptr)
 
 """
+    setwidth!(fielddefn::FieldDefn, width::Integer)
+
 Set the formatting width for this field in characters.
 
 This should never be done to an OGRFieldDefn that is already part of an
@@ -100,6 +115,8 @@ function setwidth!(fielddefn::FieldDefn, width::Integer)
 end
 
 """
+    getprecision(fielddefn::AbstractFieldDefn)
+
 Get the formatting precision for this field.
 
 This should normally be zero for fields of types other than OFTReal.
@@ -108,6 +125,8 @@ getprecision(fielddefn::AbstractFieldDefn) =
     GDAL.ogr_fld_getprecision(fielddefn.ptr)
 
 """
+    setprecision!(fielddefn::FieldDefn, precision::Integer)
+
 Set the formatting precision for this field in characters.
 
 This should normally be zero for fields of types other than OFTReal.
@@ -118,6 +137,8 @@ function setprecision!(fielddefn::FieldDefn, precision::Integer)
 end
 
 """
+    setparams!(fielddefn, name, etype, [nwidth, [nprecision, [justify]]])
+
 Set defining parameters for a field in one call.
 
 ### Parameters
@@ -140,17 +161,27 @@ function setparams!(
     return fielddefn
 end
 
-"Return whether this field should be omitted when fetching features."
+"""
+    isignored(fielddefn::AbstractFieldDefn)
+
+Return whether this field should be omitted when fetching features.
+"""
 isignored(fielddefn::AbstractFieldDefn) =
     Bool(GDAL.ogr_fld_isignored(fielddefn.ptr))
 
-"Set whether this field should be omitted when fetching features."
+"""
+    setignored!(fielddefn::FieldDefn, ignore::Bool)
+
+Set whether this field should be omitted when fetching features.
+"""
 function setignored!(fielddefn::FieldDefn, ignore::Bool)
     GDAL.ogr_fld_setignored(fielddefn.ptr, ignore)
     return fielddefn
 end
 
 """
+    isnullable(fielddefn::AbstractFieldDefn)
+
 Return whether this field can receive null values.
 
 By default, fields are nullable.
@@ -164,6 +195,8 @@ isnullable(fielddefn::AbstractFieldDefn) =
     Bool(GDAL.ogr_fld_isnullable(fielddefn.ptr))
 
 """
+    setnullable!(fielddefn::FieldDefn, nullable::Bool)
+
 Set whether this field can receive null values.
 
 By default, fields are nullable, so this method is generally called with `false`
@@ -177,7 +210,11 @@ function setnullable!(fielddefn::FieldDefn, nullable::Bool)
     return fielddefn
 end
 
-"Get default field value"
+"""
+    getdefault(fielddefn::AbstractFieldDefn)
+
+Get default field value
+"""
 function getdefault(fielddefn::AbstractFieldDefn)
     result = @gdal(OGR_Fld_GetDefault::Cstring, fielddefn.ptr::GDALFieldDefn)
     if result == C_NULL
@@ -188,6 +225,8 @@ function getdefault(fielddefn::AbstractFieldDefn)
 end
 
 """
+    setdefault!(fielddefn::AbstractFieldDefn, default)
+
 Set default field value.
 
 The default field value is taken into account by drivers (generally those with
@@ -213,6 +252,8 @@ function setdefault!(fielddefn::AbstractFieldDefn, default)
 end
 
 """
+    isdefaultdriverspecific(fielddefn::AbstractFieldDefn)
+
 Returns whether the default value is driver specific.
 
 Driver specific default values are those that are not NULL, a numeric value, a
@@ -222,7 +263,11 @@ CURRENT_TIME, CURRENT_DATE or datetime literal value.
 isdefaultdriverspecific(fielddefn::AbstractFieldDefn) =
     Bool(GDAL.ogr_fld_isdefaultdriverspecific(fielddefn.ptr))
 
-"Create a new field geometry definition."
+"""
+    unsafe_creategeomdefn(name::AbstractString, etype::OGRwkbGeometryType)
+
+Create a new field geometry definition.
+"""
 unsafe_creategeomdefn(name::AbstractString, etype::OGRwkbGeometryType) =
     GeomFieldDefn(GDAL.ogr_gfld_create(name, etype))
 
@@ -259,7 +304,11 @@ function settype!(geomdefn::GeomFieldDefn, etype::OGRwkbGeometryType)
     return geomdefn
 end
 
-"Returns a clone of the spatial reference system for this field. May be NULL."
+"""
+    getspatialref(geomdefn::AbstractGeomFieldDefn)
+
+Returns a clone of the spatial reference system for this field. May be NULL.
+"""
 function getspatialref(geomdefn::AbstractGeomFieldDefn)
     result = GDAL.ogr_gfld_getspatialref(geomdefn.ptr)
     if result == C_NULL
@@ -283,6 +332,8 @@ function unsafe_getspatialref(geomdefn::AbstractGeomFieldDefn)
 end
 
 """
+    setspatialref!(geomdefn::GeomFieldDefn, spatialref::AbstractSpatialRef)
+
 Set the spatial reference of this field.
 
 This function drops the reference of the previously set SRS object and acquires
@@ -299,6 +350,8 @@ function setspatialref!(
 end
 
 """
+    isnullable(geomdefn::AbstractGeomFieldDefn)
+
 Return whether this geometry field can receive null values.
 
 By default, fields are nullable.
@@ -314,6 +367,8 @@ isnullable(geomdefn::AbstractGeomFieldDefn) =
     Bool(GDAL.ogr_gfld_isnullable(geomdefn.ptr))
 
 """
+    setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)
+
 Set whether this geometry field can receive null values.
 
 By default, fields are nullable, so this method is generally called with `false`
@@ -327,11 +382,19 @@ function setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)
     return geomdefn
 end
 
-"Return whether this field should be omitted when fetching features."
+"""
+    isignored(geomdefn::AbstractGeomFieldDefn)
+
+Return whether this field should be omitted when fetching features.
+"""
 isignored(geomdefn::AbstractGeomFieldDefn) =
     Bool(GDAL.ogr_gfld_isignored(geomdefn.ptr))
 
-"Set whether this field should be omitted when fetching features."
+"""
+    setignored!(geomdefn::GeomFieldDefn, ignore::Bool)
+
+Set whether this field should be omitted when fetching features.
+"""
 function setignored!(geomdefn::GeomFieldDefn, ignore::Bool)
     GDAL.ogr_gfld_setignored(geomdefn.ptr, ignore)
     return geomdefn

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1,4 +1,6 @@
 """
+    fromWKB(data)
+
 Create a geometry object of the appropriate type from it's well known
 binary (WKB) representation.
 
@@ -30,6 +32,8 @@ function unsafe_fromWKB(data)
 end
 
 """
+    fromWKT(data::Vector{String})
+
 Create a geometry object of the appropriate type from its well known text
 (WKT) representation.
 
@@ -75,7 +79,11 @@ function destroy(geom::AbstractGeometry)
     geom.ptr = C_NULL
 end
 
-"Returns a copy of the geometry with the original spatial reference system."
+"""
+    clone(geom::AbstractGeometry)
+
+Returns a copy of the geometry with the original spatial reference system.
+"""
 function clone(geom::AbstractGeometry)
     if geom.ptr == C_NULL
         return IGeometry()
@@ -93,18 +101,22 @@ function unsafe_clone(geom::AbstractGeometry)
 end
 
 """
+    creategeom(geomtype::OGRwkbGeometryType)
+
 Create an empty geometry of desired type.
 
 This is equivalent to allocating the desired geometry with new, but the
 allocation is guaranteed to take place in the context of the GDAL/OGR heap.
 """
-creategeom(geomtype::OGRwkbGeometryType) = 
+creategeom(geomtype::OGRwkbGeometryType) =
     IGeometry(GDAL.ogr_g_creategeometry(geomtype))
 
 unsafe_creategeom(geomtype::OGRwkbGeometryType) =
     Geometry(GDAL.ogr_g_creategeometry(geomtype))
 
 """
+    forceto(geom::AbstractGeometry, targettype::OGRwkbGeometryType, [options])
+
 Tries to force the provided geometry to the specified geometry type.
 
 ### Parameters
@@ -141,6 +153,8 @@ function unsafe_forceto(
 end
 
 """
+    geomdim(geom::AbstractGeometry)
+
 Get the dimension of the geometry. 0 for points, 1 for lines and 2 for surfaces.
 
 This function corresponds to the SFCOM IGeometry::GetDimension() method. It
@@ -150,6 +164,8 @@ the underlying space (as indicated by OGR_G_GetCoordinateDimension() function).
 geomdim(geom::AbstractGeometry) = GDAL.ogr_g_getdimension(geom.ptr)
 
 """
+    getcoorddim(geom::AbstractGeometry)
+
 Get the dimension of the coordinates in this geometry.
 
 ### Returns
@@ -160,6 +176,8 @@ getcoorddim(geom::AbstractGeometry) =
     GDAL.ogr_g_getcoordinatedimension(geom.ptr)
 
 """
+    setcoorddim!(geom::AbstractGeometry, dim::Integer)
+
 Set the coordinate dimension.
 
 This method sets the explicit coordinate dimension. Setting the coordinate
@@ -173,14 +191,22 @@ function setcoorddim!(geom::AbstractGeometry, dim::Integer)
     return geom
 end
 
-"Computes and returns the bounding envelope for this geometry"
+"""
+    envelope(geom::AbstractGeometry)
+
+Computes and returns the bounding envelope for this geometry.
+"""
 function envelope(geom::AbstractGeometry)
     envelope = Ref{GDAL.OGREnvelope}(GDAL.OGREnvelope(0, 0, 0, 0))
     GDAL.ogr_g_getenvelope(geom.ptr, envelope)
     return envelope[]
 end
 
-"Computes and returns the bounding envelope (3D) for this geometry"
+"""
+    envelope3d(geom::AbstractGeometry)
+
+Computes and returns the bounding envelope (3D) for this geometry
+"""
 function envelope3d(geom::AbstractGeometry)
     envelope = Ref{GDAL.OGREnvelope3D}(GDAL.OGREnvelope3D(0, 0, 0, 0, 0, 0))
     GDAL.ogr_g_getenvelope3d(geom.ptr, envelope)
@@ -188,6 +214,8 @@ function envelope3d(geom::AbstractGeometry)
 end
 
 """
+    toWKB(geom::AbstractGeometry, order::OGRwkbByteOrder = GDAL.wkbNDR)
+
 Convert a geometry well known binary format.
 
 ### Parameters
@@ -202,6 +230,8 @@ function toWKB(geom::AbstractGeometry, order::OGRwkbByteOrder = GDAL.wkbNDR)
 end
 
 """
+    toISOWKB(geom::AbstractGeometry, order::OGRwkbByteOrder = GDAL.wkbNDR)
+
 Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known binary format.
 
 ### Parameters
@@ -215,10 +245,18 @@ function toISOWKB(geom::AbstractGeometry, order::OGRwkbByteOrder = GDAL.wkbNDR)
     return buffer
 end
 
-"Returns size (in bytes) of related binary representation."
+"""
+    wkbsize(geom::AbstractGeometry)
+
+Returns size (in bytes) of related binary representation.
+"""
 wkbsize(geom::AbstractGeometry) = GDAL.ogr_g_wkbsize(geom.ptr)
 
-"Convert a geometry into well known text format."
+"""
+    toWKT(geom::AbstractGeometry)
+
+Convert a geometry into well known text format.
+"""
 function toWKT(geom::AbstractGeometry)
     wkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttowkt(geom.ptr, wkt_ptr)
@@ -228,7 +266,11 @@ function toWKT(geom::AbstractGeometry)
     return wkt
 end
 
-"Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format."
+"""
+    toISOWKT(geom::AbstractGeometry)
+
+Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
+"""
 function toISOWKT(geom::AbstractGeometry)
     isowkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttoisowkt(geom.ptr, isowkt_ptr)
@@ -238,19 +280,33 @@ function toISOWKT(geom::AbstractGeometry)
     return wkt
 end
 
-"Fetch geometry type code"
+"""
+    getgeomtype(geom::AbstractGeometry)
+
+Fetch geometry type code
+"""
 getgeomtype(geom::AbstractGeometry) = GDAL.ogr_g_getgeometrytype(geom.ptr)
 
-"Fetch WKT name for geometry type."
+"""
+    geomname(geom::AbstractGeometry)
+
+Fetch WKT name for geometry type.
+"""
 geomname(geom::AbstractGeometry) = GDAL.ogr_g_getgeometryname(geom.ptr)
 
-"Convert geometry to strictly 2D."
+"""
+    flattento2d!(geom::AbstractGeometry)
+
+Convert geometry to strictly 2D.
+"""
 function flattento2d!(geom::AbstractGeometry)
     GDAL.ogr_g_flattento2d(geom.ptr)
     return geom
 end
 
 """
+    closerings!(geom::AbstractGeometry)
+
 Force rings to be closed.
 
 If this geometry, or any contained geometries has polygon rings that are not
@@ -262,6 +318,8 @@ function closerings!(geom::AbstractGeometry)
 end
 
 """
+    fromGML(data)
+
 Create geometry from GML.
 
 This method translates a fragment of GML containing only the geometry portion
@@ -275,29 +333,49 @@ fromGML(data) = IGeometry(GDAL.ogr_g_createfromgml(data))
 
 unsafe_fromGML(data) = Geometry(GDAL.ogr_g_createfromgml(data))
 
-"Convert a geometry into GML format."
+"""
+    toGML(geom::AbstractGeometry)
+
+Convert a geometry into GML format.
+"""
 toGML(geom::AbstractGeometry) = GDAL.ogr_g_exporttogml(geom.ptr)
 
-"Convert a geometry into KML format."
+"""
+    toKML(geom::AbstractGeometry, altitudemode = C_NULL)
+
+Convert a geometry into KML format.
+"""
 toKML(geom::AbstractGeometry, altitudemode = C_NULL) =
     GDAL.ogr_g_exporttokml(geom.ptr, altitudemode)
 # ↑ * `altitudemode`: value to write in altitudeMode element, or NULL.
 
-"Convert a geometry into GeoJSON format."
+"""
+    toJSON(geom::AbstractGeometry)
+
+Convert a geometry into GeoJSON format.
+"""
 toJSON(geom::AbstractGeometry) = GDAL.ogr_g_exporttojson(geom.ptr)
 
 """
+    toJSON(geom::AbstractGeometry, options)
+
 Convert a geometry into GeoJSON format.
+
 ### Parameters
 * `geom`: handle to the geometry.
 * `options`: a list of options.
+
 ### Returns
 A GeoJSON fragment or NULL in case of error.
 """
 toJSON(geom::AbstractGeometry, options) =
     GDAL.ogr_g_exporttojsonex(geom.ptr, options)
 
-"Create a geometry object from its GeoJSON representation"
+"""
+    fromJSON(data::String)
+
+Create a geometry object from its GeoJSON representation.
+"""
 fromJSON(data::String) = IGeometry(GDAL.ogr_g_creategeometryfromjson(data))
 
 unsafe_fromJSON(data::String) =
@@ -323,6 +401,8 @@ unsafe_fromJSON(data::String) =
 # end
 
 """
+    getspatialref(geom::AbstractGeometry)
+
 Returns a clone of the spatial reference system for the geometry.
 
 (The original SRS may be shared with many objects, and should not be modified.)
@@ -352,6 +432,8 @@ function unsafe_getspatialref(geom::AbstractGeometry)
 end
 
 """
+    transform!(geom::AbstractGeometry, coordtransform::CoordTransform)
+
 Apply arbitrary coordinate transformation to geometry.
 
 ### Parameters
@@ -394,6 +476,8 @@ end
 # end
 
 """
+    simplify(geom::AbstractGeometry, tol::Real)
+
 Compute a simplified geometry.
 
 ### Parameters
@@ -407,6 +491,8 @@ unsafe_simplify(geom::AbstractGeometry, tol::Real) =
     Geometry(GDAL.ogr_g_simplify(geom.ptr, tol))
 
 """
+    simplifypreservetopology(geom::AbstractGeometry, tol::Real)
+
 Simplify the geometry while preserving topology.
 
 ### Parameters
@@ -420,6 +506,8 @@ unsafe_simplifypreservetopology(geom::AbstractGeometry, tol::Real) =
     Geometry(GDAL.ogr_g_simplifypreservetopology(geom.ptr, tol))
 
 """
+    delaunaytriangulation(geom::AbstractGeometry, tol::Real, onlyedges::Bool)
+
 Return a Delaunay triangulation of the vertices of the geometry.
 
 ### Parameters
@@ -440,6 +528,8 @@ function unsafe_delaunaytriangulation(
 end
 
 """
+    segmentize!(geom::AbstractGeometry, maxlength::Real)
+
 Modify the geometry such it has no segment longer than the given distance.
 
 Interpolated points will have Z and M values (if needed) set to 0. Distance
@@ -455,6 +545,8 @@ function segmentize!(geom::AbstractGeometry, maxlength::Real)
 end
 
 """
+    intersects(g1::AbstractGeometry, g2::AbstractGeometry)
+
 Returns whether the geometries intersect
 
 Determines whether two geometries intersect. If GEOS is enabled, then this is
@@ -464,35 +556,65 @@ boxes) of the two geometries overlap.
 intersects(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_intersects(g1.ptr, g2.ptr))
 
-"Returns `true` if the geometries are equivalent."
+"""
+    equals(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if the geometries are equivalent.
+"""
 equals(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_equals(g1.ptr, g2.ptr))
 
-"Returns `true` if the geometries are disjoint."
+"""
+    disjoint(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if the geometries are disjoint.
+"""
 disjoint(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_disjoint(g1.ptr, g2.ptr))
 
-"Returns `true` if the geometries are touching."
+"""
+    touches(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if the geometries are touching.
+"""
 touches(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_touches(g1.ptr, g2.ptr))
 
-"Returns `true` if the geometries are crossing."
+"""
+    crosses(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if the geometries are crossing.
+"""
 crosses(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_crosses(g1.ptr, g2.ptr))
 
-"Returns `true` if g1 is contained within g2."
+"""
+    within(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if g1 is contained within g2.
+"""
 within(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_within(g1.ptr, g2.ptr))
 
-"Returns `true` if g1 contains g2."
+"""
+    contains(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if g1 contains g2.
+"""
 contains(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_contains(g1.ptr, g2.ptr))
 
-"Returns `true` if the geometries overlap."
+"""
+    overlaps(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns `true` if the geometries overlap.
+"""
 overlaps(g1::AbstractGeometry, g2::AbstractGeometry) =
     Bool(GDAL.ogr_g_overlaps(g1.ptr, g2.ptr))
 
 """
+    boundary(geom::AbstractGeometry)
+
 Returns the boundary of the geometry.
 
 A new geometry object is created and returned containing the boundary of the
@@ -504,6 +626,8 @@ unsafe_boundary(geom::AbstractGeometry) =
     Geometry(GDAL.ogr_g_boundary(geom.ptr))
 
 """
+    convexhull(geom::AbstractGeometry)
+
 Returns the convex hull of the geometry.
 
 A new geometry object is created and returned containing the convex hull of the
@@ -515,6 +639,8 @@ unsafe_convexhull(geom::AbstractGeometry) =
     Geometry(GDAL.ogr_g_convexhull(geom.ptr))
 
 """
+    buffer(geom::AbstractGeometry, dist::Real, quadsegs::Integer = 30)
+
 Compute buffer of geometry.
 
 Builds a new geometry containing the buffer region around the geometry on which
@@ -542,6 +668,8 @@ unsafe_buffer(geom::AbstractGeometry, dist::Real, quadsegs::Integer = 30) =
     Geometry(GDAL.ogr_g_buffer(geom.ptr, dist, quadsegs))
 
 """
+    intersection(g1::AbstractGeometry, g2::AbstractGeometry)
+
 Returns a new geometry representing the intersection of the geometries, or NULL
 if there is no intersection or an error occurs.
 
@@ -555,7 +683,11 @@ intersection(g1::AbstractGeometry, g2::AbstractGeometry) =
 unsafe_intersection(g1::AbstractGeometry, g2::AbstractGeometry) =
     Geometry(GDAL.ogr_g_intersection(g1.ptr, g2.ptr))
 
-"Returns a new geometry representing the union of the geometries."
+"""
+    union(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns a new geometry representing the union of the geometries.
+"""
 union(g1::AbstractGeometry, g2::AbstractGeometry) =
     IGeometry(GDAL.ogr_g_union(g1.ptr, g2.ptr))
 
@@ -563,6 +695,8 @@ unsafe_union(g1::AbstractGeometry, g2::AbstractGeometry) =
     Geometry(GDAL.ogr_g_union(g1.ptr, g2.ptr))
 
 """
+    pointonsurface(geom::AbstractGeometry)
+
 Returns a point guaranteed to lie on the surface.
 
 This method relates to the SFCOM ISurface::get_PointOnSurface() method however
@@ -577,6 +711,8 @@ unsafe_pointonsurface(geom::AbstractGeometry) =
     Geometry(GDAL.ogr_g_pointonsurface(geom.ptr))
 
 """
+    difference(g1::AbstractGeometry, g2::AbstractGeometry)
+
 Generates a new geometry which is the region of this geometry with the region of
 the other geometry removed.
 
@@ -591,6 +727,8 @@ unsafe_difference(g1::AbstractGeometry, g2::AbstractGeometry) =
     Geometry(GDAL.ogr_g_difference(g1.ptr, g2.ptr))
 
 """
+    symdifference(g1::AbstractGeometry, g2::AbstractGeometry)
+
 Returns a new geometry representing the symmetric difference of the geometries
 or NULL if the difference is empty or an error occurs.
 """
@@ -600,17 +738,31 @@ symdifference(g1::AbstractGeometry, g2::AbstractGeometry) =
 unsafe_symdifference(g1::AbstractGeometry, g2::AbstractGeometry) =
     Geometry(GDAL.ogr_g_symdifference(g1.ptr, g2.ptr))
 
-"Returns the distance between the geometries or -1 if an error occurs."
+"""
+    distance(g1::AbstractGeometry, g2::AbstractGeometry)
+
+Returns the distance between the geometries or -1 if an error occurs.
+"""
 distance(g1::AbstractGeometry, g2::AbstractGeometry) =
     GDAL.ogr_g_distance(g1.ptr, g2.ptr)
 
-"Returns the length of the geometry, or 0.0 for unsupported geometry types."
+"""
+    geomlength(geom::AbstractGeometry)
+
+Returns the length of the geometry, or 0.0 for unsupported geometry types.
+"""
 geomlength(geom::AbstractGeometry) = GDAL.ogr_g_length(geom.ptr)
 
-"Returns the area of the geometry or 0.0 for unsupported geometry types."
+"""
+    geomarea(geom::AbstractGeometry)
+
+Returns the area of the geometry or 0.0 for unsupported geometry types.
+"""
 geomarea(geom::AbstractGeometry) = GDAL.ogr_g_area(geom.ptr)
 
 """
+    centroid!(geom::AbstractGeometry, centroid::AbstractGeometry)
+
 Compute the geometry centroid.
 
 The centroid location is applied to the passed in OGRPoint object. The centroid
@@ -629,6 +781,8 @@ function centroid!(geom::AbstractGeometry, centroid::AbstractGeometry)
 end
 
 """
+    centroid(geom::AbstractGeometry)
+
 Compute the geometry centroid.
 
 The centroid is not necessarily within the geometry.
@@ -652,6 +806,8 @@ function unsafe_centroid(geom::AbstractGeometry)
 end
 
 """
+    pointalongline(geom::AbstractGeometry, distance::Real)
+
 Fetch point at given distance along curve.
 
 ### Parameters
@@ -669,6 +825,8 @@ unsafe_pointalongline(geom::AbstractGeometry, distance::Real) =
     Geometry(GDAL.ogr_g_value(geom.ptr, distance))
 
 """
+    empty!(geom::AbstractGeometry)
+
 Clear geometry information.
 
 This restores the geometry to its initial state after construction, and before
@@ -679,19 +837,37 @@ function empty!(geom::AbstractGeometry)
     return geom
 end
 
-"Returns `true` if the geometry has no points, otherwise `false`."
+"""
+    isempty(geom::AbstractGeometry)
+
+Returns `true` if the geometry has no points, otherwise `false`.
+"""
 isempty(geom::AbstractGeometry) = Bool(GDAL.ogr_g_isempty(geom.ptr))
 
-"Returns `true` if the geometry is valid, otherwise `false`."
+"""
+    isvalid(geom::AbstractGeometry)
+
+Returns `true` if the geometry is valid, otherwise `false`.
+"""
 isvalid(geom::AbstractGeometry) = Bool(GDAL.ogr_g_isvalid(geom.ptr))
 
-"Returns `true` if the geometry is simple, otherwise `false`."
+"""
+    issimple(geom::AbstractGeometry)
+
+Returns `true` if the geometry is simple, otherwise `false`.
+"""
 issimple(geom::AbstractGeometry) = Bool(GDAL.ogr_g_issimple(geom.ptr))
 
-"Returns `true` if the geometry is a ring, otherwise `false`."
+"""
+    isring(geom::AbstractGeometry)
+
+Returns `true` if the geometry is a ring, otherwise `false`.
+"""
 isring(geom::AbstractGeometry) = Bool(GDAL.ogr_g_isring(geom.ptr))
 
 """
+    polygonize(geom::AbstractGeometry)
+
 Polygonizes a set of sparse edges.
 
 A new geometry object is created and returned containing a collection of
@@ -735,16 +911,30 @@ unsafe_polygonize(geom::AbstractGeometry) =
 # end
 
 
-"Fetch the x coordinate of a point from a geometry, at index i."
+"""
+    getx(geom::AbstractGeometry, i::Integer)
+
+Fetch the x coordinate of a point from a geometry, at index i.
+"""
 getx(geom::AbstractGeometry, i::Integer) = GDAL.ogr_g_getx(geom.ptr, i)
 
-"Fetch the y coordinate of a point from a geometry, at index i."
+"""
+    gety(geom::AbstractGeometry, i::Integer)
+
+Fetch the y coordinate of a point from a geometry, at index i.
+"""
 gety(geom::AbstractGeometry, i::Integer) = GDAL.ogr_g_gety(geom.ptr, i)
 
-"Fetch the z coordinate of a point from a geometry, at index i."
+"""
+    getz(geom::AbstractGeometry, i::Integer)
+
+Fetch the z coordinate of a point from a geometry, at index i.
+"""
 getz(geom::AbstractGeometry, i::Integer) = GDAL.ogr_g_getz(geom.ptr, i)
 
 """
+    getpoint(geom::AbstractGeometry, i::Integer)
+
 Fetch a point in line string or a point geometry, at index i.
 
 ### Parameters
@@ -759,6 +949,8 @@ function getpoint!(geom::AbstractGeometry, i::Integer, x, y, z)
 end
 
 """
+    setpointcount!(geom::AbstractGeometry, n::Integer)
+
 Set number of points in a geometry.
 
 ### Parameters
@@ -771,6 +963,9 @@ function setpointcount!(geom::AbstractGeometry, n::Integer)
 end
 
 """
+    setpoint!(geom::AbstractGeometry, i::Integer, x, y)
+    setpoint!(geom::AbstractGeometry, i::Integer, x, y, z)
+
 Set the location of a vertex in a point or linestring geometry.
 
 ### Parameters
@@ -780,6 +975,8 @@ Set the location of a vertex in a point or linestring geometry.
 * `y`: input Y coordinate to assign.
 * `z`: input Z coordinate to assign (defaults to zero).
 """
+function setpoint! end
+
 function setpoint!(
         geom::AbstractGeometry,
         i::Integer,
@@ -791,21 +988,15 @@ function setpoint!(
     return geom
 end
 
-"""
-Set the location of a vertex in a point or linestring geometry.
-
-### Parameters
-* `geom`: handle to the geometry to add a vertex to.
-* `i`: the index of the vertex to assign (zero based) or zero for a point.
-* `x`: input X coordinate to assign.
-* `y`: input Y coordinate to assign.
-"""
 function setpoint!(geom::AbstractGeometry, i::Integer, x::Real, y::Real)
     GDAL.ogr_g_setpoint_2d(geom.ptr, i, x, y)
     return geom
 end
 
 """
+    addpoint!(geom::AbstractGeometry, x, y)
+    addpoint!(geom::AbstractGeometry, x, y, z)
+
 Add a point to a geometry (line string or point).
 
 ### Parameters
@@ -814,19 +1005,13 @@ Add a point to a geometry (line string or point).
 * `y`: y coordinate of point to add.
 * `z`: z coordinate of point to add.
 """
+function addpoint! end
+
 function addpoint!(geom::AbstractGeometry, x::Real, y::Real, z::Real)
     GDAL.ogr_g_addpoint(geom.ptr, x, y, z)
     return geom
 end
 
-"""
-Add a point to a geometry (line string or point).
-
-### Parameters
-* `geom`: the geometry to add a point to.
-* `x`: x coordinate of point to add.
-* `y`: y coordinate of point to add.
-"""
 function addpoint!(geom::AbstractGeometry, x::Real, y::Real)
     GDAL.ogr_g_addpoint_2d(geom.ptr, x, y)
     return geom
@@ -862,6 +1047,8 @@ end
 
 
 """
+    ngeom(geom::AbstractGeometry)
+
 The number of elements in a geometry or number of geometries in container.
 
 This corresponds to
@@ -878,6 +1065,8 @@ function ngeom(geom::AbstractGeometry)
 end
 
 """
+    getgeom(geom::AbstractGeometry, i::Integer)
+
 Fetch geometry from a geometry container.
 
 For a polygon, `getgeom(polygon,i)` returns the exterior ring if
@@ -920,6 +1109,8 @@ function unsafe_getgeom(geom::AbstractGeometry, i::Integer)
 end
 
 """
+    addgeom!(geomcontainer::AbstractGeometry, subgeom::AbstractGeometry)
+
 Add a geometry to a geometry container.
 
 Some subclasses of OGRGeometryCollection restrict the types of geometry that can
@@ -965,6 +1156,8 @@ end
 # end
 
 """
+    removegeom!(geom::AbstractGeometry, i::Integer, todelete::Bool = true)
+
 Remove a geometry from an exiting geometry container.
 
 ### Parameters
@@ -982,6 +1175,8 @@ function removegeom!(geom::AbstractGeometry, i::Integer, todelete::Bool = true)
 end
 
 """
+    removeallgeoms!(geom::AbstractGeometry, todelete::Bool = true)
+
 Remove all geometries from an exiting geometry container.
 
 ### Parameters
@@ -997,6 +1192,8 @@ function removeallgeoms!(geom::AbstractGeometry, todelete::Bool = true)
 end
 
 """
+    hascurvegeom(geom::AbstractGeometry, nonlinear::Bool)
+
 Returns if this geometry is or has curve geometry.
 
 ### Parameters
@@ -1008,6 +1205,8 @@ hascurvegeom(geom::AbstractGeometry, nonlinear::Bool) =
     Bool(GDAL.ogr_g_hascurvegeometry(geom.ptr, nonlinear))
 
 """
+    lineargeom(geom::AbstractGeometry, stepsize::Real = 0)
+
 Return, possibly approximate, linear version of this geometry.
 
 Returns a geometry that has no CIRCULARSTRING, COMPOUNDCURVE, CURVEPOLYGON,
@@ -1038,6 +1237,8 @@ function unsafe_lineargeom(
 end
 
 """
+    curvegeom(geom::AbstractGeometry)
+
 Return curve version of this geometry.
 
 Returns a geometry that has possibly CIRCULARSTRING, COMPOUNDCURVE,
@@ -1055,6 +1256,8 @@ unsafe_curvegeom(geom::AbstractGeometry) =
     Geometry(GDAL.ogr_g_getcurvegeometry(geom.ptr, C_NULL))
 
 """
+    polygonfromedges(lines::AbstractGeometry, tol::Real; besteffort = false, autoclose = false)
+
 Build a ring from a bunch of arcs.
 
 ### Parameters
@@ -1094,6 +1297,8 @@ function unsafe_polygonfromedges(
 end
 
 """
+    setnonlineargeomflag!(flag::Bool)
+
 Set flag to enable/disable returning non-linear geometries in the C API.
 
 This flag has only an effect on the OGR_F_GetGeometryRef(),
@@ -1118,7 +1323,11 @@ a point or NULL.
 setnonlineargeomflag!(flag::Bool) =
     GDAL.ogrsetnonlineargeometriesenabledflag(flag)
 
-"Get flag to enable/disable returning non-linear geometries in the C API."
+"""
+    getnonlineargeomflag()
+
+Get flag to enable/disable returning non-linear geometries in the C API.
+"""
 getnonlineargeomflag() = Bool(GDAL.ogrgetnonlineargeometriesenabledflag())
 
 for (geom, wkbgeom) in ((:geomcollection,       GDAL.wkbGeometryCollection),

--- a/src/ogr/styletable.jl
+++ b/src/ogr/styletable.jl
@@ -1,4 +1,6 @@
 """
+    unsafe_createstylemanager(styletable = GDALStyleTable(C_NULL))
+
 OGRStyleMgr factory.
 
 ### Parameters
@@ -23,6 +25,8 @@ end
 
 
 """
+    initialize!(stylemanager::StyleManager, feature::Feature)
+
 Initialize style manager from the style string of a feature.
 
 ### Parameters
@@ -36,6 +40,8 @@ initialize!(stylemanager::StyleManager, feature::Feature) =
     GDAL.ogr_sm_initfromfeature(stylemanager.ptr, feature.ptr)
 
 """
+    initialize!(stylemanager::StyleManager, stylestring = C_NULL)
+
 Initialize style manager from the style string.
 
 ### Parameters
@@ -48,6 +54,9 @@ initialize!(stylemanager::StyleManager, stylestring = C_NULL) =
     Bool(GDAL.ogr_sm_initstylestring(stylemanager.ptr, stylestring))
 
 """
+    npart(stylemanager::StyleManager)
+    npart(stylemanager::StyleManager, stylestring::AbstractString)
+
 Get the number of parts in a style.
 
 ### Parameters
@@ -58,6 +67,8 @@ Get the number of parts in a style.
 ### Returns
 the number of parts (style tools) in the style.
 """
+function npart end
+
 npart(stylemanager::StyleManager) =
     GDAL.ogr_sm_getpartcount(stylemanager.ptr, C_NULL)
 
@@ -65,6 +76,8 @@ npart(stylemanager::StyleManager, stylestring::AbstractString) =
     GDAL.ogr_sm_getpartcount(stylemanager.ptr, stylestring)
 
 """
+    unsafe_getpart(stylemanager::StyleManager, id::Integer, stylestring = C_NULL)
+
 Fetch a part (style tool) from the current style.
 
 ### Parameters
@@ -80,6 +93,8 @@ unsafe_getpart(stylemanager::StyleManager, id::Integer, stylestring = C_NULL) =
     StyleTool(GDAL.ogr_sm_getpart(stylemanager.ptr, id, stylestring))
 
 """
+    addpart!(stylemanager::StyleManager, styletool::StyleTool)
+
 Add a part (style tool) to the current style.
 
 ### Parameters
@@ -93,6 +108,8 @@ addpart!(stylemanager::StyleManager, styletool::StyleTool) =
     Bool(GDAL.ogr_sm_addpart(stylemanager.ptr, styletool.ptr))
 
 """
+    addstyle!(stylemanager::StyleManager, stylename, stylestring)
+
 Add a style to the current style table.
 
 ### Parameters
@@ -116,6 +133,8 @@ addstyle!(stylemanager::StyleManager, stylename::AbstractString) =
     Bool(GDAL.ogr_sm_addstyle(stylemanager.ptr, stylename, C_NULL))
 
 """
+    unsafe_createstyletool(classid::OGRSTClassId)
+
 OGRStyleTool factory.
 
 ### Parameters
@@ -140,6 +159,8 @@ function destroy(styletool::StyleTool)
 end
 
 """
+    gettype(styletool::StyleTool)
+
 Determine type of Style Tool.
 
 ### Parameters
@@ -152,6 +173,8 @@ OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
 gettype(styletool::StyleTool) = GDAL.ogr_st_gettype(styletool.ptr)
 
 """
+    getunit(styletool::StyleTool)
+
 Get Style Tool units.
 
 ### Parameters
@@ -163,10 +186,10 @@ the style tool units.
 getunit(styletool::StyleTool) = GDAL.ogr_st_getunit(styletool.ptr)
 
 """
-    OGR_ST_SetUnit(OGRStyleToolH styletool,
-                   OGRSTUnitId eUnit,
-                   double scale) -> void
+    setunit!(styletool::StyleTool, newunit::OGRSTUnitId, scale::Real)
+
 Set Style Tool units.
+
 ### Parameters
 * `styletool`: handle to the style tool.
 * `newunit`: the new unit.
@@ -176,6 +199,9 @@ setunit!(styletool::StyleTool, newunit::OGRSTUnitId, scale::Real) =
     GDAL.ogr_st_setunit(styletool.ptr, newunit, scale)
 
 """
+    asstring(styletool::StyleTool, id::Integer)
+    asstring(styletool::StyleTool, id::Integer, nullflag::Ref{Cint})
+
 Get Style Tool parameter value as a string.
 
 ### Parameters
@@ -183,7 +209,7 @@ Get Style Tool parameter value as a string.
 * `id`: the parameter id from the enumeration corresponding to the type of this
         style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
         or OGRSTLabelParam enumerations)
-* `nullflag`: pointer to an integer that will be set to `true` or `false` to 
+* `nullflag`: pointer to an integer that will be set to `true` or `false` to
         indicate whether the parameter value is NULL.
 
 ### Returns
@@ -196,6 +222,8 @@ asstring(styletool::StyleTool, id::Integer) =
     asstring(styletool, id, Ref{Cint}(0))
 
 """
+    asint(styletool::StyleTool, id::Integer, nullflag = Ref{Cint}(0))
+
 Get Style Tool parameter value as an integer.
 
 ### Parameters
@@ -203,7 +231,7 @@ Get Style Tool parameter value as an integer.
 * `id`: the parameter id from the enumeration corresponding to the type of this
         style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
         or OGRSTLabelParam enumerations)
-* `nullflag`: pointer to an integer that will be set to `true` or `false` to 
+* `nullflag`: pointer to an integer that will be set to `true` or `false` to
         indicate whether the parameter value is NULL.
 
 ### Returns
@@ -213,6 +241,8 @@ asint(styletool::StyleTool, id::Integer, nullflag::Ref{Cint} = Ref{Cint}(0)) =
     GDAL.ogr_st_getparamnum(styletool.ptr, id, nullflag)
 
 """
+    asdouble(styletool::StyleTool, id::Integer, nullflag = Ref{Cint}(0))
+
 Get Style Tool parameter value as a double.
 
 ### Parameters
@@ -220,7 +250,7 @@ Get Style Tool parameter value as a double.
 * `id`: the parameter id from the enumeration corresponding to the type of this
         style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
         or OGRSTLabelParam enumerations)
-* `nullflag`: pointer to an integer that will be set to `true` or `false` to 
+* `nullflag`: pointer to an integer that will be set to `true` or `false` to
         indicate whether the parameter value is NULL.
 
 ### Returns
@@ -235,45 +265,31 @@ function asdouble(
 end
 
 """
-Set Style Tool parameter value from a string.
+    setparam!(styletool::StyleTool, id::Integer, value)
+
+Set Style Tool parameter value.
 
 ### Parameters
 * `styletool`: handle to the style tool.
 * `id`: the parameter id from the enumeration corresponding to the type of this
         style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
         or OGRSTLabelParam enumerations)
-* `value`: the new parameter value
+* `value`: the new parameter value, can be an Integer, Float64, or AbstactString
 """
+function setparam! end
+
 setparam!(styletool::StyleTool, id::Integer, value::AbstractString) =
     GDAL.ogr_st_setparamstr(styletool.ptr, id, value)
 
-"""
-Set Style Tool parameter value from an integer.
-
-### Parameters
-* `styletool`: handle to the style tool.
-* `id`: the parameter id from the enumeration corresponding to the type of this
-        style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
-        or OGRSTLabelParam enumerations)
-* `value`: the new parameter value
-"""
 setparam!(styletool::StyleTool, id::Integer, value::Integer) =
     GDAL.ogr_st_setparamnum(styletool.ptr, id, value)
 
-"""
-Set Style Tool parameter value from a double.
-
-### Parameters
-* `styletool`: handle to the style tool.
-* `id`: the parameter id from the enumeration corresponding to the type of this
-        style tool (one of the OGRSTPenParam, OGRSTBrushParam, OGRSTSymbolParam
-        or OGRSTLabelParam enumerations)
-* `value`: the new parameter value
-"""
 setparam!(styletool::StyleTool, id::Integer, value::Float64) =
     GDAL.ogr_st_setparamdbl(styletool.ptr, id, value)
 
 """
+    getstylestring(styletool::StyleTool)
+
 Get the style string for this Style Tool.
 
 ### Parameters
@@ -285,6 +301,8 @@ the style string for this style tool or "" if the styletool is invalid.
 getstylestring(styletool::StyleTool) = GDAL.ogr_st_getstylestring(styletool.ptr)
 
 """
+    toRGBA(styletool::StyleTool, color::AbstractString)
+
 Return the r,g,b,a components of a color encoded in #RRGGBB[AA] format.
 
 ### Parameters
@@ -306,6 +324,8 @@ function toRGBA(styletool::StyleTool, color::AbstractString)
 end
 
 """
+    unsafe_createstyletable()
+
 OGRStyleTable factory.
 
 ### Returns
@@ -325,6 +345,8 @@ function destroy(st::StyleTable)
 end
 
 """
+    addstyle!(styletable::StyleTable, stylename, stylestring)
+
 Add a new style in the table.
 
 ### Parameters
@@ -344,10 +366,14 @@ function addstyle!(
 end
 
 """
+    savestyletable(styletable::StyleTable, filename::AbstractString)
+
 Save a style table to a file.
+
 ### Parameters
 * `styletable`: handle to the style table.
 * `filename`: the name of the file to save to.
+
 ### Returns
 `true` on success, `false` on error
 """
@@ -355,6 +381,8 @@ savestyletable(styletable::StyleTable, filename::AbstractString) =
     Bool(GDAL.ogr_stbl_savestyletable(styletable.ptr, filename))
 
 """
+    loadstyletable!(styletable::StyleTable, filename::AbstractString)
+
 Load a style table from a file.
 
 ### Parameters
@@ -368,6 +396,8 @@ loadstyletable!(styletable::StyleTable, filename::AbstractString) =
     Bool(GDAL.ogr_stbl_loadstyletable(styletable.ptr, filename))
 
 """
+    findstylestring(styletable::StyleTable, name::AbstractString)
+
 Get a style string by name.
 
 ### Parameters
@@ -381,6 +411,8 @@ findstylestring(styletable::StyleTable, name::AbstractString) =
     GDAL.ogr_stbl_find(styletable.ptr, name)
 
 """
+    resetreading!(styletable::StyleTable)
+
 Reset the next style pointer to 0.
 
 ### Parameters
@@ -390,6 +422,8 @@ resetreading!(styletable::StyleTable) =
     GDAL.ogr_stbl_resetstylestringreading(styletable.ptr)
 
 """
+    nextstyle(styletable::StyleTable)
+
 Get the next style string from the table.
 
 ### Parameters
@@ -401,6 +435,8 @@ the next style string or NULL on error.
 nextstyle(styletable::StyleTable) = GDAL.ogr_stbl_getnextstyle(styletable.ptr)
 
 """
+    laststyle(styletable::StyleTable)
+
 Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
 
 ### Parameters

--- a/src/raster/colortable.jl
+++ b/src/raster/colortable.jl
@@ -1,5 +1,6 @@
 """
-    GDALCreateColorTable(GDALPaletteInterp eInterp) -> GDALColorTableH
+    unsafe_createcolortable(palette::GDALPaletteInterp)
+
 Construct a new color table.
 """
 unsafe_createcolortable(palette::GDALPaletteInterp) =
@@ -11,10 +12,16 @@ function destroy(ct::ColorTable)
     ct.ptr = C_NULL
 end
 
-"Make a copy of a color table."
+"""
+    unsafe_clone(ct::ColorTable)
+
+Make a copy of a color table.
+"""
 unsafe_clone(ct::ColorTable) = ColorTable(GDAL.gdalclonecolortable(ct.ptr))
 
 """
+    paletteinterp(ct::ColorTable)
+
 Fetch palette interpretation.
 
 ### Returns
@@ -22,18 +29,28 @@ palette interpretation enumeration value, usually `GPI_RGB`.
 """
 paletteinterp(ct::ColorTable) = GDAL.gdalgetpaletteinterpretation(ct.ptr)
 
-"Get number of color entries in table."
+"""
+    ncolorentry(ct::ColorTable)
+
+Get number of color entries in table.
+"""
 ncolorentry(ct::ColorTable) = GDAL.gdalgetcolorentrycount(ct.ptr)
 
-"Fetch a color entry from table."
+"""
+    getcolorentry(ct::ColorTable, i::Integer)
+
+Fetch a color entry from table.
+"""
 getcolorentry(ct::ColorTable, i::Integer) =
     unsafe_load(GDAL.gdalgetcolorentry(ct.ptr, i))
 
 """
+    getcolorentryasrgb(ct::ColorTable, i::Integer)
+
 Fetch a table entry in RGB format.
 
 In theory this method should support translation of color palettes in non-RGB
-color spaces into RGB on the fly, but currently it only works on RGB color 
+color spaces into RGB on the fly, but currently it only works on RGB color
 tables.
 
 ### Parameters
@@ -50,10 +67,12 @@ function getcolorentryasrgb(ct::ColorTable, i::Integer)
 end
 
 """
+    setcolorentry!(ct::ColorTable, i::Integer, entry::GDAL.GDALColorEntry)
+
 Set entry in color table.
 
-Note that the passed in color entry is copied, and no internal reference to it 
-is maintained. Also, the passed in entry must match the color interpretation of 
+Note that the passed in color entry is copied, and no internal reference to it
+is maintained. Also, the passed in entry must match the color interpretation of
 the table to which it is being assigned.
 
 The table is grown as needed to hold the supplied offset.
@@ -68,9 +87,12 @@ function setcolorentry!(ct::ColorTable, i::Integer, entry::GDAL.GDALColorEntry)
 end
 
 """
+    createcolorramp!(ct::ColorTable, startindex, startcolor::GDAL.GDALColorEntry,
+        endindex, endcolor::GDAL.GDALColorEntry)
+
 Create color ramp.
 
-Automatically creates a color ramp from one color entry to another. It can be 
+Automatically creates a color ramp from one color entry to another. It can be
 called several times to create multiples ramps in the same color table.
 
 ### Parameters

--- a/src/raster/rasterattributetable.jl
+++ b/src/raster/rasterattributetable.jl
@@ -1,7 +1,15 @@
-"Construct empty table."
+"""
+    unsafe_createRAT()
+
+Construct empty table.
+"""
 unsafe_createRAT() = RasterAttrTable(GDAL.gdalcreaterasterattributetable())
 
-"Construct table from an existing colortable."
+"""
+    unsafe_createRAT(ct::ColorTable)
+
+Construct table from an existing colortable.
+"""
 unsafe_createRAT(ct::ColorTable) =
     initializeRAT!(unsafe_createRAT(), ct)
 
@@ -11,10 +19,16 @@ function destroy(rat::RasterAttrTable)
     rat.ptr = C_NULL
 end
 
-"Fetch table column count."
+"""
+    ncolumn(rat::RasterAttrTable)
+
+Fetch table column count.
+"""
 ncolumn(rat::RasterAttrTable) = GDAL.gdalratgetcolumncount(rat.ptr)
 
 """
+    columnname(rat::RasterAttrTable, i::Integer)
+
 Fetch name of indicated column.
 
 ### Parameters
@@ -23,14 +37,20 @@ Fetch name of indicated column.
 ### Returns
 the column name or an empty string for invalid column numbers.
 """
-columnname(rat::RasterAttrTable, i::Integer) = 
+columnname(rat::RasterAttrTable, i::Integer) =
     GDAL.gdalratgetnameofcol(rat.ptr, i)
 
-"Fetch column usage value."
+"""
+    columnusage(rat::RasterAttrTable, i::Integer)
+
+Fetch column usage value.
+"""
 columnusage(rat::RasterAttrTable, i::Integer) =
     GDAL.gdalratgetusageofcol(rat.ptr, i)
 
 """
+    columntype(rat::RasterAttrTable, i::Integer)
+
 Fetch column type.
 
 ### Parameters
@@ -43,6 +63,8 @@ columntype(rat::RasterAttrTable, i::Integer) =
     GDAL.gdalratgettypeofcol(rat.ptr, i)
 
 """
+    findcolumnindex(rat::RasterAttrTable, usage::GDALRATFieldUsage)
+
 Returns the index of the first column of the requested usage type, or -1 if no
 match is found.
 
@@ -52,14 +74,20 @@ match is found.
 findcolumnindex(rat::RasterAttrTable, usage::GDALRATFieldUsage) =
     GDAL.gdalratgetcolofusage(rat.ptr, usage)
 
-"Fetch row count."
+"""
+    nrow(rat::RasterAttrTable)
+
+Fetch row count.
+"""
 nrow(rat::RasterAttrTable) = GDAL.gdalratgetrowcount(rat.ptr)
 
 """
+    asstring(rat::RasterAttrTable, row::Integer, col::Integer)
+
 Fetch field value as a string.
 
 The value of the requested column in the requested row is returned as a string.
-If the field is numeric, it is formatted as a string using default rules, so 
+If the field is numeric, it is formatted as a string using default rules, so
 some precision may be lost.
 
 ### Parameters
@@ -68,8 +96,10 @@ some precision may be lost.
 """
 asstring(rat::RasterAttrTable, row::Integer, col::Integer) =
     GDAL.gdalratgetvalueasstring(rat.ptr, row, col)
-    
+
 """
+    asint(rat::RasterAttrTable, row::Integer, col::Integer)
+
 Fetch field value as a integer.
 
 The value of the requested column in the requested row is returned as an int.
@@ -83,6 +113,8 @@ asint(rat::RasterAttrTable, row::Integer, col::Integer) =
     GDAL.gdalratgetvalueasint(rat.ptr, row, col)
 
 """
+    asdouble(rat::RasterAttrTable, row::Integer, col::Integer)
+
 Fetch field value as a double.
 
 The value of the requested column in the requested row is returned as a double.
@@ -96,6 +128,8 @@ asdouble(rat::RasterAttrTable, row::Integer, col::Integer) =
     GDAL.gdalratgetvalueasdouble(rat.ptr, row, col)
 
 """
+    setvalue!(rat::RasterAttrTable, row, col, val)
+
 Set field value from string.
 
 The indicated field (column) on the indicated row is set from the passed value.
@@ -105,8 +139,10 @@ loss of precision.
 ### Parameters
 * `row`  row to fetch (zero based).
 * `col`  column to fetch (zero based).
-* `val`  the value to assign.
+* `val`  the value to assign, can be an AbstractString, Integer or Float64.
 """
+function setvalue! end
+
 function setvalue!(
         rat::RasterAttrTable,
         row::Integer,
@@ -117,44 +153,20 @@ function setvalue!(
     return rat
 end
 
-"""
-Set field value from integer.
-
-The indicated field (column) on the indicated row is set from the passed value.
-The value will be automatically converted for other field types, with a possible
-loss of precision.
-
-### Parameters
-* `row`  row to fetch (zero based).
-* `col`  column to fetch (zero based).
-* `val`  the value to assign.
-"""
 function setvalue!(
         rat::RasterAttrTable,
         row::Integer,
-        col::Integer, 
+        col::Integer,
         val::Integer
     )
     GDAL.gdalratsetvalueasint(rat.ptr, row, col, val)
     return rat
 end
 
-"""
-Set field value from double.
-
-The indicated field (column) on the indicated row is set from the passed value.
-The value will be automatically converted for other field types, with a possible
-loss of precision.
-
-### Parameters
-* `row`  row to fetch (zero based).
-* `col`  column to fetch (zero based).
-* `val`  the value to assign.
-"""
 function setvalue!(
         rat::RasterAttrTable,
         row::Integer,
-        col::Integer, 
+        col::Integer,
         val::Float64
     )
     GDAL.gdalratsetvalueasdouble(rat.ptr, row, col, val)
@@ -162,25 +174,31 @@ function setvalue!(
 end
 
 """
+    changesarewrittentofile(rat::RasterAttrTable)
+
 Determine whether changes made to this RAT are reflected directly in the dataset
 
-If this returns `false` then GDALRasterBand.SetDefaultRAT() should be called. 
-Otherwise this is unnecessary since changes to this object are reflected in the 
+If this returns `false` then GDALRasterBand.SetDefaultRAT() should be called.
+Otherwise this is unnecessary since changes to this object are reflected in the
 dataset.
 """
 changesarewrittentofile(rat::RasterAttrTable) =
     Bool(GDAL.gdalratchangesarewrittentofile(rat.ptr))
 
 """
-Read or Write a block of doubles to/from the Attribute Table.
+    attributeio!(rat::RasterAttrTable, access::GDALRWFlag, col, startrow, nrows, data::Vector)
+
+Read or Write a block of data to/from the Attribute Table.
 
 ### Parameters
 * `access`      Either `GF_Read` or `GF_Write`
 * `col`         Column of the Attribute Table
 * `startrow`    Row to start reading/writing (zero based)
 * `nrows`       Number of rows to read or write
-* `data`        Array of doubles to read/write. Should be at least `nrows` long.
+* `data`        Vector of Float64, Int32 or AbstractString to read/write. Should be at least `nrows` long.
 """
+function attributeio! end
+
 function attributeio!(
         rat::RasterAttrTable,
         access::GDALRWFlag,
@@ -195,16 +213,6 @@ function attributeio!(
     return data
 end
 
-"""
-Read or Write a block of ints to/from the Attribute Table.
-
-### Parameters
-* `access`      Either `GF_Read` or `GF_Write`
-* `col`         Column of the Attribute Table
-* `startrow`    Row to start reading/writing (zero based)
-* `nrows`       Number of rows to read or write
-* `data`        Array of ints to read/write. Should be at least `nrows` long.
-"""
 function attributeio!(
         rat::RasterAttrTable,
         access::GDALRWFlag,
@@ -219,16 +227,6 @@ function attributeio!(
     return data
 end
 
-"""
-Read or Write a block of strings to/from the Attribute Table.
-
-### Parameters
-* `access`      Either `GF_Read` or `GF_Write`
-* `col`         Column of the Attribute Table
-* `startrow`    Row to start reading/writing (zero based)
-* `nrows`       Number of rows to read or write
-* `data`        Array of strings to read/write. Should be at least `nrows` long.
-"""
 function attributeio!(
         rat::RasterAttrTable,
         access::GDALRWFlag,
@@ -244,10 +242,12 @@ function attributeio!(
 end
 
 """
+    setrowcount!(rat::RasterAttrTable, n::Integer)
+
 Set row count.
 
-Resizes the table to include the indicated number of rows. Newly created rows 
-will be initialized to their default values - \"\" for strings, and zero for 
+Resizes the table to include the indicated number of rows. Newly created rows
+will be initialized to their default values - \"\" for strings, and zero for
 numeric fields.
 """
 function setrowcount!(rat::RasterAttrTable, n::Integer)
@@ -256,16 +256,18 @@ function setrowcount!(rat::RasterAttrTable, n::Integer)
 end
 
 """
+    createcolumn!(rat::RasterAttrTable, name, fieldtype::GDALRATFieldType, fieldusage::GDALRATFieldUsage)
+
 Create new column.
 
-If the table already has rows, all row values for the new column will be 
-initialized to the default value (\"\", or zero). The new column is always 
-created as the last column, can will be column (field) \"GetColumnCount()-1\" 
+If the table already has rows, all row values for the new column will be
+initialized to the default value (\"\", or zero). The new column is always
+created as the last column, can will be column (field) \"GetColumnCount()-1\"
 after CreateColumn() has completed successfully.
 """
 function createcolumn!(
         rat::RasterAttrTable,
-        name::AbstractString, 
+        name::AbstractString,
         fieldtype::GDALRATFieldType,
         fieldusage::GDALRATFieldUsage
     )
@@ -275,9 +277,11 @@ function createcolumn!(
 end
 
 """
+    setlinearbinning!(rat::RasterAttrTable, row0min::Real, binsize::Real)
+
 Set linear binning information.
 
-For RATs with equal sized categories (in pixel value space) that are evenly 
+For RATs with equal sized categories (in pixel value space) that are evenly
 spaced, this method may be used to associate the linear binning information with
 the table.
 
@@ -292,6 +296,8 @@ function setlinearbinning!(rat::RasterAttrTable, row0min::Real, binsize::Real)
 end
 
 """
+    getlinearbinning(rat::RasterAttrTable)
+
 Get linear binning information.
 
 ### Returns
@@ -307,11 +313,13 @@ function getlinearbinning(rat::RasterAttrTable)
 end
 
 """
+    initializeRAT!(rat::RasterAttrTable, colortable::ColorTable)
+
 Initialize from color table.
 
 This method will setup a whole raster attribute table based on the contents of
 the passed color table. The Value (GFU_MinMax), Red (GFU_Red),
-Green (GFU_Green), Blue (GFU_Blue), and Alpha (GFU_Alpha) fields are created, 
+Green (GFU_Green), Blue (GFU_Blue), and Alpha (GFU_Alpha) fields are created,
 and a row is set for each entry in the color table.
 
 The raster attribute table must be empty before calling `initializeRAT!()`.
@@ -326,6 +334,8 @@ function initializeRAT!(rat::RasterAttrTable, colortable::ColorTable)
 end
 
 """
+    toColorTable(rat::RasterAttrTable, n::Integer = -1)
+
 Translate to a color table.
 
 ### Parameters
@@ -334,7 +344,7 @@ Translate to a color table.
 ### Returns
 the generated color table or `NULL` on failure.
 """
-toColorTable(rat::RasterAttrTable, n::Integer = -1) = 
+toColorTable(rat::RasterAttrTable, n::Integer = -1) =
     ColorTable(GDAL.gdalrattranslatetocolortable(rat.ptr, n))
 
 # """
@@ -348,22 +358,30 @@ toColorTable(rat::RasterAttrTable, n::Integer = -1) =
 # end
 
 """
+    unsafe_clone(rat::RasterAttrTable)
+
 Copy Raster Attribute Table.
 
-Creates a new copy of an existing raster attribute table. The new copy becomes 
-the responsibility of the caller to destroy. May fail (return `NULL`) if the 
+Creates a new copy of an existing raster attribute table. The new copy becomes
+the responsibility of the caller to destroy. May fail (return `NULL`) if the
 attribute table is too large to clone:
     `(nrow() * ncolumn() > RAT_MAX_ELEM_FOR_CLONE)`
 """
 unsafe_clone(rat::RasterAttrTable) = RasterAttrTable(GDAL.gdalratclone(rat.ptr))
 
-"Serialize Raster Attribute Table in Json format."
+"""
+    serializeJSON(rat::RasterAttrTable)
+
+Serialize Raster Attribute Table in Json format.
+"""
 serializeJSON(rat::RasterAttrTable) = GDAL.gdalratserializejson(rat.ptr)
 
 """
+    findrowindex(rat::RasterAttrTable, pxvalue::Real)
+
 Get row for pixel value.
 
-Given a raw pixel value, the raster attribute table is scanned to determine 
+Given a raw pixel value, the raster attribute table is scanned to determine
 which row in the table applies to the pixel value. The row index is returned.
 
 ### Parameters

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -11,6 +11,8 @@ function destroy(band::IRasterBand)
 end
 
 """
+    blocksize(band::AbstractRasterBand)
+
 Fetch the "natural" block size of this band.
 
 GDAL contains a concept of the natural block size of rasters so that
@@ -31,20 +33,38 @@ function blocksize(band::AbstractRasterBand)
     return xy
 end
 
-"Fetch the pixel data type for this band."
+"""
+    pixeltype(band::AbstractRasterBand)
+
+Fetch the pixel data type for this band.
+"""
 pixeltype(band::AbstractRasterBand) =
     _JLTYPE[GDAL.gdalgetrasterdatatype(band.ptr)]
 
-"Fetch the width in pixels of this band."
+"""
+    width(band::AbstractRasterBand)
+
+Fetch the width in pixels of this band.
+"""
 width(band::AbstractRasterBand) = GDAL.gdalgetrasterbandxsize(band.ptr)
 
-"Fetch the height in pixels of this band."
+"""
+    height(band::AbstractRasterBand)
+
+Fetch the height in pixels of this band.
+"""
 height(band::AbstractRasterBand) = GDAL.gdalgetrasterbandysize(band.ptr)
 
-"Return the access flag (e.g. `OF_ReadOnly` or `OF_Update`) for this band."
+"""
+    accessflag(band::AbstractRasterBand)
+
+Return the access flag (e.g. `OF_ReadOnly` or `OF_Update`) for this band.
+"""
 accessflag(band::AbstractRasterBand) = GDAL.gdalgetrasteraccess(band.ptr)
 
 """
+    indexof(band::AbstractRasterBand)
+
 Fetch the band number (1+) within its dataset, or 0 if unknown.
 
 This method may return a value of 0 to indicate overviews, or free-standing
@@ -53,6 +73,8 @@ This method may return a value of 0 to indicate overviews, or free-standing
 indexof(band::AbstractRasterBand) = GDAL.gdalgetbandnumber(band.ptr)
 
 """
+    getdataset(band::AbstractRasterBand)
+
 Fetch the handle to its dataset handle, or `NULL` if this cannot be determined.
 
 Note that some `RasterBand`s are not considered to be a part of a dataset,
@@ -63,12 +85,16 @@ getdataset(band::AbstractRasterBand) =
 # ↑ GDAL wrapper checks null by default, but it is a valid result in this case
 
 """
+    getunittype(band::AbstractRasterBand)
+
 Return a name for the units of this raster's values. For instance, it might be
 "m" for an elevation model in meters, or "ft" for feet.
 """
 getunittype(band::AbstractRasterBand) = GDAL.gdalgetrasterunittype(band.ptr)
 
 """
+    setunittype!(band::AbstractRasterBand, unitstring::AbstractString)
+
 Set unit type of `band` to `unittype`.
 
 Values should be one of \"\" (the default indicating it is unknown), \"m\"
@@ -82,6 +108,8 @@ function setunittype!(band::AbstractRasterBand, unitstring::AbstractString)
 end
 
 """
+    getoffset(band::AbstractRasterBand)
+
 Fetch the raster value offset.
 
 This (in combination with `GetScale()`) is used to transform raw pixel values
@@ -94,7 +122,11 @@ For file formats that don't know this intrinsically, a value of 0 is returned.
 """
 getoffset(band::AbstractRasterBand) = GDAL.gdalgetrasteroffset(band.ptr, C_NULL)
 
-"Set scaling offset."
+"""
+    setoffset!(band::AbstractRasterBand, value::Real)
+
+Set scaling offset.
+"""
 function setoffset!(band::AbstractRasterBand, value::Real)
     result = GDAL.gdalsetrasteroffset(band.ptr, value)
     @cplerr result "Failed to set scaling offset."
@@ -102,6 +134,8 @@ function setoffset!(band::AbstractRasterBand, value::Real)
 end
 
 """
+    getscale(band::AbstractRasterBand)
+
 Fetch the raster value scale.
 
 This value (in combination with the `GetOffset()` value) is used to transform
@@ -115,7 +149,11 @@ For file formats that don't know this intrinsically a value of one is returned.
 """
 getscale(band::AbstractRasterBand) = GDAL.gdalgetrasterscale(band.ptr, C_NULL)
 
-"Set scaling ratio."
+"""
+    setscale!(band::AbstractRasterBand, ratio::Real)
+
+Set scaling ratio.
+"""
 function setscale!(band::AbstractRasterBand, ratio::Real)
     result = GDAL.gdalsetrasterscale(band.ptr, ratio)
     @cplerr result "Failed to set scaling ratio"
@@ -123,6 +161,8 @@ function setscale!(band::AbstractRasterBand, ratio::Real)
 end
 
 """
+    getnodatavalue(band::AbstractRasterBand)
+
 Fetch the no data value for this band.
 
 If there is no out of data value, an out of range value will generally be
@@ -140,7 +180,11 @@ function getnodatavalue(band::AbstractRasterBand)
     return GDAL.gdalgetrasternodatavalue(band.ptr, C_NULL)
 end
 
-"Set the no data value for this band."
+"""
+    setnodatavalue!(band::AbstractRasterBand, value::Real)
+
+Set the no data value for this band.
+"""
 function setnodatavalue!(band::AbstractRasterBand, value::Real)
     result = GDAL.gdalsetrasternodatavalue(band.ptr, value)
     @cplerr result "Could not set nodatavalue"
@@ -153,23 +197,41 @@ function deletenodatavalue!(band::AbstractRasterBand)
     return band
 end
 
-"Set the category names for this band."
+"""
+    setcategorynames!(band::AbstractRasterBand, names)
+
+Set the category names for this band.
+"""
 function setcategorynames!(band::AbstractRasterBand, names)
     result = GDAL.gdalsetrastercategorynames(band.ptr, names)
     @cplerr result "Failed to set category names"
     return band
 end
 
-"Fetch the minimum value for this band."
+"""
+    minimum(band::AbstractRasterBand)
+
+Fetch the minimum value for this band.
+"""
 minimum(band::AbstractRasterBand) = GDAL.gdalgetrasterminimum(band.ptr, C_NULL)
 
-"Fetch the maximum value for this band."
+"""
+    maximum(band::AbstractRasterBand)
+
+Fetch the maximum value for this band.
+"""
 maximum(band::AbstractRasterBand) = GDAL.gdalgetrastermaximum(band.ptr, C_NULL)
 
-"Fetch default Raster Attribute Table."
+"""
+    getdefaultRAT(band::AbstractRasterBand)
+
+Fetch default Raster Attribute Table.
+"""
 getdefaultRAT(band::AbstractRasterBand) = GDAL.gdalgetdefaultrat(band.ptr)
 
 """
+    setdefaultRAT!(band::AbstractRasterBand, rat::RasterAttrTable)
+
 Set default Raster Attribute Table.
 
 Associates a default RAT with the band. If not implemented for the format a
@@ -183,6 +245,9 @@ function setdefaultRAT!(band::AbstractRasterBand, rat::RasterAttrTable)
 end
 
 """
+    copywholeraster!( source::AbstractRasterBand, dest::AbstractRasterBand;
+        [options, [progressdata, [progressfunc]]])
+
 Copy all raster band raster data.
 
 This function copies the complete raster contents of one band to another
@@ -216,10 +281,18 @@ function copywholeraster!(
     return source
 end
 
-"Return the number of overview layers available, zero if none."
+"""
+    noverview(band::AbstractRasterBand)
+
+Return the number of overview layers available, zero if none.
+"""
 noverview(band::AbstractRasterBand) = GDAL.gdalgetoverviewcount(band.ptr)
 
-"Fetch overview raster band object."
+"""
+    getoverview(band::IRasterBand, i::Integer)
+
+Fetch overview raster band object.
+"""
 getoverview(band::IRasterBand, i::Integer) =
     IRasterBand(GDAL.gdalgetoverview(band.ptr, i), ownedby = band.ownedby)
 
@@ -227,6 +300,8 @@ unsafe_getoverview(band::AbstractRasterBand, i::Integer) =
     RasterBand(GDAL.gdalgetoverview(band.ptr, i))
 
 """
+    sampleoverview(band::IRasterBand, nsamples::Integer)
+
 Fetch best overview satisfying `nsamples` number of samples.
 
 Returns the most reduced overview of the given band that still satisfies the
@@ -245,11 +320,19 @@ end
 unsafe_sampleoverview(band::AbstractRasterBand, nsamples::Integer) =
     RasterBand(GDAL.gdalgetrastersampleoverviewex(band.ptr, UInt64(nsamples)))
 
-"Color Interpretation value for band"
+"""
+    getcolorinterp(band::AbstractRasterBand)
+
+Color Interpretation value for band
+"""
 getcolorinterp(band::AbstractRasterBand) =
     GDAL.gdalgetrastercolorinterpretation(band.ptr)
 
-"Set color interpretation of a band."
+"""
+    setcolorinterp!(band::AbstractRasterBand, color::GDALColorInterp)
+
+Set color interpretation of a band.
+"""
 function setcolorinterp!(band::AbstractRasterBand, color::GDALColorInterp)
     result = GDAL.gdalsetrastercolorinterpretation(band.ptr, color)
     @cplerr result "Failed to set color interpretation"
@@ -257,6 +340,8 @@ function setcolorinterp!(band::AbstractRasterBand, color::GDALColorInterp)
 end
 
 """
+    unsafe_getcolortable(band::AbstractRasterBand)
+
 Returns a clone of the color table associated with the band.
 
 (If there is no associated color table, the original result is `NULL`. The
@@ -273,6 +358,8 @@ function unsafe_getcolortable(band::AbstractRasterBand)
 end
 
 """
+    setcolortable!(band::AbstractRasterBand, colortable::ColorTable)
+
 Set the raster color table.
 
 The driver will make a copy of all desired data in the colortable. It remains
@@ -294,6 +381,9 @@ function clearcolortable!(band::AbstractRasterBand)
 end
 
 """
+    regenerateoverviews!(band::AbstractRasterBand, overviewbands::Vector{<:AbstractRasterBand},
+        resampling = "NEAREST")
+
 Generate downsampled overviews.
 
 This function will generate one or more overview images from a base image using
@@ -354,6 +444,8 @@ end
 #                          nBYSize, eBDataType, papszOptions)::CPLErr
 
 """
+    getcategorynames(band::AbstractRasterBand)
+
 Fetch the list of category names for this raster.
 
 The return list is a "StringList" in the sense of the CPL functions. That is a
@@ -364,7 +456,11 @@ raster values of zero, and so on.
 getcategorynames(band::AbstractRasterBand) =
     GDAL.gdalgetrastercategorynames(band.ptr)
 
-"Set the category names for this band."
+"""
+    setcategorynames!(band::AbstractRasterBand, names::Vector{String})
+
+Set the category names for this band.
+"""
 function setcategorynames!(band::AbstractRasterBand, names::Vector{String})
     result = GDAL.gdalsetrastercategorynames(band.ptr, names)
     @cplerr result "Failed to set category names for this band"
@@ -384,6 +480,8 @@ end
 # end
 
 """
+    fillraster!(band::AbstractRasterBand, realvalue::Real, imagvalue::Real = 0)
+
 Fill this band with a constant value.
 
 GDAL makes no guarantees about what values pixels in newly created files are
@@ -407,6 +505,8 @@ function fillraster!(
 end
 
 """
+    getmaskband(band::IRasterBand)
+
 Return the mask band associated with the band.
 
 The `GDALRasterBand` class includes a default implementation of `GetMaskBand()`
@@ -435,13 +535,15 @@ See also: http://trac.osgeo.org/gdal/wiki/rfc15_nodatabitmask
 ### Returns
 a valid mask band.
 """
-getmaskband(band::IRasterBand) = 
+getmaskband(band::IRasterBand) =
     IRasterBand(GDAL.gdalgetmaskband(band.ptr), ownedby = band.ownedby)
 
-unsafe_getmaskband(band::AbstractRasterBand) = 
+unsafe_getmaskband(band::AbstractRasterBand) =
     RasterBand(GDAL.gdalgetmaskband(band.ptr))
 
 """
+    maskflags(band::AbstractRasterBand)
+
 Return the status flags of the mask band associated with the band.
 
 The GetMaskFlags() method returns an bitwise OR-ed set of status flags with the
@@ -482,6 +584,8 @@ a valid mask band.
 maskflags(band::AbstractRasterBand) = GDAL.gdalgetmaskflags(band.ptr)
 
 """
+    createmaskband!(band::AbstractRasterBand, nflags::Integer)
+    
 Adds a mask band to the current band.
 
 The default implementation of the `CreateMaskBand()` method is implemented

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -1,4 +1,8 @@
-"Construct a Spatial Reference System from its WKT."
+"""
+    newspatialref(wkt::AbstractString = "")
+
+Construct a Spatial Reference System from its WKT.
+"""
 newspatialref(wkt::AbstractString = "") =
     ISpatialRef(GDAL.osrnewspatialreference(wkt))
 
@@ -10,7 +14,11 @@ function destroy(spref::AbstractSpatialRef)
     spref.ptr = C_NULL
 end
 
-"Makes a clone of the Spatial Reference System. May return NULL."
+"""
+    clone(spref::AbstractSpatialRef)
+
+Makes a clone of the Spatial Reference System. May return NULL.
+"""
 function clone(spref::AbstractSpatialRef)
     if spref.ptr == C_NULL
         return ISpatialRef()
@@ -28,6 +36,8 @@ function unsafe_clone(spref::AbstractSpatialRef)
 end
 
 """
+    importEPSG!(spref::AbstractSpatialRef, code::Integer)
+
 Initialize SRS based on EPSG GCS or PCS code.
 
 This method will initialize the spatial reference based on the passed in
@@ -56,12 +66,18 @@ function importEPSG!(spref::AbstractSpatialRef, code::Integer)
     return spref
 end
 
-"Construct a Spatial Reference System from its EPSG GCS or PCS code."
+"""
+    importEPSG(code::Integer)
+
+Construct a Spatial Reference System from its EPSG GCS or PCS code.
+"""
 importEPSG(code::Integer) = importEPSG!(newspatialref(), code)
 
 unsafe_importEPSG(code::Integer) = importEPSG!(unsafe_newspatialref(), code)
 
 """
+    importEPSGA!(spref::AbstractSpatialRef, code::Integer)
+
 Initialize SRS based on EPSG CRS code.
 
 This method is similar to `importFromEPSG()` except that EPSG preferred axis
@@ -78,6 +94,8 @@ function importEPSGA!(spref::AbstractSpatialRef, code::Integer)
 end
 
 """
+    importEPSGA(code::Integer)
+
 Construct a Spatial Reference System from its EPSG CRS code.
 
 This method is similar to `importFromEPSG()` except that EPSG preferred axis
@@ -92,6 +110,8 @@ importEPSGA(code::Integer) = importEPSGA!(newspatialref(), code)
 unsafe_importEPSGA(code::Integer) = importEPSGA!(unsafe_newspatialref(), code)
 
 """
+    importWKT!(spref::AbstractSpatialRef, wktstr::AbstractString)
+
 Import from WKT string.
 
 This method will wipe the existing SRS definition, and reassign it based on the
@@ -105,12 +125,18 @@ function importWKT!(spref::AbstractSpatialRef, wktstr::AbstractString)
     return spref
 end
 
-"Create SRS from its WKT string."
+"""
+    importWKT(wktstr::AbstractString)
+
+Create SRS from its WKT string.
+"""
 importWKT(wktstr::AbstractString) = newspatialref(wktstr)
 
 unsafe_importWKT(wktstr::AbstractString) = unsafe_newspatialref(wktstr)
 
 """
+    importPROJ4!(spref::AbstractSpatialRef, projstr::AbstractString)
+
 Import PROJ.4 coordinate string.
 
 The OGRSpatialReference is initialized from the passed PROJ.4 style coordinate
@@ -136,7 +162,11 @@ function importPROJ4!(spref::AbstractSpatialRef, projstr::AbstractString)
     return spref
 end
 
-"Create SRS from its PROJ.4 string."
+"""
+    importPROJ4(projstr::AbstractString)
+
+Create SRS from its PROJ.4 string.
+"""
 importPROJ4(projstr::AbstractString) =
     importPROJ4!(newspatialref(), projstr)
 
@@ -144,6 +174,8 @@ unsafe_importPROJ4(projstr::AbstractString) =
     importPROJ4!(unsafe_newspatialref(), projstr)
 
 """
+    importESRI!(spref::AbstractSpatialRef, esristr::AbstractString)
+
 Import coordinate system from ESRI .prj format(s).
 
 This function will read the text loaded from an ESRI .prj file, and translate it
@@ -169,21 +201,33 @@ function importESRI!(spref::AbstractSpatialRef, esristr::AbstractString)
     return spref
 end
 
-"Create SRS from its ESRI .prj format(s)."
+"""
+    importESRI(esristr::AbstractString)
+
+Create SRS from its ESRI .prj format(s).
+"""
 importESRI(esristr::AbstractString) =
     importESRI!(newspatialref(), esristr)
 
 unsafe_importESRI(esristr::AbstractString) =
     importESRI!(unsafe_newspatialref(), esristr)
 
-"Import SRS from XML format (GML only currently)."
+"""
+    importXML!(spref::AbstractSpatialRef, xmlstr::AbstractString)
+
+Import SRS from XML format (GML only currently).
+"""
 function importXML!(spref::AbstractSpatialRef, xmlstr::AbstractString)
     result = GDAL.osrimportfromxml(spref.ptr, xmlstr)
     @ogrerr result "Failed to initialize SRS based on XML string"
     return spref
 end
 
-"Construct SRS from XML format (GML only currently)."
+"""
+    importXML(xmlstr::AbstractString)
+
+Construct SRS from XML format (GML only currently).
+"""
 importXML(xmlstr::AbstractString) =
     importXML!(newspatialref(), xmlstr)
 
@@ -191,6 +235,8 @@ unsafe_importXML(xmlstr::AbstractString) =
     importXML!(unsafe_newspatialref(), xmlstr)
 
 """
+    importURL!(spref::AbstractSpatialRef, url::AbstractString)
+
 Set spatial reference from a URL.
 
 This method will download the spatial reference at a given URL and feed it into
@@ -203,6 +249,8 @@ function importURL!(spref::AbstractSpatialRef, url::AbstractString)
 end
 
 """
+    importURL(url::AbstractString)
+
 Construct SRS from a URL.
 
 This method will download the spatial reference at a given URL and feed it into
@@ -212,7 +260,11 @@ importURL(url::AbstractString) = importURL!(newspatialref(), url)
 
 unsafe_importURL(url::AbstractString) = importURL!(unsafe_newspatialref(), url)
 
-"Convert this SRS into WKT format."
+"""
+    toWKT(spref::AbstractSpatialRef)
+
+Convert this SRS into WKT format.
+"""
 function toWKT(spref::AbstractSpatialRef)
     wktptr = Ref{Cstring}()
     result = GDAL.osrexporttowkt(spref.ptr, wktptr)
@@ -221,6 +273,8 @@ function toWKT(spref::AbstractSpatialRef)
 end
 
 """
+    toWKT(spref::AbstractSpatialRef, simplify::Bool)
+
 Convert this SRS into a nicely formatted WKT string for display to a person.
 
 ### Parameters
@@ -236,8 +290,8 @@ function toWKT(spref::AbstractSpatialRef, simplify::Bool)
 end
 
 """
-    OSRExportToProj4(OGRSpatialReferenceH,
-                     char **) -> OGRErr
+    toPROJ4(spref::AbstractSpatialRef)
+
 Export coordinate system in PROJ.4 format.
 """
 function toPROJ4(spref::AbstractSpatialRef)
@@ -248,6 +302,8 @@ function toPROJ4(spref::AbstractSpatialRef)
 end
 
 """
+    toXML(spref::AbstractSpatialRef)
+
 Export coordinate system in XML format.
 
 Converts the loaded coordinate reference system into XML format to the extent
@@ -261,7 +317,11 @@ function toXML(spref::AbstractSpatialRef)
     return unsafe_string(xmlptr[])
 end
 
-"Export coordinate system in Mapinfo style CoordSys format."
+"""
+    toMICoordSys(spref::AbstractSpatialRef)
+
+Export coordinate system in Mapinfo style CoordSys format.
+"""
 function toMICoordSys(spref::AbstractSpatialRef)
     ptr = Ref{Cstring}()
     result = GDAL.osrexporttomicoordsys(spref.ptr, ptr)
@@ -270,10 +330,12 @@ function toMICoordSys(spref::AbstractSpatialRef)
 end
 
 """
+    morphtoESRI!(spref::AbstractSpatialRef)
+
 Convert in place to ESRI WKT format.
 
 The value nodes of this coordinate system are modified in various manners more
-closely map onto the ESRI concept of WKT format. This includes renaming a 
+closely map onto the ESRI concept of WKT format. This includes renaming a
 variety of projections and arguments, and stripping out nodes note recognised by
 ESRI (like AUTHORITY and AXIS).
 """
@@ -284,6 +346,8 @@ function morphtoESRI!(spref::AbstractSpatialRef)
 end
 
 """
+    morphfromESRI!(spref::AbstractSpatialRef)
+
 Convert in place from ESRI WKT format.
 
 The value notes of this coordinate system are modified in various manners to
@@ -316,6 +380,8 @@ function morphfromESRI!(spref::AbstractSpatialRef)
 end
 
 """
+    setattrvalue!(spref::AbstractSpatialRef, path::AbstractString, value::AbstractString)
+
 Set attribute value in spatial reference.
 
 Missing intermediate nodes in the path will be created if not already in
@@ -344,6 +410,8 @@ function setattrvalue!(spref::AbstractSpatialRef, path::AbstractString)
 end
 
 """
+    getattrvalue(spref::AbstractSpatialRef, name::AbstractString, i::Integer)
+
 Fetch indicated attribute of named node.
 
 This method uses GetAttrNode() to find the named node, and then extracts the
@@ -362,6 +430,8 @@ getattrvalue(spref::AbstractSpatialRef, name::AbstractString, i::Integer) =
     GDAL.osrgetattrvalue(spref.ptr, name, i)
 
 """
+    unsafe_createcoordtrans(source::AbstractSpatialRef, target::AbstractSpatialRef)
+
 Create transformation object.
 
 ### Parameters
@@ -386,6 +456,8 @@ function destroy(obj::CoordTransform)
 end
 
 """
+    transform!(xvertices, yvertices, zvertices, obj::CoordTransform)
+
 Transform points from source to destination space.
 
 ### Parameters

--- a/src/types.jl
+++ b/src/types.jl
@@ -305,44 +305,94 @@ import Base.|
 |(x::UInt8,y::GDALOpenFlag) = x | UInt8(y)
 |(x::GDALOpenFlag,y::GDALOpenFlag) = UInt8(x) | UInt8(y)
 
-"Get data type size in bits."
+"""
+    typesize(dt::GDALDataType)
+
+Get data type size in bits.
+"""
 typesize(dt::GDALDataType) = GDAL.gdalgetdatatypesize(dt)
 
-"name (string) corresponding to GDAL data type"
+"""
+    typename(dt::GDALDataType)
+
+name (string) corresponding to GDAL data type.
+"""
 typename(dt::GDALDataType) = GDAL.gdalgetdatatypename(dt)
 
-"Returns GDAL data type by symbolic name."
+"""
+    gettype(name::AbstractString)
+
+Returns GDAL data type by symbolic name.
+"""
 gettype(name::AbstractString) = GDAL.gdalgetdatatypebyname(name)
 
-"Return the smallest data type that can fully express both input data types."
+"""
+    typeunion(dt1::GDALDataType, dt2::GDALDataType)
+
+Return the smallest data type that can fully express both input data types.
+"""
 typeunion(dt1::GDALDataType, dt2::GDALDataType) = GDAL.gdaldatatypeunion(dt1, dt2)
 
 """
-`true` if `dtype` is one of `GDT_{CInt16|CInt32|CFloat32|CFloat64}`
+    iscomplex(dtype::GDALDataType)
+
+`true` if `dtype` is one of `GDT_{CInt16|CInt32|CFloat32|CFloat64}.`
 """
 iscomplex(dtype::GDALDataType) = Bool(GDAL.gdaldatatypeiscomplex(dtype))
 
-"Get name of AsyncStatus data type."
+"""
+    getname(dtype::GDALAsyncStatusType)
+
+Get name of AsyncStatus data type.
+"""
 getname(dtype::GDALAsyncStatusType) = GDAL.gdalgetasyncstatustypename(dtype)
 
-"Get AsyncStatusType by symbolic name."
+"""
+    asyncstatustype(name::AbstractString)
+
+Get AsyncStatusType by symbolic name.
+"""
 asyncstatustype(name::AbstractString) = GDAL.gdalgetasyncstatustypebyname(name)
 
-"Return name (string) corresponding to color interpretation"
+"""
+    getname(obj::GDALColorInterp)
+
+Return name (string) corresponding to color interpretation.
+"""
 getname(obj::GDALColorInterp) = GDAL.gdalgetcolorinterpretationname(obj)
 
-"Get color interpretation corresponding to the given symbolic name."
+"""
+    colorinterp(name::AbstractString)
+
+Get color interpretation corresponding to the given symbolic name.
+"""
 colorinterp(name::AbstractString) = GDAL.gdalgetcolorinterpretationbyname(name)
 
-"Get name of palette interpretation."
+"""
+    getname(obj::GDALPaletteInterp)
+
+Get name of palette interpretation.
+"""
 getname(obj::GDALPaletteInterp) = GDAL.gdalgetpaletteinterpretationname(obj)
 
-"Fetch human readable name for a field type."
+"""
+    getname(obj::OGRFieldType)
+
+Fetch human readable name for a field type.
+"""
 getname(obj::OGRFieldType) = GDAL.ogr_getfieldtypename(obj)
 
-"Fetch human readable name for a field subtype."
+"""
+    getname(obj::OGRFieldSubType)
+
+Fetch human readable name for a field subtype.
+"""
 getname(obj::OGRFieldSubType) = GDAL.ogr_getfieldsubtypename(obj)
 
-"Return if type and subtype are compatible."
+"""
+    arecompatible(dtype::OGRFieldType, subtype::OGRFieldSubType)
+
+Return if type and subtype are compatible.
+"""
 arecompatible(dtype::OGRFieldType, subtype::OGRFieldSubType) =
     Bool(GDAL.ogr_aretypesubtypecompatible(dtype, subtype))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,4 +1,6 @@
 """
+    gdalinfo(dataset::Dataset, options = String[])
+
 List various information about a GDAL supported raster dataset.
 
 ### Parameters
@@ -17,6 +19,8 @@ function gdalinfo(dataset::Dataset, options = String[])
 end
 
 """
+    unsafe_gdaltranslate(dataset::Dataset, options = String[]; dest = "/vsimem/tmp")
+
 Convert raster data between different formats.
 
 ### Parameters
@@ -40,6 +44,8 @@ function unsafe_gdaltranslate(
 end
 
 """
+    unsafe_gdalwarp(datasets::Vector{Dataset}, options = String[]; dest = "/vsimem/tmp")
+
 Image reprojection and warping function.
 
 ### Parameters
@@ -64,6 +70,8 @@ function unsafe_gdalwarp(
 end
 
 """
+    unsafe_gdalvectortranslate(datasets::Vector{Dataset}, options = String[]; dest = "/vsimem/tmp")
+
 Convert vector data between file formats.
 
 ### Parameters
@@ -88,6 +96,8 @@ function unsafe_gdalvectortranslate(
 end
 
 """
+    unsafe_gdaldem(dataset::Dataset, processing::String, options = String[]; dest = "/vsimem/tmp", colorfile)
+
 Tools to analyze and visualize DEMs.
 
 ### Parameters
@@ -123,6 +133,8 @@ function unsafe_gdaldem(
 end
 
 """
+    unsafe_gdalnearblack(dataset::Dataset, options = String[]; dest = "/vsimem/tmp")
+
 Convert nearly black/white borders to exact value.
 
 ### Parameters
@@ -146,6 +158,8 @@ function unsafe_gdalnearblack(
 end
 
 """
+    unsafe_gdalgrid(dataset::Dataset, options = String[]; dest = "/vsimem/tmp")
+
 Create a raster from the scattered data.
 
 ### Parameters
@@ -169,6 +183,8 @@ function unsafe_gdalgrid(
 end
 
 """
+    unsafe_gdalrasterize(dataset::Dataset, options = String[]; dest = "/vsimem/tmp")
+
 Burn vector geometries into a raster.
 
 ### Parameters
@@ -192,6 +208,8 @@ function unsafe_gdalrasterize(
 end
 
 """
+    unsafe_gdalbuildvrt(datasets::Vector{Dataset}, options = String[]; dest = "/vsimem/tmp")
+
 Build a VRT from a list of datasets.
 
 ### Parameters

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,14 +55,24 @@ end
 #     stringlist
 # end
 
-"Fetch list of (non-empty) metadata domains. (Since: GDAL 1.11)"
+"""
+    metadatadomainlist(obj)
+
+Fetch list of (non-empty) metadata domains.
+"""
 metadatadomainlist(obj) = GDAL.gdalgetmetadatadomainlist(obj.ptr)
 
-"Fetch metadata. Note that relatively few formats return any metadata."
+"""
+    metadata(obj; domain::AbstractString = "")
+
+Fetch metadata. Note that relatively few formats return any metadata.
+"""
 metadata(obj; domain::AbstractString = "") =
     GDAL.gdalgetmetadata(obj.ptr, domain)
 
 """
+    setconfigoption(option::AbstractString, value)
+
 Set a configuration option for GDAL/OGR use.
 
 Those options are defined as a (key, value) couple. The value corresponding to a
@@ -83,6 +93,8 @@ setconfigoption(option::AbstractString, value) =
     GDAL.cplsetconfigoption(option, value)
 
 """
+    clearconfigoption(option::AbstractString)
+
 This function can be used to clear a setting.
 
 Note: it will not unset an existing environment variable; it will
@@ -91,6 +103,8 @@ just unset a value previously set by `setconfigoption()`.
 clearconfigoption(option::AbstractString) = setconfigoption(option, C_NULL)
 
 """
+    getconfigoption(option::AbstractString, default = C_NULL)
+
 Get the value of a configuration option.
 
 The value is the value of a (key, value) option set with `setconfigoption()`.
@@ -113,6 +127,8 @@ function getconfigoption(option::AbstractString, default = C_NULL)
 end
 
 """
+    setthreadconfigoption(option::AbstractString, value)
+
 Set a configuration option for GDAL/OGR use.
 
 Those options are defined as a (key, value) couple. The value corresponding to a
@@ -130,6 +146,8 @@ setthreadconfigoption(option::AbstractString, value) =
     GDAL.cplsetthreadlocalconfigoption(option, value)
 
 """
+    clearthreadconfigoption(option::AbstractString)
+
 This function can be used to clear a setting.
 
 Note: it will not unset an existing environment variable; it will
@@ -138,7 +156,11 @@ just unset a value previously set by `setthreadconfigoption()`.
 clearthreadconfigoption(option::AbstractString) =
     setthreadconfigoption(option, C_NULL)
 
-"Same as `getconfigoption()` but with settings from `setthreadconfigoption()`."
+"""
+    getthreadconfigoption(option::AbstractString, default = C_NULL)
+
+Same as `getconfigoption()` but with settings from `setthreadconfigoption()`.
+"""
 function getthreadconfigoption(option::AbstractString, default = C_NULL)
     result = @gdal(CPLGetThreadLocalConfigOption::Cstring,
         option::Cstring,

--- a/test/remotefiles.jl
+++ b/test/remotefiles.jl
@@ -1,0 +1,67 @@
+# this file downloads files which are used during testing the package
+# if they are already present and their checksum matches, they are not downloaded again
+
+using BinaryProvider
+
+const testdatadir = @__DIR__
+
+REPO_URL = "https://github.com/yeesian/ArchGDALDatasets/blob/master/"
+
+# remote files with SHA-2 256 hash
+remotefiles = [
+    ("data/A.tif", "8e8654c56dcb6cfd4b446f811cf3ca84713dbc4768107c1d84a614abeec77898"),
+    ("data/point.geojson", "8744593479054a67c784322e0c198bfa880c9388b39a2ddd4c56726944711bd9"),
+    ("data/utmsmall.tif", "f40dae6e8b5e18f3648e9f095e22a0d7027014bb463418d32f732c3756d8c54f"),
+    ("gdalworkshop/world.tif", "b376dc8af62f9894b5050a6a9273ac0763ae2990b556910d35d4a8f4753278bb"),
+    ("ospy/data1/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
+    ("ospy/data1/sites.prj", "81fb1a246728609a446b25b0df9ede41c3e7b6a133ce78f10edbd2647fc38ce1"),
+    ("ospy/data1/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
+    ("ospy/data1/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
+    ("ospy/data1/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
+    ("ospy/data1/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
+    ("ospy/data2/ut_counties.dbf", "94607dfbcb1b547bef9956e5704520003e20d3c1b7d9c38ae6c275a68a359c35"),
+    ("ospy/data2/ut_counties.prj", "f10dda97619145fe1e0c6b067675171c5b7f3861755a2daecb18f9a688df4620"),
+    ("ospy/data2/ut_counties.shp", "e05104edc9c2120cccad9bd4e316fc3e937f706e8c3ad79118784fcafe78f695"),
+    ("ospy/data2/ut_counties.shx", "20d9acbf261bfbcb8a751e6945aeb1589809c9bd5361f5714577d9513bb32bc6"),
+    ("ospy/data2/ut_counties.txt", "06585b736091f5bbc62eb040918b1693b2716f550ab306026732e1dfa6cd49a7"),
+    ("ospy/data3/cache_towns.dbf", "2344b5195e1a7cbc141f38d6f3214f04c0d43058309b162e877fca755cd1d9fa"),
+    ("ospy/data3/cache_towns.sbn", "217e938eb0bec1cdccf26d87e5127d395d68b5d660bc1ecc1d7ec7b3f052f4e3"),
+    ("ospy/data3/cache_towns.sbx", "e027b3f67bbb60fc9cf67ab6f430b286fd8a1eaa6c344edaa7da4327485ee9f2"),
+    ("ospy/data3/cache_towns.shp", "635998f789d349d80368cb105e7e0d61f95cc6eecd36b34bf005d8c7e966fedb"),
+    ("ospy/data3/cache_towns.shx", "0cafc504b829a3da2c0363074f775266f9e1f6aaaf1e066b8a613d5862f313b7"),
+    ("ospy/data3/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
+    ("ospy/data3/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
+    ("ospy/data3/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
+    ("ospy/data3/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
+    ("ospy/data3/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
+    ("ospy/data4/aster.img", "2423205bdf820b1c2a3f03862664d84ea4b5b899c57ed33afd8962664e80a298"),
+    ("ospy/data4/aster.rrd", "18e038aabe8fd92b0d12cd4f324bb2e0368343e20cc41e5411a6d038108a25cf"),
+    ("ospy/data4/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
+    ("ospy/data4/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
+    ("ospy/data4/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
+    ("ospy/data4/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
+    ("ospy/data4/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
+    ("ospy/data5/aster.img", "2423205bdf820b1c2a3f03862664d84ea4b5b899c57ed33afd8962664e80a298"),
+    ("ospy/data5/aster.rrd", "18e038aabe8fd92b0d12cd4f324bb2e0368343e20cc41e5411a6d038108a25cf"),
+    ("ospy/data5/doq1.img", "70b8e641c52367107654962e81977be65402aa3c46736a07cb512ce960203bb7"),
+    ("ospy/data5/doq1.rrd", "f9f2fe57d789977090ec0c31e465052161886e79a4c4e10805b5e7ab28c06177"),
+    ("ospy/data5/doq2.img", "1e1d744f17e6a3b97dd9b7d8705133c72ff162613bae43ad94417c54e6aced5d"),
+    ("ospy/data5/doq2.rrd", "8274dad00b27e008e5ada62afb1025b0e6e2ef2d2ff2642487ecaee64befd914"),
+    ("pyrasterio/example.tif", "e4f50bf1f92d8b045c41c6ec101c60e88d663213db9ab90983a66219f28e1b8e"),
+    ("pyrasterio/example2.tif", "08145d14e37d68dc586e0ddc74ad5047577ab86c52f2999cd34c0d851a82214c"),
+    ("pyrasterio/example3.tif", "e37f6e54d3fb565905a53e9c4a54cc2dd4937df92e35a0aba40470ac166e8688"),
+    ("pyrasterio/float_nan.tif", "ae2b8df3ff521d358c1cdd06a3d721ebb028fb19ce89f7e7e83f5efe66d39e1d"),
+    ("pyrasterio/float.tif", "758905d08f0f577571bdc083b50c638872c4e1c6465e75076c4ecdd1599e3b24"),
+    ("pyrasterio/RGB.byte.tif", "8a9079098409b516d0c3d1965b6ebf64ab69fec12e0c2495d6b200c2ea9dd12a"),
+    ("pyrasterio/shade.tif", "a763eb1f223845eeaf6309a11d03acb221b7d54cda526a639fb71a75ba5ec49b")
+]
+
+for (f, sha) in remotefiles
+    # create the directories if they don't exist
+    currdir = dirname(f)
+    isdir(currdir) || mkpath(currdir)
+    # download the file if it is not there or if it has a different checksum
+    currfile = normpath(joinpath(testdatadir, f))
+    url = REPO_URL * f * "?raw=true"
+    download_verify(url, sha, currfile; force=true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,68 +2,8 @@ using Test
 using Dates
 using BinaryProvider
 
-const testdatadir = @__DIR__
-
-REPO_URL = "https://github.com/yeesian/ArchGDALDatasets/blob/master/"
-
-# remote files with SHA-2 256 hash
-remotefiles = [
-    ("data/A.tif", "8e8654c56dcb6cfd4b446f811cf3ca84713dbc4768107c1d84a614abeec77898"),
-    ("data/point.geojson", "8744593479054a67c784322e0c198bfa880c9388b39a2ddd4c56726944711bd9"),
-    ("data/utmsmall.tif", "f40dae6e8b5e18f3648e9f095e22a0d7027014bb463418d32f732c3756d8c54f"),
-    ("gdalworkshop/world.tif", "b376dc8af62f9894b5050a6a9273ac0763ae2990b556910d35d4a8f4753278bb"),
-    ("ospy/data1/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
-    ("ospy/data1/sites.prj", "81fb1a246728609a446b25b0df9ede41c3e7b6a133ce78f10edbd2647fc38ce1"),
-    ("ospy/data1/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
-    ("ospy/data1/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
-    ("ospy/data1/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
-    ("ospy/data1/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
-    ("ospy/data2/ut_counties.dbf", "94607dfbcb1b547bef9956e5704520003e20d3c1b7d9c38ae6c275a68a359c35"),
-    ("ospy/data2/ut_counties.prj", "f10dda97619145fe1e0c6b067675171c5b7f3861755a2daecb18f9a688df4620"),
-    ("ospy/data2/ut_counties.shp", "e05104edc9c2120cccad9bd4e316fc3e937f706e8c3ad79118784fcafe78f695"),
-    ("ospy/data2/ut_counties.shx", "20d9acbf261bfbcb8a751e6945aeb1589809c9bd5361f5714577d9513bb32bc6"),
-    ("ospy/data2/ut_counties.txt", "06585b736091f5bbc62eb040918b1693b2716f550ab306026732e1dfa6cd49a7"),
-    ("ospy/data3/cache_towns.dbf", "2344b5195e1a7cbc141f38d6f3214f04c0d43058309b162e877fca755cd1d9fa"),
-    ("ospy/data3/cache_towns.sbn", "217e938eb0bec1cdccf26d87e5127d395d68b5d660bc1ecc1d7ec7b3f052f4e3"),
-    ("ospy/data3/cache_towns.sbx", "e027b3f67bbb60fc9cf67ab6f430b286fd8a1eaa6c344edaa7da4327485ee9f2"),
-    ("ospy/data3/cache_towns.shp", "635998f789d349d80368cb105e7e0d61f95cc6eecd36b34bf005d8c7e966fedb"),
-    ("ospy/data3/cache_towns.shx", "0cafc504b829a3da2c0363074f775266f9e1f6aaaf1e066b8a613d5862f313b7"),
-    ("ospy/data3/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
-    ("ospy/data3/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
-    ("ospy/data3/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
-    ("ospy/data3/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
-    ("ospy/data3/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
-    ("ospy/data4/aster.img", "2423205bdf820b1c2a3f03862664d84ea4b5b899c57ed33afd8962664e80a298"),
-    ("ospy/data4/aster.rrd", "18e038aabe8fd92b0d12cd4f324bb2e0368343e20cc41e5411a6d038108a25cf"),
-    ("ospy/data4/sites.dbf", "7df95edea06c46418287ae3430887f44f9116b29715783f7d1a11b2b931d6e7d"),
-    ("ospy/data4/sites.sbn", "198d9d695f3e7a0a0ac0ebfd6afbe044b78db3e685fffd241a32396e8b341ed3"),
-    ("ospy/data4/sites.sbx", "49bbe1942b899d52cf1d1b01ea10bd481ec40bdc4c94ff866aece5e81f2261f6"),
-    ("ospy/data4/sites.shp", "69af5a6184053f0b71f266dc54c944f1ec02013fb66dbb33412d8b1976d5ea2b"),
-    ("ospy/data4/sites.shx", "1f3da459ccb151958743171e41e6a01810b2a007305d55666e01d680da7bbf08"),
-    ("ospy/data5/aster.img", "2423205bdf820b1c2a3f03862664d84ea4b5b899c57ed33afd8962664e80a298"),
-    ("ospy/data5/aster.rrd", "18e038aabe8fd92b0d12cd4f324bb2e0368343e20cc41e5411a6d038108a25cf"),
-    ("ospy/data5/doq1.img", "70b8e641c52367107654962e81977be65402aa3c46736a07cb512ce960203bb7"),
-    ("ospy/data5/doq1.rrd", "f9f2fe57d789977090ec0c31e465052161886e79a4c4e10805b5e7ab28c06177"),
-    ("ospy/data5/doq2.img", "1e1d744f17e6a3b97dd9b7d8705133c72ff162613bae43ad94417c54e6aced5d"),
-    ("ospy/data5/doq2.rrd", "8274dad00b27e008e5ada62afb1025b0e6e2ef2d2ff2642487ecaee64befd914"),
-    ("pyrasterio/example.tif", "e4f50bf1f92d8b045c41c6ec101c60e88d663213db9ab90983a66219f28e1b8e"),
-    ("pyrasterio/example2.tif", "08145d14e37d68dc586e0ddc74ad5047577ab86c52f2999cd34c0d851a82214c"),
-    ("pyrasterio/example3.tif", "e37f6e54d3fb565905a53e9c4a54cc2dd4937df92e35a0aba40470ac166e8688"),
-    ("pyrasterio/float_nan.tif", "ae2b8df3ff521d358c1cdd06a3d721ebb028fb19ce89f7e7e83f5efe66d39e1d"),
-    ("pyrasterio/float.tif", "758905d08f0f577571bdc083b50c638872c4e1c6465e75076c4ecdd1599e3b24"),
-    ("pyrasterio/RGB.byte.tif", "8a9079098409b516d0c3d1965b6ebf64ab69fec12e0c2495d6b200c2ea9dd12a"),
-    ("pyrasterio/shade.tif", "a763eb1f223845eeaf6309a11d03acb221b7d54cda526a639fb71a75ba5ec49b")
-]
-
-for (f, sha) in remotefiles
-    # create the directories if they don't exist
-    currdir = dirname(f)
-    isdir(currdir) || mkpath(currdir)
-    # download the file if it is not there or if it has a different checksum
-    currfile = normpath(joinpath(testdatadir, f))
-    url = REPO_URL * f * "?raw=true"
-    download_verify(url, sha, currfile; force=true)
-end
+# ensure all testing files are present
+include("remotefiles.jl")
 
 @testset "ArchGDAL" begin
     cd(dirname(@__FILE__)) do


### PR DESCRIPTION
Will fix #92

~~Right now it doesn't add docstrings to the docs yet, but has some related doc improvements.~~

For docstrings I am still looking a bit what to do.

Either we can add an API reference page, with all the docstrings, split into headers following roughly the rest of the docs (features/rasters/projections). Alternatively I can try to embed the docstrings in the existing pages, suggestions for which is better are welcome. If we create a API reference page, I would still add references from the usage pages towards the API reference.

I tried locally to use `autodocs`, and find that some docstrings are effectively duplicates. For instance there is `setfield!(feature::Feature, i::Integer, value::Cint)` and `setfield!(feature::Feature, i::Integer, value::Int64)`. We need both since they go to different C functions. But right now it has almost the same docstring duplicated for each type of value. We could create one docstring instead, listing the different types of value we support.

We should probably also add the call signature to the docstring as is commonly done. This also results in clearer documentation. See also the [manual page on documentation](https://docs.julialang.org/en/latest/manual/documentation/#).