### PR TITLE
Add a kwarg to set OSRAxisMappingStrategy

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -8,38 +8,38 @@ The Geom trait is needed to separate out convert for CRS for WellKnownText
 and GML, which may contain both.
 """
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.FormatMode,Type{GFT.FormatMode}}, 
-             source::GFT.GeoFormat) =
-    convert(target, convert(AbstractGeometry, source))
+             source::GFT.GeoFormat; kwargs...) =
+    convert(target, convert(AbstractGeometry, source); kwargs...)
 
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
 Convert `GeoFormat` geometry data to an ArchGDAL `Geometry` type
 """
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText) = 
-    fromWKT(GFT.val(source))
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.WellKnownBinary) = 
-    fromWKB(GFT.val(source))
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.GeoJSON) = 
-    fromJSON(GFT.val(source))
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML) = 
-    fromGML(GFT.val(source))
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText; kwargs...) = 
+    fromWKT(GFT.val(source); kwargs...)
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.WellKnownBinary; kwargs...) = 
+    fromWKB(GFT.val(source); kwargs...)
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GeoJSON; kwargs...) = 
+    fromJSON(GFT.val(source); kwargs...)
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML; kwargs...) = 
+    fromGML(GFT.val(source); kwargs...)
 
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
 Convert `AbstractGeometry` data to any gemoetry `GeoFormat` 
 """
-Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
-    GFT.WellKnownText(GFT.Geom(), toWKT(source))
-Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
-    GFT.WellKnownBinary(GFT.Geom(), toWKB(source))
-Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry) = 
-    GFT.GeoJSON(toJSON(source))
-Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry) = 
-    GFT.GML(GFT.Geom(), toGML(source))
-Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) = 
-    GFT.KML(toKML(source))
+Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry; kwargs...) = 
+    GFT.WellKnownText(GFT.Geom(), toWKT(source; kwargs...))
+Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry; kwargs...) = 
+    GFT.WellKnownBinary(GFT.Geom(), toWKB(source; kwargs...))
+Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry; kwargs...) = 
+    GFT.GeoJSON(toJSON(source; kwargs...))
+Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry; kwargs...) = 
+    GFT.GML(GFT.Geom(), toGML(source; kwargs...))
+Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry; kwargs...) = 
+    GFT.KML(toKML(source; kwargs...))
 
 
 """
@@ -48,17 +48,19 @@ Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) =
 Convert `GeoFormat` crs data to another another `GeoFormat` crs type.
 """
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.CRS,Type{GFT.CRS}}, 
-             source::GFT.GeoFormat) =
-    unsafe_convertcrs(target, importCRS(source))
+             source::GFT.GeoFormat; kwargs...) =
+    importCRS(source; kwargs...) do crs
+        unsafe_convertcrs(target, crs)
+    end
 
-unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref) = 
-    GFT.CoordSys(toMICoordSys(crsref))
-unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref) = 
-    GFT.ProjString(toPROJ4(crsref))
-unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref) = 
-    GFT.WellKnownText(GFT.CRS(), toWKT(crsref))
-unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref) =
-    GFT.ESRIWellKnownText(GFT.CRS(), toWKT(morphtoESRI!(crsref)))
-unsafe_convertcrs(::Type{<:GFT.GML}, crsref) = 
-    GFT.GML(toXML(crsref))
+unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref; kwargs...) = 
+    GFT.CoordSys(toMICoordSys(crsref; kwargs...))
+unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref; kwargs...) = 
+    GFT.ProjString(toPROJ4(crsref; kwargs...))
+unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref; kwargs...) = 
+    GFT.WellKnownText(GFT.CRS(), toWKT(crsref; kwargs...))
+unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref; kwargs...) =
+    GFT.ESRIWellKnownText(GFT.CRS(), toWKT(morphtoESRI!(crsref; kwargs...)))
+unsafe_convertcrs(::Type{<:GFT.GML}, crsref; kwargs...) = 
+    GFT.GML(toXML(crsref; kwargs...))
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -6,40 +6,43 @@
 Convert a GeoFromat object to Geometry, then to the target format.
 The Geom trait is needed to separate out convert for CRS for WellKnownText
 and GML, which may contain both.
+
+Both `Geom` and `Mixed` formats are converted to Geometries by default. 
+To convert a `Mixed` format to crs, `CRS` must be explicitly passed for `mode`.
 """
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.FormatMode,Type{GFT.FormatMode}}, 
-             source::GFT.GeoFormat; kwargs...) =
-    convert(target, convert(AbstractGeometry, source); kwargs...)
+             source::GFT.GeoFormat) =
+    convert(target, convert(AbstractGeometry, source))
 
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
 Convert `GeoFormat` geometry data to an ArchGDAL `Geometry` type
 """
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText; kwargs...) = 
-    fromWKT(GFT.val(source); kwargs...)
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.WellKnownBinary; kwargs...) = 
-    fromWKB(GFT.val(source); kwargs...)
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.GeoJSON; kwargs...) = 
-    fromJSON(GFT.val(source); kwargs...)
-Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML; kwargs...) = 
-    fromGML(GFT.val(source); kwargs...)
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.AbstractWellKnownText) = 
+    fromWKT(GFT.val(source))
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.WellKnownBinary) = 
+    fromWKB(GFT.val(source))
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GeoJSON) = 
+    fromJSON(GFT.val(source))
+Base.convert(::Type{<:AbstractGeometry}, source::GFT.GML) = 
+    fromGML(GFT.val(source))
 
 """
     convert(::Type{<:AbstractGeometry}, source::GeoFormat)
 
 Convert `AbstractGeometry` data to any gemoetry `GeoFormat` 
 """
-Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry; kwargs...) = 
-    GFT.WellKnownText(GFT.Geom(), toWKT(source; kwargs...))
-Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry; kwargs...) = 
-    GFT.WellKnownBinary(GFT.Geom(), toWKB(source; kwargs...))
-Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry; kwargs...) = 
-    GFT.GeoJSON(toJSON(source; kwargs...))
-Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry; kwargs...) = 
-    GFT.GML(GFT.Geom(), toGML(source; kwargs...))
-Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry; kwargs...) = 
-    GFT.KML(toKML(source; kwargs...))
+Base.convert(::Type{<:GFT.AbstractWellKnownText}, source::AbstractGeometry) = 
+    GFT.WellKnownText(GFT.Geom(), toWKT(source))
+Base.convert(::Type{<:GFT.WellKnownBinary}, source::AbstractGeometry) = 
+    GFT.WellKnownBinary(GFT.Geom(), toWKB(source))
+Base.convert(::Type{<:GFT.GeoJSON}, source::AbstractGeometry) = 
+    GFT.GeoJSON(toJSON(source))
+Base.convert(::Type{<:GFT.GML}, source::AbstractGeometry) = 
+    GFT.GML(GFT.Geom(), toGML(source))
+Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry) = 
+    GFT.KML(toKML(source))
 
 
 """
@@ -48,19 +51,17 @@ Base.convert(::Type{<:GFT.KML}, source::AbstractGeometry; kwargs...) =
 Convert `GeoFormat` crs data to another another `GeoFormat` crs type.
 """
 Base.convert(target::Type{<:GFT.GeoFormat}, mode::Union{GFT.CRS,Type{GFT.CRS}}, 
-             source::GFT.GeoFormat; kwargs...) =
-    importCRS(source; kwargs...) do crs
-        unsafe_convertcrs(target, crs)
-    end
+             source::GFT.GeoFormat) =
+    unsafe_convertcrs(target, importCRS(source))
 
-unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref; kwargs...) = 
-    GFT.CoordSys(toMICoordSys(crsref; kwargs...))
-unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref; kwargs...) = 
-    GFT.ProjString(toPROJ4(crsref; kwargs...))
-unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref; kwargs...) = 
-    GFT.WellKnownText(GFT.CRS(), toWKT(crsref; kwargs...))
-unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref; kwargs...) =
-    GFT.ESRIWellKnownText(GFT.CRS(), toWKT(morphtoESRI!(crsref; kwargs...)))
-unsafe_convertcrs(::Type{<:GFT.GML}, crsref; kwargs...) = 
-    GFT.GML(toXML(crsref; kwargs...))
+unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref) = 
+    GFT.CoordSys(toMICoordSys(crsref))
+unsafe_convertcrs(::Type{<:GFT.ProjString}, crsref) = 
+    GFT.ProjString(toPROJ4(crsref))
+unsafe_convertcrs(::Type{<:GFT.WellKnownText}, crsref) = 
+    GFT.WellKnownText(GFT.CRS(), toWKT(crsref))
+unsafe_convertcrs(::Type{<:GFT.ESRIWellKnownText}, crsref) =
+    GFT.ESRIWellKnownText(GFT.CRS(), toWKT(morphtoESRI!(crsref)))
+unsafe_convertcrs(::Type{<:GFT.GML}, crsref) = 
+    GFT.GML(toXML(crsref))
 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -8,7 +8,7 @@ binary (WKB) representation.
 ### Parameters
 * `data`: pointer to the input BLOB data.
 """
-function fromWKB(data; kwargs...)
+function fromWKB(data)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkb::GDAL.OGRErr,
         data::Ptr{Cuchar},
@@ -20,7 +20,7 @@ function fromWKB(data; kwargs...)
     return IGeometry(geom[])
 end
 
-function unsafe_fromWKB(data; kwargs...)
+function unsafe_fromWKB(data)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkb::GDAL.OGRErr,
         data::Ptr{Cuchar},
@@ -43,7 +43,7 @@ Create a geometry object of the appropriate type from its well known text
     geometry to be created. The pointer is updated to point just beyond that
     last character consumed.
 """
-function fromWKT(data::Vector{String}; kwargs...)
+function fromWKT(data::Vector{String})
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkt::GDAL.OGRErr,
         data::StringList,
@@ -54,7 +54,7 @@ function fromWKT(data::Vector{String}; kwargs...)
     return IGeometry(geom[])
 end
 
-function unsafe_fromWKT(data::Vector{String}; kwargs...)
+function unsafe_fromWKT(data::Vector{String})
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkt::GDAL.OGRErr,
         data::StringList,
@@ -65,11 +65,9 @@ function unsafe_fromWKT(data::Vector{String}; kwargs...)
     return Geometry(geom[])
 end
 
-fromWKT(data::String, args...; kwargs...) = 
-    fromWKT([data], args...; kwargs...)
+fromWKT(data::String, args...) = fromWKT([data], args...)
 
-unsafe_fromWKT(data::String, args...; kwargs...) = 
-    unsafe_fromWKT([data], args...; kwargs...)
+unsafe_fromWKT(data::String, args...) = unsafe_fromWKT([data], args...)
 
 """
 Destroy geometry object.
@@ -260,7 +258,7 @@ wkbsize(geom::AbstractGeometry) = GDAL.ogr_g_wkbsize(geom.ptr)
 
 Convert a geometry into well known text format.
 """
-function toWKT(geom::AbstractGeometry; kwargs...)
+function toWKT(geom::AbstractGeometry)
     wkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttowkt(geom.ptr, wkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to WKT"
@@ -274,7 +272,7 @@ end
 
 Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
 """
-function toISOWKT(geom::AbstractGeometry; kwargs...)
+function toISOWKT(geom::AbstractGeometry)
     isowkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttoisowkt(geom.ptr, isowkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to ISOWKT"

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -8,7 +8,7 @@ binary (WKB) representation.
 ### Parameters
 * `data`: pointer to the input BLOB data.
 """
-function fromWKB(data)
+function fromWKB(data; kwargs...)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkb::GDAL.OGRErr,
         data::Ptr{Cuchar},
@@ -20,7 +20,7 @@ function fromWKB(data)
     return IGeometry(geom[])
 end
 
-function unsafe_fromWKB(data)
+function unsafe_fromWKB(data; kwargs...)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkb::GDAL.OGRErr,
         data::Ptr{Cuchar},
@@ -43,7 +43,7 @@ Create a geometry object of the appropriate type from its well known text
     geometry to be created. The pointer is updated to point just beyond that
     last character consumed.
 """
-function fromWKT(data::Vector{String})
+function fromWKT(data::Vector{String}; kwargs...)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkt::GDAL.OGRErr,
         data::StringList,
@@ -54,7 +54,7 @@ function fromWKT(data::Vector{String})
     return IGeometry(geom[])
 end
 
-function unsafe_fromWKT(data::Vector{String})
+function unsafe_fromWKT(data::Vector{String}; kwargs...)
     geom = Ref{GDALGeometry}()
     result = @gdal(OGR_G_CreateFromWkt::GDAL.OGRErr,
         data::StringList,
@@ -65,9 +65,11 @@ function unsafe_fromWKT(data::Vector{String})
     return Geometry(geom[])
 end
 
-fromWKT(data::String, args...) = fromWKT([data], args...)
+fromWKT(data::String, args...; kwargs...) = 
+    fromWKT([data], args...; kwargs...)
 
-unsafe_fromWKT(data::String, args...) = unsafe_fromWKT([data], args...)
+unsafe_fromWKT(data::String, args...; kwargs...) = 
+    unsafe_fromWKT([data], args...; kwargs...)
 
 """
 Destroy geometry object.
@@ -258,7 +260,7 @@ wkbsize(geom::AbstractGeometry) = GDAL.ogr_g_wkbsize(geom.ptr)
 
 Convert a geometry into well known text format.
 """
-function toWKT(geom::AbstractGeometry)
+function toWKT(geom::AbstractGeometry; kwargs...)
     wkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttowkt(geom.ptr, wkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to WKT"
@@ -272,7 +274,7 @@ end
 
 Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
 """
-function toISOWKT(geom::AbstractGeometry)
+function toISOWKT(geom::AbstractGeometry; kwargs...)
     isowkt_ptr = Ref(Cstring(C_NULL))
     result = GDAL.ogr_g_exporttoisowkt(geom.ptr, isowkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to ISOWKT"

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -70,11 +70,11 @@ reproject(coord::ReprojectCoord, sourcecrs::GFT.GeoFormat, targetcrs::GFT.GeoFor
     GeoInterface.coordinates(reproject(createpoint(coord...), sourcecrs, targetcrs; kwargs...))
 reproject(coords::AbstractArray{<:ReprojectCoord}, sourcecrs::GFT.GeoFormat, 
           targetcrs::GFT.GeoFormat; kwargs...) =
-    GeoInterface.coordinates.(reproject([createpoint(c...) for c in coords], sourcecrs, targetcrs))
+    GeoInterface.coordinates.(reproject([createpoint(c...) for c in coords], sourcecrs, targetcrs; kwargs...))
 
 # GeoFormat
 reproject(geom::GFT.GeoFormat, sourcecrs::GFT.GeoFormat, targetcrs::GFT.GeoFormat; kwargs...) =
-    convert(typeof(geom), reproject(convert(Geometry, geom), sourcecrs, targetcrs))
+    convert(typeof(geom), reproject(convert(Geometry, geom), sourcecrs, targetcrs; kwargs...))
 
 # Geometries
 function reproject(geom::AbstractGeometry, sourcecrs::GFT.GeoFormat, targetcrs::GFT.GeoFormat; kwargs...)

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -105,10 +105,10 @@ Construct a Spatial Reference System from its WKT.
 `order` keyword argument can be `:trad` for traditional lon/lat order (the default),
 or `:compliant` for the authority specified order. `:custom` is not yet supported.
 """
-newspatialref(wkt::AbstractString = ""; order=:trad) =
+newspatialref(wkt::AbstractString = ""; order=:compliant) =
     maybesetaxisorder!(ISpatialRef(GDAL.osrnewspatialreference(wkt)), order)
 
-unsafe_newspatialref(wkt::AbstractString = ""; order=:trad) =
+unsafe_newspatialref(wkt::AbstractString = ""; order=:compliant) =
     maybesetaxisorder!(SpatialRef(GDAL.osrnewspatialreference(wkt)), order)
 
 function maybesetaxisorder!(sr::AbstractSpatialRef, order)

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -3,6 +3,10 @@
 
 Import a coordinate reference system from a `GeoFormat` into GDAL,
 returning an [`AbstractSpatialRef`](@ref).
+
+The `order` keyword argument can be passed in. `:trad` will use traditional
+lon/lat axis ordering in any actions done with the crs. `:compliant`, the default
+will use axis ordering compliant with the relevent CRS authority.
 """
 importCRS(x::GFT.GeoFormat; kwargs...) =
     importCRS!(newspatialref(; kwargs...), x)
@@ -36,9 +40,15 @@ importCRS!(spref::AbstractSpatialRef, x::GFT.KML; kwargs...) =
 Reproject points to a different coordinate reference system and/or format.
 
 ## Arguments
--`coord`: Vector of Geometry points
--`sourcecrs`: The current coordinate reference system, as a `GeoFormat`
--`targetcrs`: The coordinate reference system to transform to, using any CRS capable `GeoFormat`
+- `coord`: Vector of Geometry points
+- `sourcecrs`: The current coordinate reference system, as a `GeoFormat`
+- `targetcrs`: The coordinate reference system to transform to, using any CRS capable `GeoFormat`
+
+
+## Keyword Argument
+- `order`: `:trad` will use traditional lon/lat axis ordering in any actions done 
+  with the crs. `:compliant`, the default will use axis ordering compliant with 
+  the relevent CRS authority.
 
 ## Example
 
@@ -81,7 +91,7 @@ function reproject(geoms::AbstractArray{<:AbstractGeometry}, sourcecrs::GFT.GeoF
 end
 
 """
-    crs2transform(f::Function, sourcecrs::GeoFormat, targetcrs::GeoFormat)
+    crs2transform(f::Function, sourcecrs::GeoFormat, targetcrs::GeoFormat; kwargs...)
 
 Run the function `f` on a coord transform generated from the source and target
 crs definitions. These can be any `GeoFormat` (from GeoFormatTypes) that holds
@@ -102,8 +112,8 @@ end
 
 Construct a Spatial Reference System from its WKT.
 
-`order` keyword argument can be `:trad` for traditional lon/lat order (the default),
-or `:compliant` for the authority specified order. `:custom` is not yet supported.
+`order` keyword argument can be `:trad` for traditional lon/lat order, or `:compliant` 
+(the default) for the authority-specified order. `:custom` is not yet supported.
 """
 newspatialref(wkt::AbstractString = ""; order=:compliant) =
     maybesetaxisorder!(ISpatialRef(GDAL.osrnewspatialreference(wkt)), order)

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -2,7 +2,6 @@ using Test
 import GeoInterface, GeoFormatTypes, ArchGDAL 
 const AG = ArchGDAL
 const GFT = GeoFormatTypes
-const GI = GeoFormatTypes
 
 @testset "Reproject a Geometry" begin
     @testset "Method 1" begin
@@ -66,13 +65,13 @@ end
             @test AG.toPROJ4(AG.getspatialref(AG.getgeom(feature))) == "+proj=utm +zone=12 +datum=WGS84 +units=m +no_defs"
         end
     end
+
     AG.importEPSG(26912) do spatialref
         if VERSION >= v"1.3"  # GDAL.jl v1.1 which uses PROJ 6.3
             proj4str = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
         else  # GDAL.jl v1.0 which uses PROJ 6.1
             proj4str = "+proj=utm +zone=12 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
         end
-
         @test AG.toPROJ4(spatialref) == proj4str
         @test AG.toWKT(spatialref)[1:6] == "PROJCS"
         AG.morphtoESRI!(spatialref)

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -40,13 +40,19 @@ const GFT = GeoFormatTypes
             @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
             @test AG.reproject([coord], GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [[47.348801, -122.598135]]
             coord = (1120351.57, 741921.42)
-            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:compliant) ≈ [47.348801, -122.598135]
-            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:trad) ≈ [-122.598135, 47.348801]
-            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:compliant) ≈ [47.348801, -122.598135]
-            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:trad) ≈ [-122.598135, 47.348801]
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:compliant) ≈ 
+                [47.348801, -122.598135]
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:trad) ≈ 
+                [-122.598135, 47.348801]
+            @test AG.reproject([coord], GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:compliant) ≈ 
+                [[47.348801, -122.598135]]
+            @test AG.reproject([coord], GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:trad) ≈ 
+                [[-122.598135, 47.348801]]
             # :compliant doesn't work on PROJ axis order, it loses authority information
-            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:compliant) ≈ [-122.598135, 47.348801]
-            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:trad) ≈ [-122.598135, 47.348801]
+            @test AG.reproject([coord], GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:compliant) ≈ 
+                [[-122.598135, 47.348801]]
+            @test AG.reproject([coord], GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:trad) ≈ 
+                [[-122.598135, 47.348801]]
         end
     end
 

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -41,9 +41,16 @@ const GI = GeoFormatTypes
             @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
             @test AG.reproject([coord], GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [[47.348801, -122.598135]]
             coord = (1120351.57, 741921.42)
-            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326)) ≈ [47.348801, -122.598135]
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:compliant) ≈ [47.348801, -122.598135]
+            @test AG.reproject(coord, GFT.EPSG(2927), GFT.EPSG(4326); order=:trad) ≈ [-122.598135, 47.348801]
+            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:compliant) ≈ [47.348801, -122.598135]
+            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.WellKnownText, GFT.EPSG(4326)); order=:trad) ≈ [-122.598135, 47.348801]
+            # :compliant doesn't work on PROJ axis order, it loses authority information
+            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:compliant) ≈ [-122.598135, 47.348801]
+            @test AG.reproject(coord, GFT.EPSG(2927), convert(GFT.ProjString, GFT.EPSG(4326)); order=:trad) ≈ [-122.598135, 47.348801]
         end
     end
+
 end
 
 @testset "Get Projection" begin

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -1,6 +1,7 @@
 using Test
 import GDAL
 import ArchGDAL; const AG = ArchGDAL
+import GeoFormatTypes; const GFT = GeoFormatTypes
 
 @testset "Test Formats for Spatial Reference Systems" begin
     proj4326 = "+proj=longlat +datum=WGS84 +no_defs"


### PR DESCRIPTION
This is a first pass at setting `OSRAxisMappingStrategy` with a keyword argument.

I'm not sure how to implement it for `fromWKT` etc methods, where the `@gdal` macro is used, so some input on that would be helpful.

But otherwise it works for reprojecting points.

The default is `:trad` now for testing, but we can change that to `:compliant` depending on what people want the default behaviour to be for ArchGDAL

closes #119