### PR TITLE
require julia 1.3 / GDAL build with artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
+  - 1.3
   - 1
   - nightly
 matrix:
@@ -20,7 +20,7 @@ jobs:
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
+          Pkg.instantiate()'
         - julia --project=docs/ test/remotefiles.jl
         - julia --project=docs/ docs/make.jl
       after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
@@ -14,10 +14,10 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 
 [compat]
 DataStreams = "0.4.2"
-GDAL = "1.0.2"
+GDAL = "1.1.1"
 GeoInterface = "0.4, 0.5"
 GeoFormatTypes = "0.3"
-julia = "1"
+julia = "1.3"
 
 [extras]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1
-  - julia_version: nightly
+    - julia_version: 1.3
+    - julia_version: 1
+    - julia_version: nightly
 
 platform:
   - x86 # 32-bit
@@ -10,7 +10,7 @@ platform:
 
 matrix:
   allow_failures:
-  - julia_version: nightly
+    - julia_version: nightly
 
 branches:
   only:
@@ -33,7 +33,6 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
-
 # # Uncomment to support code coverage upload. Should only be enabled for packages
 # # which would have coverage gaps without running on Windows
 # on_success:

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -73,11 +73,7 @@ end
     end
 
     AG.importEPSG(26912) do spatialref
-        if VERSION >= v"1.3"  # GDAL.jl v1.1 which uses PROJ 6.3
-            proj4str = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
-        else  # GDAL.jl v1.0 which uses PROJ 6.1
-            proj4str = "+proj=utm +zone=12 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
-        end
+        proj4str = "+proj=utm +zone=12 +datum=NAD83 +units=m +no_defs"
         @test AG.toPROJ4(spatialref) == proj4str
         @test AG.toWKT(spatialref)[1:6] == "PROJCS"
         AG.morphtoESRI!(spatialref)


### PR DESCRIPTION
To always make use of the new GDAL build system (jll). Should make support easier but bumps our Julia version from LTS to 1.3.