### PR TITLE
replace Cint by <:Integer and add explicit conversion to Cint in rasterio.jl

### DIFF
--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -1,7 +1,7 @@
 
 """
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{Cint}; <keyword arguments>)
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{Cint}, rows, cols; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}, rows, cols; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}, rows, cols; <keyword arguments>)
 
@@ -64,7 +64,7 @@ function rasterio! end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{Cint},
+        bands::Vector{<:Integer},
         access::GDALRWFlag  = GDAL.GF_Read,
         pxspace::Integer    = 0,
         linespace::Integer  = 0,
@@ -78,7 +78,7 @@ end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{Cint},
+        bands::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer},
         access::GDALRWFlag  = GDAL.GF_Read,
@@ -206,7 +206,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Read)
     return buffer
@@ -235,7 +235,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -259,7 +259,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -271,7 +271,7 @@ read(dataset::AbstractDataset, i::Integer) = read(getband(dataset, i))
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     buffer = Array{pixeltype(getband(dataset, indices[1]))}(undef,
         width(dataset), height(dataset), length(indices))
@@ -324,7 +324,7 @@ end
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -342,7 +342,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Write)
     return dataset
@@ -364,7 +364,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -389,7 +389,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -402,7 +402,7 @@ for (T,GT) in _GDALTYPE
         function rasterio!(
                 dataset::AbstractDataset,
                 buffer::Array{$T, 3},
-                bands::Vector{Cint},
+                bands::Vector{<:Integer},
                 xoffset::Integer,
                 yoffset::Integer,
                 xsize::Integer,
@@ -422,14 +422,43 @@ for (T,GT) in _GDALTYPE
             (dataset == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize, zbsize = size(buffer)
             nband = length(bands)
+            bands = Cint.(bands)
             @assert nband == zbsize
-            result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),GDAL.CPLErr,
-                (GDALDataset,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Cvoid},
-                Cint,Cint,GDAL.GDALDataType,Cint,Ptr{Cint},GDAL.GSpacing,
-                GDAL.GSpacing,GDAL.GSpacing,Ptr{GDAL.GDALRasterIOExtraArg}),
-                dataset.ptr,access,xoffset,yoffset,xsize,ysize,pointer(buffer),
-                xbsize,ybsize,$GT,nband,pointer(bands),pxspace,linespace,
-                bandspace,extraargs)
+            result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),
+                           GDAL.CPLErr,  # return type
+                           (GDALDataset,
+                           GDAL.GDALRWFlag,  # access
+                           Cint,  # xoffset
+                           Cint,  # yoffset
+                           Cint,  # xsize
+                           Cint,  # ysize
+                           Ptr{Cvoid},  # poiter to buffer
+                           Cint,  # xbsize
+                           Cint,  # ybsize
+                           GDAL.GDALDataType,
+                           Cint,  # number of bands
+                           Ptr{Cint},  # bands
+                           GDAL.GSpacing,  # pxspace
+                           GDAL.GSpacing,  # linespace
+                           GDAL.GSpacing,  # bandspace
+                           Ptr{GDAL.GDALRasterIOExtraArg}  # extra args
+                           ),
+                           dataset.ptr,
+                           access,
+                           xoffset,
+                           yoffset,
+                           xsize,
+                           ysize,
+                           pointer(buffer),
+                           xbsize,
+                           ybsize,
+                           $GT,
+                           nband,
+                           pointer(bands),
+                           pxspace,
+                           linespace,
+                           bandspace,
+                           extraargs)
             @cplerr result "Access in DatasetRasterIO failed."
             return buffer
         end


### PR DESCRIPTION
Now this works without conversion to Cint/Int32:
```julia
ds = ag.read("somefile.tif")
img = ag.read(ds, [1,2,3])
```