### PR TITLE
Remove type specification from indices argument in rasterio.jl

### DIFF
--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -1,7 +1,7 @@
 
 """
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{Cint}; <keyword arguments>)
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{Cint}, rows, cols; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}, rows, cols; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}, rows, cols; <keyword arguments>)
 
@@ -64,7 +64,7 @@ function rasterio! end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{Cint},
+        bands::Vector{<:Integer},
         access::GDALRWFlag  = GDAL.GF_Read,
         pxspace::Integer    = 0,
         linespace::Integer  = 0,
@@ -78,7 +78,7 @@ end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{Cint},
+        bands::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer},
         access::GDALRWFlag  = GDAL.GF_Read,
@@ -206,7 +206,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Read)
     return buffer
@@ -235,7 +235,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -259,7 +259,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -271,7 +271,7 @@ read(dataset::AbstractDataset, i::Integer) = read(getband(dataset, i))
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     buffer = Array{pixeltype(getband(dataset, indices[1]))}(undef,
         width(dataset), height(dataset), length(indices))
@@ -324,7 +324,7 @@ end
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -342,7 +342,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint}
+        indices::Vector{<:Integer}
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Write)
     return dataset
@@ -364,7 +364,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -389,7 +389,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{Cint},
+        indices::Vector{<:Integer},
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -402,7 +402,7 @@ for (T,GT) in _GDALTYPE
         function rasterio!(
                 dataset::AbstractDataset,
                 buffer::Array{$T, 3},
-                bands::Vector{Cint},
+                bands::Vector{<:Integer},
                 xoffset::Integer,
                 yoffset::Integer,
                 xsize::Integer,
@@ -422,14 +422,43 @@ for (T,GT) in _GDALTYPE
             (dataset == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize, zbsize = size(buffer)
             nband = length(bands)
+            bands = Cint.(bands)
             @assert nband == zbsize
-            result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),GDAL.CPLErr,
-                (GDALDataset,GDAL.GDALRWFlag,Cint,Cint,Cint,Cint,Ptr{Cvoid},
-                Cint,Cint,GDAL.GDALDataType,Cint,Ptr{Cint},GDAL.GSpacing,
-                GDAL.GSpacing,GDAL.GSpacing,Ptr{GDAL.GDALRasterIOExtraArg}),
-                dataset.ptr,access,xoffset,yoffset,xsize,ysize,pointer(buffer),
-                xbsize,ybsize,$GT,nband,pointer(bands),pxspace,linespace,
-                bandspace,extraargs)
+            result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),
+                           GDAL.CPLErr,  # return type
+                           (GDALDataset,
+                           GDAL.GDALRWFlag,  # access
+                           Cint,  # xoffset
+                           Cint,  # yoffset
+                           Cint,  # xsize
+                           Cint,  # ysize
+                           Ptr{Cvoid},  # poiter to buffer
+                           Cint,  # xbsize
+                           Cint,  # ybsize
+                           GDAL.GDALDataType,
+                           Cint,  # number of bands
+                           Ptr{Cint},  # bands
+                           GDAL.GSpacing,  # pxspace
+                           GDAL.GSpacing,  # linespace
+                           GDAL.GSpacing,  # bandspace
+                           Ptr{GDAL.GDALRasterIOExtraArg}  # extra args
+                           ),
+                           dataset.ptr,
+                           access,
+                           xoffset,
+                           yoffset,
+                           xsize,
+                           ysize,
+                           pointer(buffer),
+                           xbsize,
+                           ybsize,
+                           $GT,
+                           nband,
+                           pointer(bands),
+                           pxspace,
+                           linespace,
+                           bandspace,
+                           extraargs)
             @cplerr result "Access in DatasetRasterIO failed."
             return buffer
         end

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -422,7 +422,7 @@ for (T,GT) in _GDALTYPE
             (dataset == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize, zbsize = size(buffer)
             nband = length(bands)
-            bands = Cint.(collect(bands))
+            bands = isa(bands, Vector{Cint}) ? bands : Cint.(collect(bands))
             @assert nband == zbsize
             result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),
                            GDAL.CPLErr,  # return type

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -1,7 +1,7 @@
 
 """
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}; <keyword arguments>)
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands::Vector{<:Integer}, rows, cols; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands; <keyword arguments>)
+    rasterio!(dataset::AbstractDataset, buffer::Array{<:Real, 3}, bands, rows, cols; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}; <keyword arguments>)
     rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Real}, rows, cols; <keyword arguments>)
 
@@ -64,7 +64,7 @@ function rasterio! end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{<:Integer},
+        bands,
         access::GDALRWFlag  = GDAL.GF_Read,
         pxspace::Integer    = 0,
         linespace::Integer  = 0,
@@ -78,7 +78,7 @@ end
 function rasterio!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        bands::Vector{<:Integer},
+        bands,
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer},
         access::GDALRWFlag  = GDAL.GF_Read,
@@ -206,7 +206,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer}
+        indices
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Read)
     return buffer
@@ -235,7 +235,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer},
+        indices,
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -259,7 +259,7 @@ end
 function read!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer},
+        indices,
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -271,7 +271,7 @@ read(dataset::AbstractDataset, i::Integer) = read(getband(dataset, i))
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{<:Integer}
+        indices
     )
     buffer = Array{pixeltype(getband(dataset, indices[1]))}(undef,
         width(dataset), height(dataset), length(indices))
@@ -300,7 +300,7 @@ end
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{<:Integer},
+        indices,
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -324,7 +324,7 @@ end
 
 function read(
         dataset::AbstractDataset,
-        indices::Vector{<:Integer},
+        indices,
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -342,7 +342,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer}
+        indices
     )
     rasterio!(dataset, buffer, indices, GDAL.GF_Write)
     return dataset
@@ -364,7 +364,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer},
+        indices,
         xoffset::Integer,
         yoffset::Integer,
         xsize::Integer,
@@ -389,7 +389,7 @@ end
 function write!(
         dataset::AbstractDataset,
         buffer::Array{<:Real, 3},
-        indices::Vector{<:Integer},
+        indices,
         rows::UnitRange{<:Integer},
         cols::UnitRange{<:Integer}
     )
@@ -402,7 +402,7 @@ for (T,GT) in _GDALTYPE
         function rasterio!(
                 dataset::AbstractDataset,
                 buffer::Array{$T, 3},
-                bands::Vector{<:Integer},
+                bands,
                 xoffset::Integer,
                 yoffset::Integer,
                 xsize::Integer,
@@ -422,7 +422,7 @@ for (T,GT) in _GDALTYPE
             (dataset == C_NULL) && error("Can't read invalid rasterband")
             xbsize, ybsize, zbsize = size(buffer)
             nband = length(bands)
-            bands = Cint.(bands)
+            bands = Cint.(collect(bands))
             @assert nband == zbsize
             result = ccall((:GDALDatasetRasterIOEx,GDAL.libgdal),
                            GDAL.CPLErr,  # return type

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -9,7 +9,7 @@ AG.read("ospy/data4/aster.img") do ds
         total = 0
         buffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
         for (cols,rows) in AG.windows(band)
-            AG.rasterio!(ds, buffer, Cint[1], rows .- 1, cols .- 1)
+            AG.rasterio!(ds, buffer, [1], rows .- 1, cols .- 1)
             data = buffer[1:length(cols),1:length(rows)]
             count += sum(data .> 0)
             total += sum(data)
@@ -24,7 +24,7 @@ AG.read("ospy/data4/aster.img") do ds
         total = 0
         buffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
         for (cols,rows) in AG.windows(band)
-            AG.read!(ds, buffer, Cint[1], rows .- 1, cols .- 1)
+            AG.read!(ds, buffer, [1], rows .- 1, cols .- 1)
             data = buffer[1:length(cols),1:length(rows)]
             count += sum(data .> 0)
             total += sum(data)
@@ -70,7 +70,7 @@ AG.read("ospy/data4/aster.img") do ds
         xbsize, ybsize = AG.blocksize(band)
         buffer = Array{AG.pixeltype(band)}(undef, ybsize, xbsize)
         for ((i,j),(nrows,ncols)) in AG.blocks(band)
-            # AG.rasterio!(ds,buffer,Cint[1],i,j,nrows,ncols)
+            # AG.rasterio!(ds,buffer,[1],i,j,nrows,ncols)
             # AG.read!(band, buffer, j, i, ncols, nrows)
             AG.readblock!(band, j, i, buffer)
             data = buffer[1:nrows, 1:ncols]
@@ -84,7 +84,7 @@ AG.read("ospy/data4/aster.img") do ds
     @testset "version 6" begin
         band = AG.getband(ds, 1)
         buffer = Array{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds), 1)
-        AG.rasterio!(ds, buffer, Cint[1])
+        AG.rasterio!(ds, buffer, [1])
         count = sum(buffer .> 0)
         total = sum(buffer)
         @test total / count ≈ 76.33891347095299
@@ -114,7 +114,7 @@ AG.read("ospy/data4/aster.img") do ds
     @testset "version 9" begin
         band = AG.getband(ds, 1)
         buffer = Array{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds), 1)
-        AG.read!(ds, buffer, Cint[1])
+        AG.read!(ds, buffer, [1])
         count = sum(buffer .> 0)
         total = sum(buffer)
         @test total / count ≈ 76.33891347095299
@@ -130,31 +130,47 @@ AG.read("ospy/data4/aster.img") do ds
         @test total / count ≈ 76.33891347095299
         @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
     end
+
+    # check for calling with Tuple
+    @testset "version 11" begin
+        band = AG.getband(ds, 1)
+        count = 0
+        total = 0
+        buffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
+        for (cols,rows) in AG.windows(band)
+            AG.rasterio!(ds, buffer, (1,), rows .- 1, cols .- 1)
+            data = buffer[1:length(cols),1:length(rows)]
+            count += sum(data .> 0)
+            total += sum(data)
+        end
+        @test total / count ≈ 76.33891347095299
+        @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+    end
 end
 
 # Untested
 # writeblock!(rb::RasterBand, xoffset::Integer, yoffset::Integer, buffer)
 # read!(rb::RasterBand, buffer::Array{Real,2}, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
 # read!(dataset::Dataset, buffer::Array{T,2}, i::Integer, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
-# read!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
+# read!(dataset::Dataset, buffer::Array{T,3}, indices, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
 
 # read{U <: Integer}(rb::RasterBand, rows::UnitRange{U}, cols::UnitRange{U})
-# read(dataset::Dataset, indices::Vector{Cint})
+# read(dataset::Dataset, indices)
 # read(dataset::Dataset)
 # read{T <: Integer}(dataset::Dataset, indices::Vector{T}, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
 # read{U <: Integer}(dataset::Dataset, i::Integer, rows::UnitRange{U}, cols::UnitRange{U})
-# read{U <: Integer}(dataset::Dataset, indices::Vector{Cint}, rows::UnitRange{U}, cols::UnitRange{U})update!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
+# read{U <: Integer}(dataset::Dataset, indices, rows::UnitRange{U}, cols::UnitRange{U})update!{T <: Real}(rb::RasterBand, buffer::Array{T,2}) =
 
 # write!(rb::RasterBand, buffer::Array{T,2}, rows::UnitRange{U}, cols::UnitRange{U})
 # write!(dataset::Dataset, buffer::Array{T,2}, i::Integer)
-# write!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint})
-# write!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
+# write!(dataset::Dataset, buffer::Array{T,3}, indices)
+# write!(dataset::Dataset, buffer::Array{T,3}, indices, xoffset::Integer, yoffset::Integer, xsize::Integer, ysize::Integer)
 # write!(dataset::Dataset, buffer::Array{T,2}, i::Integer, rows::UnitRange{U}, cols::UnitRange{U})
-# write!(dataset::Dataset, buffer::Array{T,3}, indices::Vector{Cint}, rows::UnitRange{U}, cols::UnitRange{U})
+# write!(dataset::Dataset, buffer::Array{T,3}, indices, rows::UnitRange{U}, cols::UnitRange{U})
 
 # function rasterio!(dataset::Dataset,
 #                            buffer::Array{$T, 3},
-#                            bands::Vector{Cint},
+#                            bands,
 #                            xoffset::Integer,
 #                            yoffset::Integer,
 #                            xsize::Integer,


### PR DESCRIPTION
The user now has more freedom of entering the bands he wishes to load, no conversion to Int32 is needed anymore. This all works now:
```julia
ds = ag.read("somefile")
img = ag.read(ds, 1)
img = ag.read(ds, [1,2,3,4])
img = ag.read(ds, Int8[1,2,3,4])
img = ag.read(ds, (1,2,3,4))
```

Fixes #126 