### PR TITLE
Delete Require file in test folder

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-BinaryProvider


### PR DESCRIPTION
This file shouldn't be used by the package manager anymore and can be deleted. The test dependencies are set in the Project.toml file under extras.