### PR TITLE
Remove the matrix for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ julia:
   - 1.3
   - 1
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
 notifications:
   email: false
 coveralls: true

--- a/Project.toml
+++ b/Project.toml
@@ -22,10 +22,10 @@ GeoInterface = "0.4, 0.5"
 julia = "1.3"
 
 [extras]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dates", "Statistics", "Test", "BinaryProvider"]
+test = ["Dates", "Pkg", "Statistics", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 

--- a/test/remotefiles.jl
+++ b/test/remotefiles.jl
@@ -1,7 +1,7 @@
 # this file downloads files which are used during testing the package
 # if they are already present and their checksum matches, they are not downloaded again
 
-using Pkg.PlatformEngines
+using Pkg.PlatformEngines: download_verify
 
 const testdatadir = @__DIR__
 

--- a/test/remotefiles.jl
+++ b/test/remotefiles.jl
@@ -1,7 +1,9 @@
 # this file downloads files which are used during testing the package
 # if they are already present and their checksum matches, they are not downloaded again
 
-using Pkg.PlatformEngines: download_verify
+using Pkg.PlatformEngines
+
+probe_platform_engines!()  # for download
 
 const testdatadir = @__DIR__
 

--- a/test/remotefiles.jl
+++ b/test/remotefiles.jl
@@ -1,7 +1,7 @@
 # this file downloads files which are used during testing the package
 # if they are already present and their checksum matches, they are not downloaded again
 
-using BinaryProvider
+using Pkg.PlatformEngines
 
 const testdatadir = @__DIR__
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using Dates
-using BinaryProvider
+using Pkg.PlatformEngines: download_verify
 
 # ensure all testing files are present
 include("remotefiles.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using Dates
-using Pkg.PlatformEngines: download_verify
+using Pkg.PlatformEngines
 
 # ensure all testing files are present
 include("remotefiles.jl")


### PR DESCRIPTION
it is a deprecated alias for `jobs` (see https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#Travis-CI for details)

Ref. #134. (I don't know if it fixes it yet)

I have generated a new SSH Deploy Key called "Documenter.jl Deploy Key" and followed https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#travis-ssh to add an env variable called `DOCUMENTER_KEY` to Travis CI. I'll remove the old SSH Deploy Key called "documenter" once we manage to get things up and running with the new key.