### PR TITLE
fix too large buffer sizes on reduced reads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -156,7 +156,7 @@ function read(
         xsize::Integer,
         ysize::Integer
     )
-    buffer = Array{pixeltype(rb)}(undef, width(rb), height(rb))
+    buffer = Array{pixeltype(rb)}(undef, xsize, ysize)
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
     return buffer
 end
@@ -307,7 +307,7 @@ function read(
         ysize::Integer
     )
     buffer = Array{pixeltype(getband(dataset, indices[1]))}(undef,
-        width(dataset), height(dataset), length(indices))
+        xsize, ysize, length(indices))
     rasterio!(dataset, buffer, indices, xsize, ysize, xoffset, yoffset)
     return buffer
 end
@@ -329,7 +329,7 @@ function read(
         cols::UnitRange{<:Integer}
     )
     buffer = Array{pixeltype(getband(dataset, indices[1]))}(undef,
-        width(dataset), height(dataset), length(indices))
+        length(cols), length(rows), length(indices))
     rasterio!(dataset, buffer, indices, rows, cols)
     return buffer
 end

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -70,7 +70,7 @@ function rasterio!(
         linespace::Integer  = 0,
         bandspace::Integer  = 0
     )
-    rasterio!(dataset, buffer, bands, 0, 0, width(dataset), height(dataset),
+    rasterio!(dataset, buffer, bands, 0, 0, size(buffer, 1), size(buffer, 2),
         access, pxspace, linespace, bandspace)
     return buffer
 end

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -152,6 +152,8 @@ AG.read("ospy/data4/aster.img") do ds
         @test size(AG.read(ds, [1, 3], 0, 0, 20, 10)) === (20, 10, 2)
         @test size(AG.read(ds, 1, 1:10, 31:50)) === (20, 10)
         @test size(AG.read(ds, [1, 3], 1:10, 31:50)) === (20, 10, 2)
+        band = AG.getband(ds, 1)
+        @test size(AG.read( band, 0, 0, 20, 10)) === (20, 10)
     end
 end
 

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -146,6 +146,13 @@ AG.read("ospy/data4/aster.img") do ds
         @test total / count ≈ 76.33891347095299
         @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
     end
+
+    @testset "buffer size" begin
+        @test size(AG.read(ds, 1, 0, 0, 20, 10)) === (20, 10)
+        @test size(AG.read(ds, [1, 3], 0, 0, 20, 10)) === (20, 10, 2)
+        @test size(AG.read(ds, 1, 1:10, 31:50)) === (20, 10)
+        @test size(AG.read(ds, [1, 3], 1:10, 31:50)) === (20, 10, 2)
+    end
 end
 
 # Untested


### PR DESCRIPTION
Fixes #132
Fixes #78, with the possible exception noted in https://github.com/yeesian/ArchGDAL.jl/issues/78#issuecomment-496205117:

> We'll have to be careful about how rasterio is invoked (for [linespace and bandspace](https://github.com/yeesian/ArchGDAL.jl/blob/9cc11c3f3caa57b57680725a356b24db8ff069c8/src/raster/rasterio.jl#L2-L55)) too

I'm not really sure how those `linespace` and `bandspace` work. Should `width(dataset), height(dataset)` be replaced by looking at the buffer sizes in that method? If not clear, let's just merge this and park this as an issue to look into later.