### PR TITLE
Allow test failures on julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,5 @@ jobs:
         - julia --project=docs/ test/remotefiles.jl
         - julia --project=docs/ docs/make.jl
       after_success: skip
+  allow_failures:
+    - julia: nightly


### PR DESCRIPTION
This should allow failures to happen on julia nightly. 
I think this is the only reason, why the docs haven't been built for the releases 0.5.1 and 0.5.2.
Should be the next step to close #134