### PR TITLE
Compact display of geometry without WKT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -206,11 +206,5 @@ end
 
 function Base.show(io::IO, geom::AbstractGeometry)
     geom.ptr == C_NULL && (return print(io, "NULL Geometry"))
-    print(io, "Geometry: ")
-    geomwkt = toWKT(geom)
-    if length(geomwkt) > 60
-        print(io, "$(geomwkt[1:50]) ... $(geomwkt[end-4:end])")
-    else
-        print(io, "$geomwkt")
-    end
+    print(io, "Geometry of type $(getgeomtype(geom))")
 end

--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -206,5 +206,17 @@ end
 
 function Base.show(io::IO, geom::AbstractGeometry)
     geom.ptr == C_NULL && (return print(io, "NULL Geometry"))
-    print(io, "Geometry of type $(getgeomtype(geom))")
+    compact = get(io, :compact, false)
+
+    if !compact
+        print(io, "Geometry: ")
+        geomwkt = toWKT(geom)
+        if length(geomwkt) > 60
+            print(io, "$(geomwkt[1:50]) ... $(geomwkt[end-4:end])")
+        else
+            print(io, "$geomwkt")
+        end
+    else
+        print(io, "Geometry: $(getgeomtype(geom))")
+    end
 end

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -19,6 +19,8 @@ import ArchGDAL; const AG = ArchGDAL
              Field 0 (FID): [OFTReal], 2.0, 3.0, 0.0, 3.0
              Field 1 (pointname): [OFTString], point-a, point-b, a, b
         """
+        @test sprint(print, AG.nextnamedtuple(layer), context=:compact => true) == 
+        "(FID = 2.0, pointname = \"point-a\",  = Geometry: wkbPoint)"
         @test sprint(print, AG.layerdefn(layer)) == """
           Geometry (index 0):  (wkbPoint)
              Field (index 0): FID (OFTReal)


### PR DESCRIPTION
Getting the WKT of a (complex) geometry is non trivial and will slow down things especially when used in Tables.

With this PR:

When used in a Table (compact)
```julia
julia> df = DataFrame(geom=createpoint.(coords), name="test")
10×2 DataFrame
 Row │ geom                name
     │ IGeometr…           String
─────┼────────────────────────────
   1 │ Geometry: wkbPoint  test
   2 │ Geometry: wkbPoint  test
   3 │ Geometry: wkbPoint  test
   4 │ Geometry: wkbPoint  test
   5 │ Geometry: wkbPoint  test
   6 │ Geometry: wkbPoint  test
   7 │ Geometry: wkbPoint  test
   8 │ Geometry: wkbPoint  test
   9 │ Geometry: wkbPoint  test
  10 │ Geometry: wkbPoint  test
```

Individual or array (non-compact) usage
```julia
julia> df[1, :geom]
Geometry: POINT (0.394776848700807 0.244117475869569)
```