### PR TITLE
add methods to get driver shortname from filename extension

### DIFF
--- a/src/driver.jl
+++ b/src/driver.jl
@@ -147,14 +147,12 @@ with their respective drivers shortname.
 """
 function extensions()
     extdict = Dict{String,String}()
-    for i in 1:GDAL.gdalgetdrivercount()
-        driver = ArchGDAL.getdriver(i)
+    for i in 1:ndriver()
+        driver = getdriver(i)
         if !(driver.ptr == C_NULL)
-            exts = GDAL.gdalgetmetadataitem(driver.ptr, "DMD_EXTENSIONS", Cstring(C_NULL))
-            if !(exts isa Nothing)
-                for ext in split(exts)
-                    extdict[".$ext"] = ArchGDAL.shortname(driver)
-                end
+            # exts is a space-delimited list in a String, so split it
+            for ext in split(metadataitem(driver, "DMD_EXTENSIONS"))
+                extdict[".$ext"] = shortname(driver)
             end
         end
     end
@@ -170,9 +168,8 @@ function extensiondriver(filename::AbstractString)
     split = splitext(filename)
     extensiondict = extensions()
     ext = split[2] == "" ? split[1] : split[2]
-    if haskey(extensiondict, ext)
-        extensiondict[ext]
-    else
+    if !haskey(extensiondict, ext)
         throw(ArgumentError("There are no GDAL drivers for the $ext extension"))
     end
+    return extensiondict[ext]
 end

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -161,8 +161,10 @@ end
 
 """
     extensiondriver(filename::AbstractString)
+ 
+Returns a driver shortname that matches the filename extension.
 
-Returns a `Driver` that matches the filename extension.
+So `extensiondriver("/my/file.tif") == "GTiff"`.
 """
 function extensiondriver(filename::AbstractString)
     split = splitext(filename)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,6 +71,23 @@ metadata(obj; domain::AbstractString = "") =
     GDAL.gdalgetmetadata(obj.ptr, domain)
 
 """
+	metadataitem(obj, name::AbstractString, domain::AbstractString)
+
+Fetch single metadata item.
+
+### Parameters
+* `name` the name of the metadata item to fetch.
+* `domain` (optional) the domain to fetch for.
+
+### Returns
+The metadata item on success, or an empty string on failure.
+"""
+function metadataitem(obj, name::AbstractString; domain::AbstractString = "") 
+    item = GDAL.gdalgetmetadataitem(obj.ptr, name, domain)
+    return item === nothing ? "" : item
+end
+
+"""
     setconfigoption(option::AbstractString, value)
 
 Set a configuration option for GDAL/OGR use.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,5 +31,6 @@ include("remotefiles.jl")
         include("test_geos_operations.jl")
         include("test_cookbook_geometry.jl")
         include("test_cookbook_projection.jl")
+        include("test_utils.jl")
     end
 end

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -72,3 +72,10 @@ end
         )
     end
 end
+
+@testset "Test Driver from Extension" begin
+    @test AG.extensiondriver("filename.tif") == "GTiff"
+    @test AG.extensiondriver(".tif") == "GTiff"
+    @test AG.extensiondriver("filename.asc") == "AAIGrid"
+    @test AG.extensiondriver(".asc") == "AAIGrid"
+end

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -78,4 +78,5 @@ end
     @test AG.extensiondriver(".tif") == "GTiff"
     @test AG.extensiondriver("filename.asc") == "AAIGrid"
     @test AG.extensiondriver(".asc") == "AAIGrid"
+    @test_throws ArgumentError AG.extensiondriver(".not_an_extension")
 end

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -73,10 +73,18 @@ end
     end
 end
 
-@testset "Test Driver from Extension" begin
+@testset "Test extensions list" begin
+    exts = AG.extensions()
+    @test exts[".tif"] == "GTiff"
+    @test exts[".grb"] == "GRIB"
+    @test exts[".geojson"] == "GeoJSON"
+end
+
+@testset "Test getting extensiondriver" begin
     @test AG.extensiondriver("filename.tif") == "GTiff"
     @test AG.extensiondriver(".tif") == "GTiff"
     @test AG.extensiondriver("filename.asc") == "AAIGrid"
     @test AG.extensiondriver(".asc") == "AAIGrid"
     @test_throws ArgumentError AG.extensiondriver(".not_an_extension")
 end
+

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,10 @@
+using Test
+import GDAL
+import ArchGDAL; const AG = ArchGDAL
+
+@testset "metadataitem" begin
+    driver = AG.getdriver("DERIVED")
+    @test AG.metadataitem(driver, "DMD_EXTENSIONS") == ""
+    driver = AG.getdriver("GTiff")
+    @test AG.metadataitem(driver, "DMD_EXTENSIONS") == "tif tiff"
+end


### PR DESCRIPTION
I'm not sure if these methods are the _best_ way to organise this kind of functionality, or the best names. But it's useful for writing arbitrary drivers without specifying them.

Closes #173 