### PR TITLE
Let getnodatavalue return nothing if there is none

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -588,6 +588,32 @@ a valid mask band.
 """
 maskflags(band::AbstractRasterBand) = GDAL.gdalgetmaskflags(band.ptr)
 
+
+"""
+    maskflaginfo(band::AbstractRasterBand)
+
+Returns the flags as in `maskflags`(@ref) but unpacks the bit values into a named
+tuple with the following fields:
+
+* `all_valid`
+* `per_dataset`
+* `alpha`
+* `nodata`
+
+### Returns
+
+A named tuple with unpacked mask flags
+"""
+function maskflaginfo(band::AbstractRasterBand)
+    flags = maskflags(band)
+    (
+        all_valid = !iszero(flags & 0x01), 
+        per_dataset = !iszero(flags & 0x02),
+        alpha = !iszero(flags & 0x04),
+        nodata = !iszero(flags & 0x08),
+    )
+end
+
 """
     createmaskband!(band::AbstractRasterBand, nflags::Integer)
 

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -606,7 +606,7 @@ A named tuple with unpacked mask flags
 """
 function maskflaginfo(band::AbstractRasterBand)
     flags = maskflags(band)
-    (
+    return (
         all_valid = !iszero(flags & 0x01), 
         per_dataset = !iszero(flags & 0x02),
         alpha = !iszero(flags & 0x04),

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -164,19 +164,25 @@ end
 
 Fetch the no data value for this band.
 
-If there is no out of data value, an out of range value will generally be
-returned. The no data value for a band is generally a special marker value
+If there is no out of data value, `nothing` will be
+returned instead. The no data value for a band is generally a special marker value
 used to mark pixels that are not valid data. Such pixels should generally
 not be displayed, nor contribute to analysis operations.
 
 ### Returns
-the nodata value for this band.
+the nodata value for this band or `nothing`.
 """
 function getnodatavalue(band::AbstractRasterBand)
     # ### Parameters
     # * `pbSuccess`   pointer to a boolean to use to indicate if a value is
     #     actually associated with this layer. May be `NULL` (default).
-    return GDAL.gdalgetrasternodatavalue(band.ptr, C_NULL)
+    hasnodatavalue = Ref(Cint(0))
+    nodatavalue = GDAL.gdalgetrasternodatavalue(band.ptr, hasnodatavalue)
+    if Bool(hasnodatavalue[])
+        return nodatavalue
+    else
+        return nothing
+    end
 end
 
 """

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -58,7 +58,7 @@ import ArchGDAL; const AG = ArchGDAL
 
         @test sprint(print, AG.getband(dataset, 1)) == """
         [GA_ReadOnly] Band 1 (Red): 2048 x 1024 (UInt8)
-            blocksize: 256×256, nodata: -1.0e10, units: 1.0px + 0.0
+            blocksize: 256×256, nodata: nothing, units: 1.0px + 0.0
             overviews: (0) 1024x512 (1) 512x256 (2) 256x128 
                        (3) 128x64 (4) 64x32 (5) 32x16 
                        (6) 16x8 """

--- a/test/test_ospy_examples.jl
+++ b/test/test_ospy_examples.jl
@@ -360,7 +360,7 @@ AG.read("ospy/data4/aster.img") do ds
                 outband = AG.getband(outDS, 1)
                 @test sprint(print, outband) == """
                 [GA_Update] Band 1 (Undefined): 5665 x 5033 (Float32)
-                    blocksize: 5665×1, nodata: 0.0, units: 1.0px + 0.0
+                    blocksize: 5665×1, nodata: nothing, units: 1.0px + 0.0
                     overviews: """
                 AG.setnodatavalue!(outband, -99)
                 # georeference the image and set the projection
@@ -448,7 +448,7 @@ end end end end
                 bandout = AG.getband(dsout, 1)
                 @test sprint(print, bandout) == """
                 [GA_Update] Band 1 (Undefined): 4500 x 3000 (UInt8)
-                    blocksize: 4500×1, nodata: 0.0, units: 1.0px + 0.0
+                    blocksize: 4500×1, nodata: nothing, units: 1.0px + 0.0
                     overviews: """
 
                 # set the geotransform and projection on the output

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -41,25 +41,25 @@ import ArchGDAL; const AG = ArchGDAL
         AG.setscale!(rb, 1)
         @test AG.getscale(rb) ≈ 1
 
-        @test AG.getnodatavalue(rb) ≈ -1e10
+        @test AG.getnodatavalue(rb) === nothing
         AG.setnodatavalue!(rb, -100)
         @test AG.getnodatavalue(rb) ≈ -100
         AG.deletenodatavalue!(rb)
-        @test AG.getnodatavalue(rb) ≈ -1e10
+        @test AG.getnodatavalue(rb) === nothing
 
         AG.copy(dataset) do dest
             destband = AG.getband(dest, 1)
             AG.copywholeraster!(rb, destband)
             @test sprint(print, destband) == """
             [GA_Update] Band 1 (Gray): 100 x 100 (UInt8)
-                blocksize: 100×81, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 100×81, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             @test AG.noverview(destband) == 0
             AG.buildoverviews!(dest, Cint[2, 4, 8])
             @test AG.noverview(destband) == 3
             @test sprint(print, destband) == """
             [GA_Update] Band 1 (Gray): 100 x 100 (UInt8)
-                blocksize: 100×81, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 100×81, nodata: nothing, units: 1.0px + 0.0
                 overviews: (0) 50x50 (1) 25x25 (2) 13x13 
                            """
             @test AG.getcolorinterp(destband) == GDAL.GCI_GrayIndex
@@ -68,32 +68,32 @@ import ArchGDAL; const AG = ArchGDAL
 
             @test sprint(print, AG.sampleoverview(destband, 100)) == """
             [GA_Update] Band 1 (Gray): 13 x 13 (UInt8)
-                blocksize: 128×128, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 128×128, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             @test sprint(print, AG.sampleoverview(destband, 200)) == """
             [GA_Update] Band 1 (Gray): 25 x 25 (UInt8)
-                blocksize: 128×128, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 128×128, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             @test sprint(print, AG.sampleoverview(destband, 500)) == """
             [GA_Update] Band 1 (Gray): 25 x 25 (UInt8)
-                blocksize: 128×128, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 128×128, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             AG.sampleoverview(destband, 1000) do result
                 @test sprint(print, result) == """
                 [GA_Update] Band 1 (Gray): 50 x 50 (UInt8)
-                    blocksize: 128×128, nodata: -1.0e10, units: 1.0px + 0.0
+                    blocksize: 128×128, nodata: nothing, units: 1.0px + 0.0
                     overviews: """
             end
             @test sprint(print, AG.getmaskband(destband)) == """
             [GA_ReadOnly] Band 0 (Undefined): 100 x 100 (UInt8)
-                blocksize: 100×81, nodata: -1.0e10, units: 1.0px + 0.0
+                blocksize: 100×81, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             @test AG.maskflags(destband) == 1
             AG.createmaskband!(destband, 3)
             AG.getmaskband(destband) do maskband
                 @test sprint(print, maskband) == """
                 [GA_Update] Band 1 (Gray): 100 x 100 (UInt8)
-                    blocksize: 100×81, nodata: -1.0e10, units: 1.0px + 0.0
+                    blocksize: 100×81, nodata: nothing, units: 1.0px + 0.0
                     overviews: """
             end
             @test AG.maskflags(destband) == 3

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -89,6 +89,7 @@ import ArchGDAL; const AG = ArchGDAL
                 blocksize: 100×81, nodata: nothing, units: 1.0px + 0.0
                 overviews: """
             @test AG.maskflags(destband) == 1
+            @test AG.maskflaginfo(rb) == (all_valid = true, per_dataset = false, alpha = false, nodata = false)
             AG.createmaskband!(destband, 3)
             AG.getmaskband(destband) do maskband
                 @test sprint(print, maskband) == """
@@ -97,6 +98,7 @@ import ArchGDAL; const AG = ArchGDAL
                     overviews: """
             end
             @test AG.maskflags(destband) == 3
+            @test AG.maskflaginfo(destband) == (all_valid = true, per_dataset = true, alpha = false, nodata = false)
             AG.fillraster!(destband, 3)
             AG.setcategorynames!(destband, ["foo","bar"])
             @test AG.getcategorynames(destband) == ["foo", "bar"]


### PR DESCRIPTION
Currently the `getnodatavalue` always returns a value for a `RasterBand`, no matter if one is actually defined or not. After applying this change, `nothing` would be returned instead if there is no such value defined. I think although this would be breaking, it would enable a more fine-grained control for handling data with unknown content. 

As an alternative and to not break existing code, one could add a `hasnodatavalue` function instead. I would like to hear other opinions, maybe @rafaqz or @evetion could give a hint how it would affect GeoData.jl and GeoArrays.jl?

I would still need to fix the unit tests but wanted to hear some general opinions first. 