### PR TITLE
Upgrade to latest GDAL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -15,7 +15,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DiskArrays = "0.2.4"
-GDAL = "1.1.3"
+GDAL = "1.2.1"
 GeoFormatTypes = "0.3"
 GeoInterface = "0.4, 0.5"
 Tables = "1"


### PR DESCRIPTION
Using the latest release on MacOS I get a problematic `GDAL_jll v3.2.1+0`. Pinning to the latest GDAL release prevents this.