### PR TITLE
looser ImageCore and ColorTypes deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,11 +16,11 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-ColorTypes = "0.11"
+ColorTypes = "0.10, 0.11"
 DiskArrays = "0.2.4"
 GDAL = "1.1.3"
 GeoFormatTypes = "0.3"
 GeoInterface = "0.4, 0.5"
-ImageCore = "0.9"
+ImageCore = "0.8, 0.9"
 Tables = "1"
 julia = "1.3"


### PR DESCRIPTION
There are still packages with older dependencies, and these should work equally well here?