### PR TITLE
Add support for complex gdal data type

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -264,6 +264,8 @@ eval(
         GDT_Int32::Int32,
         GDT_Float32::Float32,
         GDT_Float64::Float64,
+        GDT_CFloat32::ComplexF32,
+        GDT_CFloat64::ComplexF64
     )
 )
 

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -275,3 +275,14 @@ const AG = ArchGDAL;
         end
     end
 end
+
+@testset "Complex IO" begin 
+    a = rand(ComplexF32, 10,10)
+    outpath = "/vsimem/" * "testcomplex1.tif"
+    AG.create(outpath, driver=AG.getdriver("GTiff"), width=10, height=10, nbands=1,dtype=ComplexF32)  do ds
+        AG.write!(ds, a, 1)
+    end
+    AG.read(outpath) do ds_copy
+    @test AG.getband(ds_copy,1) == a
+    end
+end

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -288,4 +288,3 @@ end
         @test AG.getband(ds_copy,1) == a
     end
 end
-

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -287,5 +287,5 @@ end
     AG.read(outpath) do ds_copy
         @test AG.getband(ds_copy,1) == a
     end
-    
 end
+

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -278,11 +278,14 @@ end
 
 @testset "Complex IO" begin 
     a = rand(ComplexF32, 10,10)
+
     outpath = "/vsimem/" * "testcomplex1.tif"
     AG.create(outpath, driver=AG.getdriver("GTiff"), width=10, height=10, nbands=1,dtype=ComplexF32)  do ds
         AG.write!(ds, a, 1)
     end
+
     AG.read(outpath) do ds_copy
-    @test AG.getband(ds_copy,1) == a
+        @test AG.getband(ds_copy,1) == a
     end
+    
 end

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -19,6 +19,9 @@ import ImageCore
             @test AG.typeunion(AG.GDT_UInt16, AG.GDT_Byte) == AG.GDT_UInt16
             @test AG.iscomplex(AG.GDT_Float32) == false
 
+            @test AG.iscomplex(AG.GDT_CFloat32) == true
+            @test AG.iscomplex(AG.GDT_CFloat64) == true
+
             @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
             @test_throws ErrorException Base.convert(AG.GDALDataType, Int64)
             @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)


### PR DESCRIPTION
This adds GDT_CFloat* to the supported types in the conversion and allows to load complex raster data. 
I am not sure, whether the test case in tests_rasterio.jl is at the correct place, but I wanted to test whether the reading and writing of complex data works because the test in test_types.jl also works currently without conversion.


This would partially close #170.