### PR TITLE
Add DOCUMENTER_KEY as ssh deploy key to tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This should enable TagBot to also trigger documentation builds for the tagged versions.
This fix the problems of the generation of stable docs as noticed in #210.
I assume, that the DOCUMENTER_KEY is already generated, because the development version of the docs are working fine.

See https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions

