### PR TITLE
Add possible subtypes

### DIFF
--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -445,8 +445,23 @@ function setfield!(feature::Feature, i::Integer, value::Int32)::Feature
     return feature
 end
 
+function setfield!(feature::Feature, i::Integer, value::Int16)::Feature
+    GDAL.ogr_f_setfieldinteger(feature.ptr, i, value)
+    return feature
+end
+
+function setfield!(feature::Feature, i::Integer, value::Bool)::Feature
+    GDAL.ogr_f_setfieldinteger(feature.ptr, i, value)
+    return feature
+end
+
 function setfield!(feature::Feature, i::Integer, value::Int64)::Feature
     GDAL.ogr_f_setfieldinteger64(feature.ptr, i, value)
+    return feature
+end
+
+function setfield!(feature::Feature, i::Integer, value::Float32)::Feature
+    GDAL.ogr_f_setfielddouble(feature.ptr, i, value)
     return feature
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -303,8 +303,11 @@ eval(
     @convert(
         OGRFieldType::DataType,
         OFTInteger::Int32,
+        OFTInteger::Int16,
+        OFTInteger::Bool,
         OFTIntegerList::Vector{Int32},
         OFTReal::Float64,
+        OFTReal::Float32,
         OFTRealList::Vector{Float64},
         OFTString::String,
         OFTStringList::Vector{String},

--- a/src/types.jl
+++ b/src/types.jl
@@ -302,12 +302,12 @@ eval(
 eval(
     @convert(
         OGRFieldType::DataType,
-        OFTInteger::Int32,
-        OFTInteger::Int16,
         OFTInteger::Bool,
+        OFTInteger::Int16,
+        OFTInteger::Int32,  # default type comes last
         OFTIntegerList::Vector{Int32},
-        OFTReal::Float64,
         OFTReal::Float32,
+        OFTReal::Float64,  # default type comes last
         OFTRealList::Vector{Float64},
         OFTString::String,
         OFTStringList::Vector{String},

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -51,4 +51,17 @@ const GFT = GeoFormatTypes;
         @test typeof(geom2) == AG.IGeometry{AG.wkbUnknown}
         @test AG.toWKT(geom1) == AG.toWKT(geom2)
     end
+
+    @testset "type conversions" begin
+        @test convert(AG.OGRFieldType, Int32) == AG.OFTInteger
+        @test convert(AG.OGRFieldType, Int16) == AG.OFTInteger
+        @test convert(AG.OGRFieldType, Bool) == AG.OFTInteger
+
+        @test convert(AG.OGRFieldType, Float32) == AG.OFTReal
+        @test convert(AG.OGRFieldType, Float64) == AG.OFTReal
+
+        # Reverse conversion should result in default type, not subtype
+        @test convert(DataType, AG.OFTInteger) == Int32
+        @test convert(DataType, AG.OFTReal) == Float64
+    end
 end

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -108,7 +108,7 @@ const AG = ArchGDAL;
             AG.createfielddefn("int64field", AG.OFTInteger64) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
-            AG.createfielddefn("doublefield", AG.OFTReal) do fielddefn
+            AG.createfielddefn("float64field", AG.OFTReal) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
             AG.createfielddefn("intlistfield", AG.OFTIntegerList) do fielddefn
@@ -120,7 +120,7 @@ const AG = ArchGDAL;
             ) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
-            AG.createfielddefn("doublelistfield", AG.OFTRealList) do fielddefn
+            AG.createfielddefn("float64listfield", AG.OFTRealList) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
             AG.createfielddefn("stringlistfield", AG.OFTStringList) do fielddefn
@@ -132,15 +132,31 @@ const AG = ArchGDAL;
             AG.createfielddefn("datetimefield", AG.OFTDateTime) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
+            AG.createfielddefn("booleanfield", AG.OFTInteger) do fielddefn
+                return AG.addfielddefn!(layer, fielddefn)
+            end
+            AG.createfielddefn("int16field", AG.OFTInteger) do fielddefn
+                return AG.addfielddefn!(layer, fielddefn)
+            end
+            AG.createfielddefn("int32field", AG.OFTInteger) do fielddefn
+                return AG.addfielddefn!(layer, fielddefn)
+            end
+            AG.createfielddefn("float32field", AG.OFTReal) do fielddefn
+                return AG.addfielddefn!(layer, fielddefn)
+            end
             AG.createfeature(layer) do feature
-                AG.setfield!(feature, 0, 1)
-                AG.setfield!(feature, 1, 1.0)
+                AG.setfield!(feature, 0, Int64(1))
+                AG.setfield!(feature, 1, Float64(1.0))
                 AG.setfield!(feature, 2, Int32[1, 2])
                 AG.setfield!(feature, 3, Int64[1, 2])
                 AG.setfield!(feature, 4, Float64[1.0, 2.0])
                 AG.setfield!(feature, 5, ["1", "2.0"])
                 AG.setfield!(feature, 6, UInt8[1, 2, 3, 4])
                 AG.setfield!(feature, 7, Dates.DateTime(2016, 9, 25, 21, 17, 0))
+                AG.setfield!(feature, 8, true)
+                AG.setfield!(feature, 9, Int16(1))
+                AG.setfield!(feature, 10, Int32(1))
+                AG.setfield!(feature, 11, Float32(1.0))
                 @test sprint(print, AG.getgeom(feature)) == "NULL Geometry"
                 AG.getgeom(feature) do geom
                     @test sprint(print, geom) == "NULL Geometry"
@@ -161,6 +177,10 @@ const AG = ArchGDAL;
                     @test AG.getfield(newfeature, 6) == UInt8[1, 2, 3, 4]
                     @test AG.getfield(newfeature, 7) ==
                           Dates.DateTime(2016, 9, 25, 21, 17, 0)
+                    @test AG.getfield(newfeature, 8) == true
+                    @test AG.getfield(newfeature, 9) == Int16(1)
+                    @test AG.getfield(newfeature, 10) == Int32(1)
+                    @test AG.getfield(newfeature, 11) == Float32(1.0)
 
                     AG.createfeature(layer) do lastfeature
                         AG.setfrom!(lastfeature, feature)

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -178,9 +178,9 @@ const AG = ArchGDAL;
                     @test AG.getfield(newfeature, 7) ==
                           Dates.DateTime(2016, 9, 25, 21, 17, 0)
                     @test AG.getfield(newfeature, 8) == true
-                    @test AG.getfield(newfeature, 9) == Int16(1)
-                    @test AG.getfield(newfeature, 10) == Int32(1)
-                    @test AG.getfield(newfeature, 11) == Float32(1.0)
+                    @test AG.getfield(newfeature, 9) == 1
+                    @test AG.getfield(newfeature, 10) == 1
+                    @test AG.getfield(newfeature, 11) == 1.0
 
                     AG.createfeature(layer) do lastfeature
                         AG.setfrom!(lastfeature, feature)
@@ -201,7 +201,7 @@ const AG = ArchGDAL;
                         @test AG.getfield(newfeature, 0) == 1
                         @test AG.getfield(newfeature, 1) ≈ 1.0
                         @test AG.getfield(newfeature, 5) == String["1", "2.0"]
-                        AG.setfrom!(newfeature, lastfeature, collect(Cint, 0:7))
+                        AG.setfrom!(newfeature, lastfeature, collect(Cint, 0:AG.nfield(newfeature)))
                         @test AG.getfield(newfeature, 0) == 45
                         @test AG.getfield(newfeature, 1) ≈ 18.2
                         @test AG.getfield(newfeature, 5) == String["foo", "bar"]


### PR DESCRIPTION
In order to write slightly more exotic types as `Int16`, `Bool` and `Float32`, GDAL has subtypes. However, the main type must still be set and currently ArchGDAL doesn't support these types.

I pirated it myself in https://github.com/evetion/GeoDataFrames.jl/blob/master/src/io.jl#L14, this is the upstream fix.

For the actual usage of these subtypes (in writing) see https://github.com/evetion/GeoDataFrames.jl/blob/master/src/io.jl#L103. Note that funnily enough, this enables write support of these types earlier than read support (#177).