### PR TITLE
New convert macro using a `const Dict` outside the `convert` function…

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -255,7 +255,7 @@ eval(
 )
 
 eval(
-    @convert(
+    @convert_old(
         GDALDataType::ImageCore.Normed,
         GDT_Byte::ImageCore.N0f8,
         GDT_UInt16::ImageCore.N0f16,

--- a/src/types.jl
+++ b/src/types.jl
@@ -255,7 +255,7 @@ eval(
 )
 
 eval(
-    @convert_old(
+    @convert(
         GDALDataType::ImageCore.Normed,
         GDT_Byte::ImageCore.N0f8,
         GDT_UInt16::ImageCore.N0f16,

--- a/src/types.jl
+++ b/src/types.jl
@@ -235,317 +235,281 @@ mutable struct ColorTable
     ptr::GDAL.GDALColorTableH
 end
 
-eval(
-    @convert(
-        GDALDataType::GDAL.GDALDataType,
-        GDT_Unknown::GDAL.GDT_Unknown,
-        GDT_Byte::GDAL.GDT_Byte,
-        GDT_UInt16::GDAL.GDT_UInt16,
-        GDT_Int16::GDAL.GDT_Int16,
-        GDT_UInt32::GDAL.GDT_UInt32,
-        GDT_Int32::GDAL.GDT_Int32,
-        GDT_Float32::GDAL.GDT_Float32,
-        GDT_Float64::GDAL.GDT_Float64,
-        GDT_CInt16::GDAL.GDT_CInt16,
-        GDT_CInt32::GDAL.GDT_CInt32,
-        GDT_CFloat32::GDAL.GDT_CFloat32,
-        GDT_CFloat64::GDAL.GDT_CFloat64,
-        GDT_TypeCount::GDAL.GDT_TypeCount,
-    )
+@convert(
+    GDALDataType::GDAL.GDALDataType,
+    GDT_Unknown::GDAL.GDT_Unknown,
+    GDT_Byte::GDAL.GDT_Byte,
+    GDT_UInt16::GDAL.GDT_UInt16,
+    GDT_Int16::GDAL.GDT_Int16,
+    GDT_UInt32::GDAL.GDT_UInt32,
+    GDT_Int32::GDAL.GDT_Int32,
+    GDT_Float32::GDAL.GDT_Float32,
+    GDT_Float64::GDAL.GDT_Float64,
+    GDT_CInt16::GDAL.GDT_CInt16,
+    GDT_CInt32::GDAL.GDT_CInt32,
+    GDT_CFloat32::GDAL.GDT_CFloat32,
+    GDT_CFloat64::GDAL.GDT_CFloat64,
+    GDT_TypeCount::GDAL.GDT_TypeCount,
 )
 
-eval(
-    @convert(
-        GDALDataType::ImageCore.Normed,
-        GDT_Byte::ImageCore.N0f8,
-        GDT_UInt16::ImageCore.N0f16,
-        GDT_UInt32::ImageCore.N0f32,
-    )
+@convert(
+    GDALDataType::ImageCore.Normed,
+    GDT_Byte::ImageCore.N0f8,
+    GDT_UInt16::ImageCore.N0f16,
+    GDT_UInt32::ImageCore.N0f32,
 )
 
-eval(
-    @convert(
-        GDALDataType::DataType,
-        GDT_Unknown::Any,
-        GDT_Byte::UInt8,
-        GDT_UInt16::UInt16,
-        GDT_Int16::Int16,
-        GDT_UInt32::UInt32,
-        GDT_Int32::Int32,
-        GDT_Float32::Float32,
-        GDT_Float64::Float64,
-        GDT_CFloat32::ComplexF32,
-        GDT_CFloat64::ComplexF64
-    )
+@convert(
+    GDALDataType::DataType,
+    GDT_Unknown::Any,
+    GDT_Byte::UInt8,
+    GDT_UInt16::UInt16,
+    GDT_Int16::Int16,
+    GDT_UInt32::UInt32,
+    GDT_Int32::Int32,
+    GDT_Float32::Float32,
+    GDT_Float64::Float64,
+    GDT_CFloat32::ComplexF32,
+    GDT_CFloat64::ComplexF64
 )
 
-eval(
-    @convert(
-        OGRFieldType::GDAL.OGRFieldType,
-        OFTInteger::GDAL.OFTInteger,
-        OFTIntegerList::GDAL.OFTIntegerList,
-        OFTReal::GDAL.OFTReal,
-        OFTRealList::GDAL.OFTRealList,
-        OFTString::GDAL.OFTString,
-        OFTStringList::GDAL.OFTStringList,
-        OFTWideString::GDAL.OFTWideString,
-        OFTWideStringList::GDAL.OFTWideStringList,
-        OFTBinary::GDAL.OFTBinary,
-        OFTDate::GDAL.OFTDate,
-        OFTTime::GDAL.OFTTime,
-        OFTDateTime::GDAL.OFTDateTime,
-        OFTInteger64::GDAL.OFTInteger64,
-        OFTInteger64List::GDAL.OFTInteger64List,
-    )
+@convert(
+    OGRFieldType::GDAL.OGRFieldType,
+    OFTInteger::GDAL.OFTInteger,
+    OFTIntegerList::GDAL.OFTIntegerList,
+    OFTReal::GDAL.OFTReal,
+    OFTRealList::GDAL.OFTRealList,
+    OFTString::GDAL.OFTString,
+    OFTStringList::GDAL.OFTStringList,
+    OFTWideString::GDAL.OFTWideString,
+    OFTWideStringList::GDAL.OFTWideStringList,
+    OFTBinary::GDAL.OFTBinary,
+    OFTDate::GDAL.OFTDate,
+    OFTTime::GDAL.OFTTime,
+    OFTDateTime::GDAL.OFTDateTime,
+    OFTInteger64::GDAL.OFTInteger64,
+    OFTInteger64List::GDAL.OFTInteger64List,
 )
 
-eval(
-    @convert(
-        OGRFieldType::DataType,
-        OFTInteger::Bool,
-        OFTInteger::Int16,
-        OFTInteger::Int32,  # default type comes last
-        OFTIntegerList::Vector{Int32},
-        OFTReal::Float32,
-        OFTReal::Float64,  # default type comes last
-        OFTRealList::Vector{Float64},
-        OFTString::String,
-        OFTStringList::Vector{String},
-        OFTWideString::Nothing,
-        OFTWideStringList::Nothing,
-        OFTBinary::Vector{UInt8},
-        OFTDate::Dates.Date,
-        OFTTime::Dates.Time,
-        OFTDateTime::Dates.DateTime,
-        OFTInteger64::Int64,
-        OFTInteger64List::Vector{Int64},
-    )
+@convert(
+    OGRFieldType::DataType,
+    OFTInteger::Bool,
+    OFTInteger::Int16,
+    OFTInteger::Int32,  # default type comes last
+    OFTIntegerList::Vector{Int32},
+    OFTReal::Float32,
+    OFTReal::Float64,  # default type comes last
+    OFTRealList::Vector{Float64},
+    OFTString::String,
+    OFTStringList::Vector{String},
+    OFTWideString::Nothing,
+    OFTWideStringList::Nothing,
+    OFTBinary::Vector{UInt8},
+    OFTDate::Dates.Date,
+    OFTTime::Dates.Time,
+    OFTDateTime::Dates.DateTime,
+    OFTInteger64::Int64,
+    OFTInteger64List::Vector{Int64},
 )
 
-eval(
-    @convert(
-        OGRFieldSubType::GDAL.OGRFieldSubType,
-        OFSTNone::GDAL.OFSTNone,
-        OFSTBoolean::GDAL.OFSTBoolean,
-        OFSTInt16::GDAL.OFSTInt16,
-        OFSTFloat32::GDAL.OFSTFloat32,
-        OFSTJSON::GDAL.OFSTJSON,
-    )
+@convert(
+    OGRFieldSubType::GDAL.OGRFieldSubType,
+    OFSTNone::GDAL.OFSTNone,
+    OFSTBoolean::GDAL.OFSTBoolean,
+    OFSTInt16::GDAL.OFSTInt16,
+    OFSTFloat32::GDAL.OFSTFloat32,
+    OFSTJSON::GDAL.OFSTJSON,
 )
 
-eval(
-    @convert(
-        OGRFieldSubType::DataType,
-        OFSTNone::Nothing,
-        OFSTBoolean::Bool,
-        OFSTInt16::Int16,
-        OFSTFloat32::Float32,
-        OFSTJSON::String,
-    )
+@convert(
+    OGRFieldSubType::DataType,
+    OFSTNone::Nothing,
+    OFSTBoolean::Bool,
+    OFSTInt16::Int16,
+    OFSTFloat32::Float32,
+    OFSTJSON::String,
 )
 
-eval(
-    @convert(
-        OGRJustification::GDAL.OGRJustification,
-        OJUndefined::GDAL.OJUndefined,
-        OJLeft::GDAL.OJLeft,
-        OJRight::GDAL.OJRight,
-    )
+@convert(
+    OGRJustification::GDAL.OGRJustification,
+    OJUndefined::GDAL.OJUndefined,
+    OJLeft::GDAL.OJLeft,
+    OJRight::GDAL.OJRight,
 )
 
-eval(
-    @convert(
-        GDALRATFieldType::GDAL.GDALRATFieldType,
-        GFT_Integer::GDAL.GFT_Integer,
-        GFT_Real::GDAL.GFT_Real,
-        GFT_String::GDAL.GFT_String,
-    )
+@convert(
+    GDALRATFieldType::GDAL.GDALRATFieldType,
+    GFT_Integer::GDAL.GFT_Integer,
+    GFT_Real::GDAL.GFT_Real,
+    GFT_String::GDAL.GFT_String,
 )
 
-eval(
-    @convert(
-        GDALRATFieldUsage::GDAL.GDALRATFieldUsage,
-        GFU_Generic::GDAL.GFU_Generic,
-        GFU_PixelCount::GDAL.GFU_PixelCount,
-        GFU_Name::GDAL.GFU_Name,
-        GFU_Min::GDAL.GFU_Min,
-        GFU_Max::GDAL.GFU_Max,
-        GFU_MinMax::GDAL.GFU_MinMax,
-        GFU_Red::GDAL.GFU_Red,
-        GFU_Green::GDAL.GFU_Green,
-        GFU_Blue::GDAL.GFU_Blue,
-        GFU_Alpha::GDAL.GFU_Alpha,
-        GFU_RedMin::GDAL.GFU_RedMin,
-        GFU_GreenMin::GDAL.GFU_GreenMin,
-        GFU_BlueMin::GDAL.GFU_BlueMin,
-        GFU_AlphaMin::GDAL.GFU_AlphaMin,
-        GFU_RedMax::GDAL.GFU_RedMax,
-        GFU_GreenMax::GDAL.GFU_GreenMax,
-        GFU_BlueMax::GDAL.GFU_BlueMax,
-        GFU_AlphaMax::GDAL.GFU_AlphaMax,
-        GFU_MaxCount::GDAL.GFU_MaxCount,
-    )
+@convert(
+    GDALRATFieldUsage::GDAL.GDALRATFieldUsage,
+    GFU_Generic::GDAL.GFU_Generic,
+    GFU_PixelCount::GDAL.GFU_PixelCount,
+    GFU_Name::GDAL.GFU_Name,
+    GFU_Min::GDAL.GFU_Min,
+    GFU_Max::GDAL.GFU_Max,
+    GFU_MinMax::GDAL.GFU_MinMax,
+    GFU_Red::GDAL.GFU_Red,
+    GFU_Green::GDAL.GFU_Green,
+    GFU_Blue::GDAL.GFU_Blue,
+    GFU_Alpha::GDAL.GFU_Alpha,
+    GFU_RedMin::GDAL.GFU_RedMin,
+    GFU_GreenMin::GDAL.GFU_GreenMin,
+    GFU_BlueMin::GDAL.GFU_BlueMin,
+    GFU_AlphaMin::GDAL.GFU_AlphaMin,
+    GFU_RedMax::GDAL.GFU_RedMax,
+    GFU_GreenMax::GDAL.GFU_GreenMax,
+    GFU_BlueMax::GDAL.GFU_BlueMax,
+    GFU_AlphaMax::GDAL.GFU_AlphaMax,
+    GFU_MaxCount::GDAL.GFU_MaxCount,
 )
 
-eval(
-    @convert(
-        GDALAccess::GDAL.GDALAccess,
-        GA_ReadOnly::GDAL.GA_ReadOnly,
-        GA_Update::GDAL.GA_Update,
-    )
+@convert(
+    GDALAccess::GDAL.GDALAccess,
+    GA_ReadOnly::GDAL.GA_ReadOnly,
+    GA_Update::GDAL.GA_Update,
 )
 
-eval(
-    @convert(
-        GDALRWFlag::GDAL.GDALRWFlag,
-        GF_Read::GDAL.GF_Read,
-        GF_Write::GDAL.GF_Write,
-    )
+@convert(
+    GDALRWFlag::GDAL.GDALRWFlag,
+    GF_Read::GDAL.GF_Read,
+    GF_Write::GDAL.GF_Write,
 )
 
-eval(
-    @convert(
-        GDALPaletteInterp::GDAL.GDALPaletteInterp,
-        GPI_Gray::GDAL.GPI_Gray,
-        GPI_RGB::GDAL.GPI_RGB,
-        GPI_CMYK::GDAL.GPI_CMYK,
-        GPI_HLS::GDAL.GPI_HLS,
-    )
+@convert(
+    GDALPaletteInterp::GDAL.GDALPaletteInterp,
+    GPI_Gray::GDAL.GPI_Gray,
+    GPI_RGB::GDAL.GPI_RGB,
+    GPI_CMYK::GDAL.GPI_CMYK,
+    GPI_HLS::GDAL.GPI_HLS,
 )
 
-eval(
-    @convert(
-        GDALColorInterp::GDAL.GDALColorInterp,
-        GCI_Undefined::GDAL.GCI_Undefined,
-        GCI_GrayIndex::GDAL.GCI_GrayIndex,
-        GCI_PaletteIndex::GDAL.GCI_PaletteIndex,
-        GCI_RedBand::GDAL.GCI_RedBand,
-        GCI_GreenBand::GDAL.GCI_GreenBand,
-        GCI_BlueBand::GDAL.GCI_BlueBand,
-        GCI_AlphaBand::GDAL.GCI_AlphaBand,
-        GCI_HueBand::GDAL.GCI_HueBand,
-        GCI_SaturationBand::GDAL.GCI_SaturationBand,
-        GCI_LightnessBand::GDAL.GCI_LightnessBand,
-        GCI_CyanBand::GDAL.GCI_CyanBand,
-        GCI_MagentaBand::GDAL.GCI_MagentaBand,
-        GCI_YellowBand::GDAL.GCI_YellowBand,
-        GCI_BlackBand::GDAL.GCI_BlackBand,
-        GCI_YCbCr_YBand::GDAL.GCI_YCbCr_YBand,
-        GCI_YCbCr_CbBand::GDAL.GCI_YCbCr_CbBand,
-        GCI_YCbCr_CrBand::GDAL.GCI_YCbCr_CrBand,
-    )
+@convert(
+    GDALColorInterp::GDAL.GDALColorInterp,
+    GCI_Undefined::GDAL.GCI_Undefined,
+    GCI_GrayIndex::GDAL.GCI_GrayIndex,
+    GCI_PaletteIndex::GDAL.GCI_PaletteIndex,
+    GCI_RedBand::GDAL.GCI_RedBand,
+    GCI_GreenBand::GDAL.GCI_GreenBand,
+    GCI_BlueBand::GDAL.GCI_BlueBand,
+    GCI_AlphaBand::GDAL.GCI_AlphaBand,
+    GCI_HueBand::GDAL.GCI_HueBand,
+    GCI_SaturationBand::GDAL.GCI_SaturationBand,
+    GCI_LightnessBand::GDAL.GCI_LightnessBand,
+    GCI_CyanBand::GDAL.GCI_CyanBand,
+    GCI_MagentaBand::GDAL.GCI_MagentaBand,
+    GCI_YellowBand::GDAL.GCI_YellowBand,
+    GCI_BlackBand::GDAL.GCI_BlackBand,
+    GCI_YCbCr_YBand::GDAL.GCI_YCbCr_YBand,
+    GCI_YCbCr_CbBand::GDAL.GCI_YCbCr_CbBand,
+    GCI_YCbCr_CrBand::GDAL.GCI_YCbCr_CrBand,
 )
 
-eval(
-    @convert(
-        GDALAsyncStatusType::GDAL.GDALAsyncStatusType,
-        GARIO_PENDING::GDAL.GARIO_PENDING,
-        GARIO_UPDATE::GDAL.GARIO_UPDATE,
-        GARIO_ERROR::GDAL.GARIO_ERROR,
-        GARIO_COMPLETE::GDAL.GARIO_COMPLETE,
-        GARIO_TypeCount::GDAL.GARIO_TypeCount,
-    )
+@convert(
+    GDALAsyncStatusType::GDAL.GDALAsyncStatusType,
+    GARIO_PENDING::GDAL.GARIO_PENDING,
+    GARIO_UPDATE::GDAL.GARIO_UPDATE,
+    GARIO_ERROR::GDAL.GARIO_ERROR,
+    GARIO_COMPLETE::GDAL.GARIO_COMPLETE,
+    GARIO_TypeCount::GDAL.GARIO_TypeCount,
 )
 
-eval(
-    @convert(
-        OGRSTClassId::GDAL.OGRSTClassId,
-        OGRSTCNone::GDAL.OGRSTCNone,
-        OGRSTCPen::GDAL.OGRSTCPen,
-        OGRSTCBrush::GDAL.OGRSTCBrush,
-        OGRSTCSymbol::GDAL.OGRSTCSymbol,
-        OGRSTCLabel::GDAL.OGRSTCLabel,
-        OGRSTCVector::GDAL.OGRSTCVector,
-    )
+@convert(
+    OGRSTClassId::GDAL.OGRSTClassId,
+    OGRSTCNone::GDAL.OGRSTCNone,
+    OGRSTCPen::GDAL.OGRSTCPen,
+    OGRSTCBrush::GDAL.OGRSTCBrush,
+    OGRSTCSymbol::GDAL.OGRSTCSymbol,
+    OGRSTCLabel::GDAL.OGRSTCLabel,
+    OGRSTCVector::GDAL.OGRSTCVector,
 )
 
-eval(
-    @convert(
-        OGRSTUnitId::GDAL.OGRSTUnitId,
-        OGRSTUGround::GDAL.OGRSTUGround,
-        OGRSTUPixel::GDAL.OGRSTUPixel,
-        OGRSTUPoints::GDAL.OGRSTUPoints,
-        OGRSTUMM::GDAL.OGRSTUMM,
-        OGRSTUCM::GDAL.OGRSTUCM,
-        OGRSTUInches::GDAL.OGRSTUInches,
-    )
+@convert(
+    OGRSTUnitId::GDAL.OGRSTUnitId,
+    OGRSTUGround::GDAL.OGRSTUGround,
+    OGRSTUPixel::GDAL.OGRSTUPixel,
+    OGRSTUPoints::GDAL.OGRSTUPoints,
+    OGRSTUMM::GDAL.OGRSTUMM,
+    OGRSTUCM::GDAL.OGRSTUCM,
+    OGRSTUInches::GDAL.OGRSTUInches,
 )
 
-eval(
-    @convert(
-        OGRwkbGeometryType::GDAL.OGRwkbGeometryType,
-        wkbUnknown::GDAL.wkbUnknown,
-        wkbPoint::GDAL.wkbPoint,
-        wkbLineString::GDAL.wkbLineString,
-        wkbPolygon::GDAL.wkbPolygon,
-        wkbMultiPoint::GDAL.wkbMultiPoint,
-        wkbMultiLineString::GDAL.wkbMultiLineString,
-        wkbMultiPolygon::GDAL.wkbMultiPolygon,
-        wkbGeometryCollection::GDAL.wkbGeometryCollection,
-        wkbCircularString::GDAL.wkbCircularString,
-        wkbCompoundCurve::GDAL.wkbCompoundCurve,
-        wkbCurvePolygon::GDAL.wkbCurvePolygon,
-        wkbMultiCurve::GDAL.wkbMultiCurve,
-        wkbMultiSurface::GDAL.wkbMultiSurface,
-        wkbCurve::GDAL.wkbCurve,
-        wkbSurface::GDAL.wkbSurface,
-        wkbPolyhedralSurface::GDAL.wkbPolyhedralSurface,
-        wkbTIN::GDAL.wkbTIN,
-        wkbTriangle::GDAL.wkbTriangle,
-        wkbNone::GDAL.wkbNone,
-        wkbLinearRing::GDAL.wkbLinearRing,
-        wkbCircularStringZ::GDAL.wkbCircularStringZ,
-        wkbCompoundCurveZ::GDAL.wkbCompoundCurveZ,
-        wkbCurvePolygonZ::GDAL.wkbCurvePolygonZ,
-        wkbMultiCurveZ::GDAL.wkbMultiCurveZ,
-        wkbMultiSurfaceZ::GDAL.wkbMultiSurfaceZ,
-        wkbCurveZ::GDAL.wkbCurveZ,
-        wkbSurfaceZ::GDAL.wkbSurfaceZ,
-        wkbPolyhedralSurfaceZ::GDAL.wkbPolyhedralSurfaceZ,
-        wkbTINZ::GDAL.wkbTINZ,
-        wkbTriangleZ::GDAL.wkbTriangleZ,
-        wkbPointM::GDAL.wkbPointM,
-        wkbLineStringM::GDAL.wkbLineStringM,
-        wkbPolygonM::GDAL.wkbPolygonM,
-        wkbMultiPointM::GDAL.wkbMultiPointM,
-        wkbMultiLineStringM::GDAL.wkbMultiLineStringM,
-        wkbMultiPolygonM::GDAL.wkbMultiPolygonM,
-        wkbGeometryCollectionM::GDAL.wkbGeometryCollectionM,
-        wkbCircularStringM::GDAL.wkbCircularStringM,
-        wkbCompoundCurveM::GDAL.wkbCompoundCurveM,
-        wkbCurvePolygonM::GDAL.wkbCurvePolygonM,
-        wkbMultiCurveM::GDAL.wkbMultiCurveM,
-        wkbMultiSurfaceM::GDAL.wkbMultiSurfaceM,
-        wkbCurveM::GDAL.wkbCurveM,
-        wkbSurfaceM::GDAL.wkbSurfaceM,
-        wkbPolyhedralSurfaceM::GDAL.wkbPolyhedralSurfaceM,
-        wkbTINM::GDAL.wkbTINM,
-        wkbTriangleM::GDAL.wkbTriangleM,
-        wkbPointZM::GDAL.wkbPointZM,
-        wkbLineStringZM::GDAL.wkbLineStringZM,
-        wkbPolygonZM::GDAL.wkbPolygonZM,
-        wkbMultiPointZM::GDAL.wkbMultiPointZM,
-        wkbMultiLineStringZM::GDAL.wkbMultiLineStringZM,
-        wkbMultiPolygonZM::GDAL.wkbMultiPolygonZM,
-        wkbGeometryCollectionZM::GDAL.wkbGeometryCollectionZM,
-        wkbCircularStringZM::GDAL.wkbCircularStringZM,
-        wkbCompoundCurveZM::GDAL.wkbCompoundCurveZM,
-        wkbCurvePolygonZM::GDAL.wkbCurvePolygonZM,
-        wkbMultiCurveZM::GDAL.wkbMultiCurveZM,
-        wkbMultiSurfaceZM::GDAL.wkbMultiSurfaceZM,
-        wkbCurveZM::GDAL.wkbCurveZM,
-        wkbSurfaceZM::GDAL.wkbSurfaceZM,
-        wkbPolyhedralSurfaceZM::GDAL.wkbPolyhedralSurfaceZM,
-        wkbTINZM::GDAL.wkbTINZM,
-        wkbTriangleZM::GDAL.wkbTriangleZM,
-        wkbPoint25D::GDAL.wkbPoint25D,
-        wkbLineString25D::GDAL.wkbLineString25D,
-        wkbPolygon25D::GDAL.wkbPolygon25D,
-        wkbMultiPoint25D::GDAL.wkbMultiPoint25D,
-        wkbMultiLineString25D::GDAL.wkbMultiLineString25D,
-        wkbMultiPolygon25D::GDAL.wkbMultiPolygon25D,
-        wkbGeometryCollection25D::GDAL.wkbGeometryCollection25D,
-    )
+@convert(
+    OGRwkbGeometryType::GDAL.OGRwkbGeometryType,
+    wkbUnknown::GDAL.wkbUnknown,
+    wkbPoint::GDAL.wkbPoint,
+    wkbLineString::GDAL.wkbLineString,
+    wkbPolygon::GDAL.wkbPolygon,
+    wkbMultiPoint::GDAL.wkbMultiPoint,
+    wkbMultiLineString::GDAL.wkbMultiLineString,
+    wkbMultiPolygon::GDAL.wkbMultiPolygon,
+    wkbGeometryCollection::GDAL.wkbGeometryCollection,
+    wkbCircularString::GDAL.wkbCircularString,
+    wkbCompoundCurve::GDAL.wkbCompoundCurve,
+    wkbCurvePolygon::GDAL.wkbCurvePolygon,
+    wkbMultiCurve::GDAL.wkbMultiCurve,
+    wkbMultiSurface::GDAL.wkbMultiSurface,
+    wkbCurve::GDAL.wkbCurve,
+    wkbSurface::GDAL.wkbSurface,
+    wkbPolyhedralSurface::GDAL.wkbPolyhedralSurface,
+    wkbTIN::GDAL.wkbTIN,
+    wkbTriangle::GDAL.wkbTriangle,
+    wkbNone::GDAL.wkbNone,
+    wkbLinearRing::GDAL.wkbLinearRing,
+    wkbCircularStringZ::GDAL.wkbCircularStringZ,
+    wkbCompoundCurveZ::GDAL.wkbCompoundCurveZ,
+    wkbCurvePolygonZ::GDAL.wkbCurvePolygonZ,
+    wkbMultiCurveZ::GDAL.wkbMultiCurveZ,
+    wkbMultiSurfaceZ::GDAL.wkbMultiSurfaceZ,
+    wkbCurveZ::GDAL.wkbCurveZ,
+    wkbSurfaceZ::GDAL.wkbSurfaceZ,
+    wkbPolyhedralSurfaceZ::GDAL.wkbPolyhedralSurfaceZ,
+    wkbTINZ::GDAL.wkbTINZ,
+    wkbTriangleZ::GDAL.wkbTriangleZ,
+    wkbPointM::GDAL.wkbPointM,
+    wkbLineStringM::GDAL.wkbLineStringM,
+    wkbPolygonM::GDAL.wkbPolygonM,
+    wkbMultiPointM::GDAL.wkbMultiPointM,
+    wkbMultiLineStringM::GDAL.wkbMultiLineStringM,
+    wkbMultiPolygonM::GDAL.wkbMultiPolygonM,
+    wkbGeometryCollectionM::GDAL.wkbGeometryCollectionM,
+    wkbCircularStringM::GDAL.wkbCircularStringM,
+    wkbCompoundCurveM::GDAL.wkbCompoundCurveM,
+    wkbCurvePolygonM::GDAL.wkbCurvePolygonM,
+    wkbMultiCurveM::GDAL.wkbMultiCurveM,
+    wkbMultiSurfaceM::GDAL.wkbMultiSurfaceM,
+    wkbCurveM::GDAL.wkbCurveM,
+    wkbSurfaceM::GDAL.wkbSurfaceM,
+    wkbPolyhedralSurfaceM::GDAL.wkbPolyhedralSurfaceM,
+    wkbTINM::GDAL.wkbTINM,
+    wkbTriangleM::GDAL.wkbTriangleM,
+    wkbPointZM::GDAL.wkbPointZM,
+    wkbLineStringZM::GDAL.wkbLineStringZM,
+    wkbPolygonZM::GDAL.wkbPolygonZM,
+    wkbMultiPointZM::GDAL.wkbMultiPointZM,
+    wkbMultiLineStringZM::GDAL.wkbMultiLineStringZM,
+    wkbMultiPolygonZM::GDAL.wkbMultiPolygonZM,
+    wkbGeometryCollectionZM::GDAL.wkbGeometryCollectionZM,
+    wkbCircularStringZM::GDAL.wkbCircularStringZM,
+    wkbCompoundCurveZM::GDAL.wkbCompoundCurveZM,
+    wkbCurvePolygonZM::GDAL.wkbCurvePolygonZM,
+    wkbMultiCurveZM::GDAL.wkbMultiCurveZM,
+    wkbMultiSurfaceZM::GDAL.wkbMultiSurfaceZM,
+    wkbCurveZM::GDAL.wkbCurveZM,
+    wkbSurfaceZM::GDAL.wkbSurfaceZM,
+    wkbPolyhedralSurfaceZM::GDAL.wkbPolyhedralSurfaceZM,
+    wkbTINZM::GDAL.wkbTINZM,
+    wkbTriangleZM::GDAL.wkbTriangleZM,
+    wkbPoint25D::GDAL.wkbPoint25D,
+    wkbLineString25D::GDAL.wkbLineString25D,
+    wkbPolygon25D::GDAL.wkbPolygon25D,
+    wkbMultiPoint25D::GDAL.wkbMultiPoint25D,
+    wkbMultiLineString25D::GDAL.wkbMultiLineString25D,
+    wkbMultiPolygon25D::GDAL.wkbMultiPolygon25D,
+    wkbGeometryCollection25D::GDAL.wkbGeometryCollection25D,
 )
 
 function basetype(gt::OGRwkbGeometryType)::OGRwkbGeometryType
@@ -555,12 +519,10 @@ function basetype(gt::OGRwkbGeometryType)::OGRwkbGeometryType
     return GDAL.OGRwkbGeometryType(wkbGeomType)
 end
 
-eval(
-    @convert(
-        OGRwkbByteOrder::GDAL.OGRwkbByteOrder,
-        wkbXDR::GDAL.wkbXDR,
-        wkbNDR::GDAL.wkbNDR,
-    )
+@convert(
+    OGRwkbByteOrder::GDAL.OGRwkbByteOrder,
+    wkbXDR::GDAL.wkbXDR,
+    wkbNDR::GDAL.wkbNDR,
 )
 
 import Base.|

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,46 +1,48 @@
 """
+    @convert(args...)
+
 # General case:
-
-    eval(@convert(GDALRWFlag::GDAL.GDALRWFlag,
-        GF_Read::GDAL.GF_Read,
-        GF_Write::GDAL.GF_Write,
-    ))
-
+```
+eval(@convert(GDALRWFlag::GDAL.GDALRWFlag,
+    GF_Read::GDAL.GF_Read,
+    GF_Write::GDAL.GF_Write,
+))
+```
 does the equivalent of 
+```
+const GDALRWFlag_to_GDALRWFlag_map = Dict(
+    GF_Read => GDAL.GF_Read,
+    GF_Write => GDAL.GF_Write
+)
+Base.convert(::Type{GDAL.GDALRWFlag}, ft::GDALRWFlag) =
+    GDALRWFlag_to_GDALRWFlag_map[ft]
 
-    const GDALRWFlag_to_GDALRWFlag_map = Dict(
-        GF_Read => GDAL.GF_Read,
-        GF_Write => GDAL.GF_Write
-    )
-    Base.convert(::Type{GDAL.GDALRWFlag}, ft::GDALRWFlag) =
-        GDALRWFlag_to_GDALRWFlag_map[ft]
-
-    const GDALRWFlag_to_GDALRWFlag_map = Dict(
-        GDAL.GF_Read => GF_Read, 
-        GDAL.GF_Write => GF_Write
-    )
-    Base.convert(::Type{GDALRWFlag}, ft::GDAL.GDALRWFlag) =
-        GDALRWFlag_to_GDALRWFlag_map[ft]
-
+const GDALRWFlag_to_GDALRWFlag_map = Dict(
+    GDAL.GF_Read => GF_Read, 
+    GDAL.GF_Write => GF_Write
+)
+Base.convert(::Type{GDALRWFlag}, ft::GDAL.GDALRWFlag) =
+    GDALRWFlag_to_GDALRWFlag_map[ft]
+```
 # Case where 1st type `<: Enum` and 2nd type `== DataType`:
-
-    eval(@convert(OGRFieldType::DataType,
-        OFTInteger::Bool,
-        OFTInteger::Int16,
-    ))
-
+```
+eval(@convert(OGRFieldType::DataType,
+    OFTInteger::Bool,
+    OFTInteger::Int16,
+))
+```
 does the equivalent of
+```
+const OGRFieldType_to_DataType_map = Dict(
+    OFTInteger => Bool, 
+    OFTInteger => Int16,
+)
+Base.convert(::Type{DataType}, ft::OGRFieldType) =
+    OGRFieldType_to_DataType_map[ft]
 
-    const OGRFieldType_to_DataType_map = Dict(
-        OFTInteger => Bool, 
-        OFTInteger => Int16,
-    )
-    Base.convert(::Type{DataType}, ft::OGRFieldType) =
-        OGRFieldType_to_DataType_map[ft]
-
-    Base.convert(::Type{OGRFieldType}, ft::Type{Bool}) = OFTInteger
-    Base.convert(::Type{OGRFieldType}, ft::Type{Int16}) = OFTInteger
-    
+Base.convert(::Type{OGRFieldType}, ft::Type{Bool}) = OFTInteger
+Base.convert(::Type{OGRFieldType}, ft::Type{Int16}) = OFTInteger
+```
 
 """
 macro convert(args...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,10 +91,7 @@ macro convert(args...)
             esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
         push!(
             result_expr.args,
-            :(
-                const $type1_to_type2_map_name =
-                    Dict{$type1,$type2}(Tuple{$type1,$type2}[$(fwd_map...)])
-            ),
+            :(const $type1_to_type2_map_name = Dict([$(fwd_map...)])),
         )
         push!(
             result_expr.args,
@@ -125,10 +122,7 @@ macro convert(args...)
             esc(Symbol(type2_string * "_to_" * type1_string * "_map"))
         push!(
             result_expr.args,
-            :(
-                const $type2_to_type1_map_name =
-                    Dict{$type2,$type1}(Tuple{$type2,$type1}[$(rev_map...)])
-            ),
+            :(const $type2_to_type1_map_name = Dict([$(rev_map...)])),
         )
         push!(
             result_expr.args,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,8 +52,10 @@ macro convert(args...)
     type2_symbol = args[1].args[2]
     type1_string = replace(string(type1_symbol), "." => "_")
     type2_string = replace(string(type2_symbol), "." => "_")
-    type1_isenum_and_type2_equaldatatype = (eval(type1_symbol) <: Enum) && (eval(type2_symbol) == DataType)
-    type2_isenum_and_type1_equaldatatype = (eval(type2_symbol) <: Enum) && (eval(type1_symbol) == DataType)
+    type1_isenum_and_type2_equaldatatype =
+        (eval(type1_symbol) <: Enum) && (eval(type2_symbol) == DataType)
+    type2_isenum_and_type1_equaldatatype =
+        (eval(type2_symbol) <: Enum) && (eval(type1_symbol) == DataType)
     type1 = esc(type1_symbol)
     type2 = esc(type2_symbol)
     if type2_isenum_and_type1_equaldatatype
@@ -64,7 +66,8 @@ macro convert(args...)
     if type1_isenum_and_type2_equaldatatype
         rev_to_enum_map = [Tuple(esc.(reverse(a.args))) for a in args[2:end]]
     else
-        rev_map = Expr[Expr(:tuple, esc.(reverse(a.args))...) for a in args[2:end]]
+        rev_map =
+            Expr[Expr(:tuple, esc.(reverse(a.args))...) for a in args[2:end]]
     end
 
     result_expr = Expr(:block)
@@ -73,13 +76,19 @@ macro convert(args...)
         for stypes in fwd_to_enum_map
             push!(
                 result_expr.args,
-                :(function Base.convert(::Type{$type2}, ft::Type{$(stypes[1])})
-                    return $(stypes[2])
-                end),
+                :(
+                    function Base.convert(
+                        ::Type{$type2},
+                        ft::Type{$(stypes[1])},
+                    )
+                        return $(stypes[2])
+                    end
+                ),
             )
         end
     else
-        type1_to_type2_map_name = esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
+        type1_to_type2_map_name =
+            esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
         push!(
             result_expr.args,
             :(
@@ -87,24 +96,33 @@ macro convert(args...)
                     Dict{$type1,$type2}(Tuple{$type1,$type2}[$(fwd_map...)])
             ),
         )
-        push!(result_expr.args, :(function Base.convert(::Type{$type2}, ft::$type1)
-            return get($type1_to_type2_map_name, ft) do
-                return error("Unknown type: $ft")
-            end
-        end))
+        push!(
+            result_expr.args,
+            :(function Base.convert(::Type{$type2}, ft::$type1)
+                return get($type1_to_type2_map_name, ft) do
+                    return error("Unknown type: $ft")
+                end
+            end),
+        )
     end
     # Reverse conversion
     if type1_isenum_and_type2_equaldatatype
         for stypes in rev_to_enum_map
             push!(
                 result_expr.args,
-                :(function Base.convert(::Type{$type1}, ft::Type{$(stypes[1])})
-                    return $(stypes[2])
-                end),
+                :(
+                    function Base.convert(
+                        ::Type{$type1},
+                        ft::Type{$(stypes[1])},
+                    )
+                        return $(stypes[2])
+                    end
+                ),
             )
         end
     else
-        type2_to_type1_map_name = esc(Symbol(type2_string * "_to_" * type1_string * "_map"))
+        type2_to_type1_map_name =
+            esc(Symbol(type2_string * "_to_" * type1_string * "_map"))
         push!(
             result_expr.args,
             :(
@@ -112,11 +130,14 @@ macro convert(args...)
                     Dict{$type2,$type1}(Tuple{$type2,$type1}[$(rev_map...)])
             ),
         )
-        push!(result_expr.args, :(function Base.convert(::Type{$type1}, ft::$type2)
-            return get($type2_to_type1_map_name, ft) do
-                return error("Unknown type: $ft")
-            end
-        end))
+        push!(
+            result_expr.args,
+            :(function Base.convert(::Type{$type1}, ft::$type2)
+                return get($type2_to_type1_map_name, ft) do
+                    return error("Unknown type: $ft")
+                end
+            end),
+        )
     end
     return result_expr
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,5 @@
 """
+# General case:
 
     eval(@convert(GDALRWFlag::GDAL.GDALRWFlag,
         GF_Read::GDAL.GF_Read,
@@ -7,44 +8,41 @@
 
 does the equivalent of 
 
+    const GDALRWFlag_to_GDALRWFlag_map = Dict(
+        GF_Read => GDAL.GF_Read,
+        GF_Write => GDAL.GF_Write
+    )
     Base.convert(::Type{GDAL.GDALRWFlag}, ft::GDALRWFlag) =
-        Dict{GDALRWFlag, GDAL.GDALRWFlag}(
-            GF_Read => GDAL.GF_Read,
-            GF_Write => GDAL.GF_Write
-        )[ft]
+        GDALRWFlag_to_GDALRWFlag_map[ft]
 
+    const GDALRWFlag_to_GDALRWFlag_map = Dict(
+        GDAL.GF_Read => GF_Read, 
+        GDAL.GF_Write => GF_Write
+    )
     Base.convert(::Type{GDALRWFlag}, ft::GDAL.GDALRWFlag) =
-        Dict{GDAL.GDALRWFlag, GDALRWFlag}(
-            GDAL.GF_Read => GF_Read,
-            GDAL.GF_Write => GF_Write
-        )[ft]
+        GDALRWFlag_to_GDALRWFlag_map[ft]
+
+# Case where 1st type `<: Enum` and 2nd type `== DataType`:
+
+    eval(@convert(OGRFieldType::DataType,
+        OFTInteger::Bool,
+        OFTInteger::Int16,
+    ))
+
+does the equivalent of
+
+    const OGRFieldType_to_DataType_map = Dict(
+        OFTInteger => Bool, 
+        OFTInteger => Int16,
+    )
+    Base.convert(::Type{DataType}, ft::OGRFieldType) =
+        OGRFieldType_to_DataType_map[ft]
+
+    Base.convert(::Type{OGRFieldType}, ft::Type{Bool}) = OFTInteger
+    Base.convert(::Type{OGRFieldType}, ft::Type{Int16}) = OFTInteger
+    
 
 """
-macro convert_old(args...)
-    @assert length(args) > 0
-    @assert args[1].head == :(::)
-    type1 = esc(args[1].args[1])
-    type2 = esc(args[1].args[2])
-    forward_map = Expr[Expr(:tuple, esc.(a.args)...) for a in args[2:end]]
-    reverse_map =
-        Expr[Expr(:tuple, esc.(reverse(a.args))...) for a in args[2:end]]
-    quote
-        function Base.convert(::Type{$type2}, ft::$type1)
-            fwd = Dict{$type1,$type2}(Tuple{$type1,$type2}[$(forward_map...)])
-            return get(fwd, ft) do
-                return error("Unknown type: $ft")
-            end
-        end
-
-        function Base.convert(::Type{$type1}, ft::$type2)
-            rev = Dict{$type2,$type1}(Tuple{$type2,$type1}[$(reverse_map...)])
-            return get(rev, ft) do
-                return error("Unknown type: $ft")
-            end
-        end
-    end
-end
-
 macro convert(args...)
     @assert length(args) > 0
     @assert args[1].head == :(::)
@@ -54,15 +52,9 @@ macro convert(args...)
     type2_string = replace(string(type2_symbol), "." => "_")
     type1_isenum_and_type2_equaldatatype =
         (eval(type1_symbol) <: Enum) && (eval(type2_symbol) == DataType)
-    type2_isenum_and_type1_equaldatatype =
-        (eval(type2_symbol) <: Enum) && (eval(type1_symbol) == DataType)
     type1 = esc(type1_symbol)
     type2 = esc(type2_symbol)
-    if type2_isenum_and_type1_equaldatatype
-        fwd_to_enum_map = [Tuple(esc.(a.args)) for a in args[2:end]]
-    else
-        fwd_map = Expr[Expr(:tuple, esc.(a.args)...) for a in args[2:end]]
-    end
+    fwd_map = Expr[Expr(:tuple, esc.(a.args)...) for a in args[2:end]]
     if type1_isenum_and_type2_equaldatatype
         rev_to_enum_map = [Tuple(esc.(reverse(a.args))) for a in args[2:end]]
     else
@@ -71,37 +63,21 @@ macro convert(args...)
     end
 
     result_expr = Expr(:block)
-    # Forward conversion
-    if type2_isenum_and_type1_equaldatatype
-        for stypes in fwd_to_enum_map
-            push!(
-                result_expr.args,
-                :(
-                    function Base.convert(
-                        ::Type{$type2},
-                        ft::Type{$(stypes[1])},
-                    )
-                        return $(stypes[2])
-                    end
-                ),
-            )
-        end
-    else
-        type1_to_type2_map_name =
-            esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
-        push!(
-            result_expr.args,
-            :(const $type1_to_type2_map_name = Dict([$(fwd_map...)])),
-        )
-        push!(
-            result_expr.args,
-            :(function Base.convert(::Type{$type2}, ft::$type1)
-                return get($type1_to_type2_map_name, ft) do
-                    return error("Unknown type: $ft")
-                end
-            end),
-        )
-    end
+    # Forward conversion (no case of 1st type == DataType and 2nd type <: Enum handled)
+    type1_to_type2_map_name =
+        esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
+    push!(
+        result_expr.args,
+        :(const $type1_to_type2_map_name = Dict([$(fwd_map...)])),
+    )
+    push!(
+        result_expr.args,
+        :(function Base.convert(::Type{$type2}, ft::$type1)
+            return get($type1_to_type2_map_name, ft) do
+                return error("Unknown type: $ft")
+            end
+        end),
+    )
     # Reverse conversion
     if type1_isenum_and_type2_equaldatatype
         for stypes in rev_to_enum_map

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -23,7 +23,7 @@ import ImageCore
             @test AG.iscomplex(AG.GDT_CFloat64) == true
 
             @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
-            @test_throws ErrorException Base.convert(AG.GDALDataType, Int64)
+            @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
             @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)
             @test_throws MethodError Base.convert(
                 ImageCore.Normed,

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -25,7 +25,7 @@ import ImageCore
             @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
             @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
             @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)
-            @test_throws MethodError Base.convert(
+            @test_throws ErrorException Base.convert(
                 ImageCore.Normed,
                 AG.GDT_Float32,
             )

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -29,6 +29,7 @@ import ImageCore
                 ImageCore.Normed,
                 AG.GDT_Float32,
             )
+            @test_throws ErrorException Base.convert(DataType, AG.OFSTMaxSubType)
         end
 
         @testset "GDAL Colors and Palettes" begin


### PR DESCRIPTION
… and a `convert` function of the form `convert(::Type{type1}, ::Type{subtype2}) = subtype1` when `type1` is an `Enum` type and `type2` is `DataType`

Fixes #221 

Hello @yeesian, I have a proposal for `@convert` macro evolution. 

## Modifications
I modified to items:
1) Moved `fwd_map` and `rev_map` to a `const` outside the `convert` function
2) Used the `convert` signature found by @evetion when one type is an `Enum` and the other is `DataType`

It does not work for:
```julia
(
    GDALDataType::ImageCore.Normed,
    GDT_Byte::ImageCore.N0f8,
    GDT_UInt16::ImageCore.N0f16,
    GDT_UInt32::ImageCore.N0f32,
)
```
It fails at compile time although both old and new `@convert` macro expands into similar code. I have not figured out why, yet. There seem to be an issue with declaring a `const Dict` with `ImageCore.Normed` types in it.  
Therefore I kept the old `@convert` macro for these types conversion, renaming it `@convert_old` and using it for the above conversions.

## Performance
The new `@convert` macro brings a x2 speed up on conversion to Tables:

With the master version:
```julia
julia> ds = get_road_ds(;clean=false)
       layer = AG.getlayer(ds, 0)
       @benchmark Tables.columns($layer)
BenchmarkTools.Trial: 21 samples with 1 evaluation.
 Range (min … max):  227.551 ms … 254.846 ms  ┊ GC (min … max): 6.85% … 10.86%
 Time  (median):     241.586 ms               ┊ GC (median):    8.71%
 Time  (mean ± σ):   242.752 ms ±   5.826 ms  ┊ GC (mean ± σ):  8.74% ±  0.97%

                             █  ▁        ▁   ▁                   
  ▆▁▁▁▁▁▁▁▁▁▁▁▁▁▆▁▁▁▁▁▁▁▆▁▁▁▁█▆▁█▆▁▁▁▁▁▁▆█▁▆▆█▁▁▁▆▆▁▁▁▁▁▁▁▁▁▁▁▆ ▁
  228 ms           Histogram: frequency by time          255 ms <

 Memory estimate: 133.47 MiB, allocs estimate: 1427522.
```

With the new `@macro` macro
```julia
julia> ds = get_road_ds(;clean=false)
       layer = AG.getlayer(ds, 0)
       @benchmark Tables.columns($layer)
BenchmarkTools.Trial: 41 samples with 1 evaluation.
 Range (min … max):   94.682 ms … 264.763 ms  ┊ GC (min … max): 0.00% … 28.53%
 Time  (median):     106.135 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   122.680 ms ±  45.326 ms  ┊ GC (mean ± σ):  5.07% ±  7.51%

    █▃▁                                                          
  ▇▇███▆▆▆▆▇▄▁▄▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▄▁▆ ▁
  94.7 ms          Histogram: frequency by time          265 ms <

 Memory estimate: 8.98 MiB, allocs estimate: 373860.
```

## Additionnal question
Is the call to `eval` necessary in types.jl after calling the `@convert` macro ?

