### PR TITLE
Return the default geotransform rather than throwing an error.

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -714,7 +714,8 @@ function getgeotransform!(
     @assert length(transform) == 6
     result = GDAL.gdalgetgeotransform(dataset.ptr, pointer(transform))
     if result != GDAL.CE_None
-        transform .= (0, 1, 0, 0, 0, 1)
+        # The default geotransform.
+        transform .= (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
     end
     return transform
 end

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -713,7 +713,9 @@ function getgeotransform!(
 )::Vector{Cdouble}
     @assert length(transform) == 6
     result = GDAL.gdalgetgeotransform(dataset.ptr, pointer(transform))
-    @cplerr result "Failed to get geotransform"
+    if result != GDAL.CE_None
+        transform .= (0,1,0,0,0,1)
+    end
     return transform
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -714,7 +714,7 @@ function getgeotransform!(
     @assert length(transform) == 6
     result = GDAL.gdalgetgeotransform(dataset.ptr, pointer(transform))
     if result != GDAL.CE_None
-        transform .= (0,1,0,0,0,1)
+        transform .= (0, 1, 0, 0, 0, 1)
     end
     return transform
 end

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -51,6 +51,8 @@ const AG = ArchGDAL;
             @test AG.nfeature(layer1) == 4
         end
         @test AG.getgeotransform(dataset1) ≈ [0, 1, 0, 0, 0, 1]
+        # the following test covers an example of `macro cplerr(code, message)`
+        @test_throws ErrorException AG.setproj!(dataset1, "nonsensestring")
 
         dataset2 = AG.create(AG.getdriver("Memory"))
         @test AG.nlayer(dataset2) == 0

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -50,7 +50,7 @@ const AG = ArchGDAL;
         AG.getlayer(dataset1, 0) do layer1
             @test AG.nfeature(layer1) == 4
         end
-        @test AG.getgeotransform(dataset1) ≈ [0,1,0,0,0,1]
+        @test AG.getgeotransform(dataset1) ≈ [0, 1, 0, 0, 0, 1]
 
         dataset2 = AG.create(AG.getdriver("Memory"))
         @test AG.nlayer(dataset2) == 0

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -50,8 +50,7 @@ const AG = ArchGDAL;
         AG.getlayer(dataset1, 0) do layer1
             @test AG.nfeature(layer1) == 4
         end
-        # the following test is to cover an example of `macro cplerr(code, message)`
-        @test_throws ErrorException AG.getgeotransform(dataset1)
+        @test AG.getgeotransform(dataset1) ≈ [0,1,0,0,0,1]
 
         dataset2 = AG.create(AG.getdriver("Memory"))
         @test AG.nlayer(dataset2) == 0


### PR DESCRIPTION
Fixes #190.

~~@visr There's a small drop in test coverage due to the drop in test coverage for [`cplerr`](https://github.com/yeesian/ArchGDAL.jl/blob/f98a7cdce3482691ab526e3fbbf796d23aec35ed/src/utils.jl#L137-L143). However, I haven't been able to come up with a scenario in which I'll actually get `CE_Failure` without GDAL.jl throwing an `GDAL.GDALError`. (Which I think is a good thing!)~~ (Update: fixed by Felix in https://github.com/yeesian/ArchGDAL.jl/pull/236#discussion_r698527429)