### PR TITLE
Bidirectional conversion between `GDALDataType` and `ImageCore.Normed` via `UnionAll` case in `@convert` macro

### DIFF
--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -5,7 +5,7 @@ using GDAL: GDAL
 using GeoFormatTypes: GeoFormatTypes
 using GeoInterface: GeoInterface
 using Tables: Tables
-using ImageCore: ImageCore
+using ImageCore: Normed, N0f8, N0f16, N0f32, ImageCore
 using ColorTypes: ColorTypes
 
 const GFT = GeoFormatTypes

--- a/src/types.jl
+++ b/src/types.jl
@@ -253,10 +253,10 @@ end
 )
 
 @convert(
-    GDALDataType::ImageCore.Normed,
-    GDT_Byte::ImageCore.N0f8,
-    GDT_UInt16::ImageCore.N0f16,
-    GDT_UInt32::ImageCore.N0f32,
+    GDALDataType::Normed,
+    GDT_Byte::N0f8,
+    GDT_UInt16::N0f16,
+    GDT_UInt32::N0f32,
 )
 
 @convert(

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -29,7 +29,10 @@ import ImageCore
                 ImageCore.Normed,
                 AG.GDT_Float32,
             )
-            @test_throws ErrorException Base.convert(DataType, AG.OFSTMaxSubType)
+            @test_throws ErrorException Base.convert(
+                DataType,
+                AG.OFSTMaxSubType,
+            )
         end
 
         @testset "GDAL Colors and Palettes" begin


### PR DESCRIPTION
Fixes #235

I have handled the bidirectional conversion between `ArchGDAL.GDALDataType` and `ImageCore.Normed` via `UnionAll` case in `@convert` macro

It gives: 
```julia 
julia> using ArchGDAL

julia> using ImageCore

julia> convert(ArchGDAL.GDALDataType, N0f8)
GDT_Byte::GDALDataType = 1

julia> convert(Normed, ArchGDAL.GDT_Byte)
N0f8 (alias for Normed{UInt8, 8})
```