### PR TITLE
Return `missing` if the field is set but null.

### DIFF
--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -149,7 +149,7 @@ function Base.show(io::IO, layer::AbstractFeatureLayer)::Nothing
     nfielddisplay = min(n, 5)
     for i in 1:nfielddisplay
         fd = getfielddefn(featuredefn, i - 1)
-        display = "     Field $(i - 1) ($(getname(fd))): [$(gettype(fd))]"
+        display = "     Field $(i - 1) ($(getname(fd))): [$(getfieldtype(fd))]"
         if length(display) > 75
             println(io, "$display[1:70]...")
             continue

--- a/src/ogr/fielddefn.jl
+++ b/src/ogr/fielddefn.jl
@@ -72,6 +72,26 @@ function setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)::FieldDefn
 end
 
 """
+    getfieldtype(fielddefn::AbstractFieldDefn)
+
+Returns the type or subtype (if any) of this field.
+
+### Parameters
+* `fielddefn`: handle to the field definition.
+
+### Returns
+The field type or subtype.
+"""
+function getfieldtype(fielddefn::AbstractFieldDefn)::Union{OGRFieldType, OGRFieldSubType}
+    fieldsubtype = getsubtype(fielddefn)
+    return if fieldsubtype != OFSTNone
+        fieldsubtype
+    else
+        gettype(fielddefn)
+    end
+end
+
+"""
     getjustify(fielddefn::AbstractFieldDefn)
 
 Get the justification for this field.

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -157,6 +157,10 @@ const AG = ArchGDAL;
                 AG.setfield!(feature, 9, Int16(1))
                 AG.setfield!(feature, 10, Int32(1))
                 AG.setfield!(feature, 11, Float32(1.0))
+                for i in 1:AG.nfield(feature)
+                    @test !AG.isfieldnull(feature, i-1)
+                    @test AG.isfieldsetandnotnull(feature, i-1)
+                end
                 @test sprint(print, AG.getgeom(feature)) == "NULL Geometry"
                 AG.getgeom(feature) do geom
                     @test sprint(print, geom) == "NULL Geometry"
@@ -169,6 +173,10 @@ const AG = ArchGDAL;
                 AG.addfeature(layer) do newfeature
                     AG.setfrom!(newfeature, feature)
                     @test AG.getfield(newfeature, 0) == 1
+                    for i in 1:AG.nfield(newfeature)
+                        @test !AG.isfieldnull(newfeature, i-1)
+                        @test AG.isfieldsetandnotnull(newfeature, i-1)
+                    end
                     @test AG.getfield(newfeature, 1) ≈ 1.0
                     @test AG.getfield(newfeature, 2) == Int32[1, 2]
                     @test AG.getfield(newfeature, 3) == Int64[1, 2]
@@ -209,6 +217,13 @@ const AG = ArchGDAL;
                         @test AG.getfield(newfeature, 0) == 45
                         @test AG.getfield(newfeature, 1) ≈ 18.2
                         @test AG.getfield(newfeature, 5) == String["foo", "bar"]
+
+                        @test AG.isfieldsetandnotnull(newfeature, 5)
+                        AG.setfieldnull!(newfeature, 5)
+                        @test !AG.isfieldsetandnotnull(newfeature, 5)
+                        @test AG.isfieldset(newfeature, 5)
+                        @test AG.isfieldnull(newfeature, 5)
+                        @test ismissing(AG.getfield(newfeature, 5))
                     end
                     @test AG.nfeature(layer) == 1
                 end

--- a/test/test_fielddefn.jl
+++ b/test/test_fielddefn.jl
@@ -10,14 +10,19 @@ const AG = ArchGDAL;
             AG.setname!(fd, "newname")
             @test AG.getname(fd) == "newname"
             @test AG.gettype(fd) == AG.OFTInteger
+            @test AG.getfieldtype(fd) == AG.OFTInteger
             AG.settype!(fd, AG.OFTDate)
             @test AG.gettype(fd) == AG.OFTDate
+            @test AG.getfieldtype(fd) == AG.OFTDate
             AG.settype!(fd, AG.OFTInteger)
             @test AG.getsubtype(fd) == AG.OFSTNone
+            @test AG.getfieldtype(fd) == ArchGDAL.OFTInteger
             AG.setsubtype!(fd, AG.OFSTInt16)
             @test AG.getsubtype(fd) == AG.OFSTInt16
+            @test AG.getfieldtype(fd) == AG.OFSTInt16
             AG.setsubtype!(fd, AG.OFSTBoolean)
             @test AG.getsubtype(fd) == AG.OFSTBoolean
+            @test AG.getfieldtype(fd) == AG.OFSTBoolean
             AG.setsubtype!(fd, AG.OFSTNone)
             @test AG.getjustify(fd) == AG.OJUndefined
             AG.setjustify!(fd, AG.OJLeft)

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -488,7 +488,7 @@ using Tables
                 withmissingfield::Bool,
                 withmixedgeomtypes::Bool,
                 reference_geotable::NamedTuple,
-            )::Bool
+            )
                 map_on_test_dataset(
                     drvshortname,
                     geomfamilly;
@@ -497,18 +497,14 @@ using Tables
                     withmixedgeomtypes = withmixedgeomtypes,
                 ) do ds
                     layer = AG.getlayer(ds, 0)
-                    return all([
-                        keys(Tables.columntable(layer)) ==
-                        reference_geotable.names,
-                        eltype.(values(Tables.columntable(layer))) ==
-                        reference_geotable.types,
-                        tupleoftuples_equal(
-                            columntablevalues_toWKT(
-                                values(Tables.columntable(layer)),
-                            ),
-                            reference_geotable.values,
+                    @test keys(Tables.columntable(layer)) == reference_geotable.names
+                    @test eltype.(values(Tables.columntable(layer))) == reference_geotable.types
+                    @test tupleoftuples_equal(
+                        columntablevalues_toWKT(
+                            values(Tables.columntable(layer)),
                         ),
-                    ])
+                        reference_geotable.values,
+                    )
                 end
             end
 
@@ -524,24 +520,21 @@ using Tables
             function test_layer_to_table(
                 layer::AG.AbstractFeatureLayer,
                 reference_geotable::NamedTuple,
-            )::Bool
-                return all([
-                    keys(Tables.columntable(layer)) == reference_geotable.names,
-                    eltype.(values(Tables.columntable(layer))) ==
-                    reference_geotable.types,
-                    tupleoftuples_equal(
-                        columntablevalues_toWKT(
-                            values(Tables.columntable(layer)),
-                        ),
-                        reference_geotable.values,
+            )
+                @test keys(Tables.columntable(layer)) == reference_geotable.names
+                @test eltype.(values(Tables.columntable(layer))) == reference_geotable.types
+                @test tupleoftuples_equal(
+                    columntablevalues_toWKT(
+                        values(Tables.columntable(layer)),
                     ),
-                ])
+                    reference_geotable.values,
+                )
             end
 
             @testset "Conversion to table for ESRI Shapefile driver" begin
                 ESRI_Shapefile_test_reference_geotable = (
                     names = (Symbol(""), :id, :name),
-                    types = (Union{Missing,ArchGDAL.IGeometry}, Int64, String),
+                    types = (Union{Missing,ArchGDAL.IGeometry}, Union{Missing,Int64}, String),
                     values = (
                         Union{Missing,String}[
                             "POLYGON ((0 0,0 1,1 1))",
@@ -549,11 +542,11 @@ using Tables
                             missing,
                             "POLYGON ((0 0,-1 0,-1 1))",
                         ],
-                        [1, 2, 3, 0],
+                        [1, 2, 3, missing],
                         ["polygon1", "multipolygon1", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "ESRI Shapefile",
                     "polygon",
                     true,
@@ -569,7 +562,7 @@ using Tables
                             Missing,
                             ArchGDAL.IGeometry{ArchGDAL.wkbLineString},
                         },
-                        Int64,
+                        Union{Missing,Int64},
                         String,
                     ),
                     values = (
@@ -579,11 +572,11 @@ using Tables
                             missing,
                             "LINESTRING (5 6,6 7,7 8)",
                         ],
-                        [1, 2, 3, 0],
+                        [1, 2, 3, missing],
                         ["line1", "line2", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "ESRI Shapefile",
                     "line",
                     true,
@@ -612,7 +605,7 @@ using Tables
                         ["polygon1", "multipolygon1", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "GeoJSON",
                     "polygon",
                     true,
@@ -642,7 +635,7 @@ using Tables
                         ["line1", "line2", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "GeoJSON",
                     "line",
                     true,
@@ -678,7 +671,7 @@ using Tables
                         ["line1", "multiline1", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "GML",
                     "line",
                     true,
@@ -691,7 +684,7 @@ using Tables
             @testset "Conversion to table for GPKG driver" begin
                 GPKG_test_reference_geotable = (
                     names = (:geom, :id, :name),
-                    types = (Union{Missing,ArchGDAL.IGeometry}, Int64, String),
+                    types = (Union{Missing,ArchGDAL.IGeometry}, Union{Missing,Int64}, String),
                     values = (
                         Union{Missing,String}[
                             "LINESTRING (1 2,2 3,3 4)",
@@ -699,11 +692,11 @@ using Tables
                             missing,
                             "LINESTRING (5 6,6 7,7 8)",
                         ],
-                        [1, 2, 3, 0],
+                        Union{Missing,Int64}[1, 2, 3, missing],
                         ["line1", "multiline1", "emptygeom", "emptyid"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "GPKG",
                     "line",
                     true,
@@ -727,7 +720,7 @@ using Tables
                         ["", "", ""],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "KML",
                     "line",
                     true,
@@ -751,7 +744,7 @@ using Tables
                         ["emptyid", "multiline1", "line1"],
                     ),
                 )
-                @test test_layer_to_table(
+                test_layer_to_table(
                     "FlatGeobuf",
                     "line",
                     true,
@@ -762,7 +755,6 @@ using Tables
             end
 
             @testset "Conversion to table for CSV driver" begin
-                @test begin
                     AG.read(
                         joinpath(@__DIR__, "data/multi_geom.csv"),
                         options = [
@@ -797,11 +789,10 @@ using Tables
                                 ["Mumbai", "New Delhi"],
                             ),
                         )
-                        return test_layer_to_table(
+                        test_layer_to_table(
                             multigeom_test_layer,
                             CSV_multigeom_test_reference_geotable,
                         )
-                    end
                 end
             end
 


### PR DESCRIPTION
Fixes #177 .

I think this aligns the behavior a lot better across the different file formats (see the test sets in test/test_tables.jl)

This behavior is implemented through `getfield(feature, i)` which makes use of `getfieldtype(feature, i)`. That way, we are aligned in behavior for field subtypes even for e.g. displaying the fields.

Because a lot hinges on distinguishing between whether a field is set versus whether it is null (see https://github.com/Toblerity/Fiona/issues/460#issue-240013079), I have also added support for `isfieldnull()`, `isfieldsetandnotnull()`, and `setfieldnull!()`.