### PR TITLE
Handle non-bijective data-type conversions more robustly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
 version = "0.7.4"
 
 [deps]
+CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
@@ -16,6 +17,7 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+CEnum = "0.4"
 ColorTypes = "0.10, 0.11"
 DiskArrays = "0.2.4"
 GDAL = "1.1.3"

--- a/src/ArchGDAL.jl
+++ b/src/ArchGDAL.jl
@@ -7,6 +7,7 @@ using GeoInterface: GeoInterface
 using Tables: Tables
 using ImageCore: Normed, N0f8, N0f16, N0f32, ImageCore
 using ColorTypes: ColorTypes
+using CEnum
 
 const GFT = GeoFormatTypes
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,10 @@
+# An ImmutableDict constructor based on a list of Pair arguments has been introduced in Julia 1.6.0 and backported to Julia 1.5
+if VERSION < v"1.5"
+    function ImmutableDict(KV::Pair, rest::Pair...)
+        return ImmutableDict(ImmutableDict(KV), rest...)
+    end
+end
+
 """
     @convert(<T1>::<T2>, 
         <conversions>

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 # An ImmutableDict constructor based on a list of Pair arguments has been introduced in Julia 1.6.0 and backported to Julia 1.5
 if VERSION < v"1.5"
     function Base.ImmutableDict(KV::Pair, rest::Pair...)
-        return Base.ImmutableDict(ImmutableDict(KV), rest...)
+        return Base.ImmutableDict(Base.ImmutableDict(KV), rest...)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,11 @@
 # An ImmutableDict constructor based on a list of Pair arguments has been introduced in Julia 1.6.0 and backported to Julia 1.5
 if VERSION < v"1.5"
-    function Base.ImmutableDict(KV::Pair, rest::Pair...)
-        return Base.ImmutableDict(Base.ImmutableDict(KV), rest...)
+    function Base.ImmutableDict(KV::Pair{K,V}, KVs::Pair{K,V}...) where {K,V}
+        d = Base.ImmutableDict(KV)
+        for p in KVs
+            d = Base.ImmutableDict(d, p)
+        end
+        return d
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -123,7 +123,6 @@ macro convert(args...)
     # Optimization for conversion from types
     if !(eval(T2) <: CEnum.Cenum)
         for stypes in [Tuple(esc.(reverse(a.args))) for a in args[2:end]]
-            eval(T2) isa UnionAll && @assert eval(stypes[1].args[1]) <: eval(T2)
             push!(
                 result_expr.args,
                 :(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,3 @@
-import CEnum
-
 """
     @convert(<T1>::<T2>, 
         <conversions>

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,16 +1,29 @@
+import CEnum
+
 """
-    @convert(args...)
+    @convert(<T1>::<T2>, 
+        <conversions>
+    )
+
+Generate `convert` functions both ways between ArchGDAL Enum of typeids (e.g. `ArchGDAL.OGRFieldType`) 
+and other types or typeids.
 
 ArchGDAL uses Enum types, listing typeids of various data container used in GDAL/OGR object model. 
-These types are used (or not) to implement concrete types in julia through parametric composite types 
-based on those Enum of typeids.
+Some of these types are used to implement concrete types in julia through parametric composite types 
+based on those Enum of typeids (e.g. `Geometry` and `IGeometry` types with `OGRwkbGeometryType`)
 
-@convert generates convert functions between ArchGDAL Enum of typeids (e.g. `ArchGDAL.OGRFieldType`) 
-with other types or typeids such as:
+Other types or typeids can be:
 - GDAL CEnum.Cenum typeids (e.g. `GDAL.OGRFieldType`), 
 - Base primitive DataType types (e.g. `Bool`), 
 - other parametric composite types (e.g. `ImageCore.Normed`)
-`convert` functions are generated both ways
+
+# Arguments
+- `(<T1>::<T2>)::Expr`: source and target supertypes, where `T1<:Enum`  and `T2<:CEnum.Cenum || T2::Type{DataType} || T2::UnionAll}``
+- `(<stype1>::<stype2>)::Expr`: source and target subtypes or type ids with `stype1::T1` and 
+    - `stype2::T2 where T2<:CEnum.Cenum` or 
+    - `stype2::T2 where T2::Type{DataType}` or 
+    - `stype2<:T2`where T2<:UnionAll
+- ...
 
 **Note:** In the case where the mapping is not bijective, the last declared typeid of subtype is used. 
 Example: 
@@ -25,10 +38,6 @@ Example:
 will generate a `convert` functions giving:
 - `Int32` type for `OFTInteger` and not `Ìnt16`
 - `OFTInteger` OGRFieldType typeid for both `Int16` and `Int32`
-
-# Parameters
-- `<type1>::<type2>`
-- list of `<typeid1>::<typeid2|subtype2>`
 
 # Usage
 ### General case:
@@ -76,46 +85,47 @@ Base.convert(::Type{OGRFieldType}, ft::Type{Int16}) = OFTInteger
 
 """
 macro convert(args...)
-    @assert length(args) > 0
+    @assert length(args) > 1
     @assert args[1].head == :(::)
-    type1_symbol = args[1].args[1]
-    type2_symbol = args[1].args[2]
-    type1_string = replace(string(type1_symbol), "." => "_")
-    type2_string = replace(string(type2_symbol), "." => "_")
-    type1_isenum_and_type2_equaldatatype_or_isaunionall =
-        (eval(type1_symbol) <: Enum) &&
-        ((eval(type2_symbol) == DataType) || (eval(type2_symbol) isa UnionAll))
-    type1 = esc(type1_symbol)
-    type2 = esc(type2_symbol)
-    fwd_map = Expr[Expr(:tuple, esc.(a.args)...) for a in args[2:end]]
-    if type1_isenum_and_type2_equaldatatype_or_isaunionall
-        rev_to_enum_map = [Tuple(esc.(reverse(a.args))) for a in args[2:end]]
-    else
-        rev_map =
-            Expr[Expr(:tuple, esc.(reverse(a.args))...) for a in args[2:end]]
-    end
+    (T1, T2) = args[1].args
 
-    result_expr = Expr(:block)
-    # Forward conversion (no case of 1st type == DataType and 2nd type <: Enum handled)
-    type1_to_type2_map_name =
-        esc(Symbol(type1_string * "_to_" * type2_string * "_map"))
-    push!(
-        result_expr.args,
-        :(const $type1_to_type2_map_name = Dict([$(fwd_map...)])),
+    # Types and type ids / subtypes checks
+    stypes1, stypes2 = zip((eval.(a.args) for a in args[2:end])...)
+    @assert(eval(T1) <: Enum && all(isa.(stypes1, eval(T1))))
+    @assert(
+        ((eval(T2) <: CEnum.Cenum) && all(isa.(stypes2, eval(T2)))) ||
+        ((eval(T2) isa Type{DataType}) && all(isa.(stypes2, eval(T2)))) ||
+        ((eval(T2) isa UnionAll) && all((<:).(stypes2, eval(T2))))
     )
+
+    # Types other representations
+    (T1_string, T2_string) = replace.(string.((T1, T2)), "." => "_")
+    (type1, type2) = esc.((T1, T2))
+
+    # Subtypes forward and backward mapping
+    fwd_map = Expr[Expr(:tuple, esc.(a.args)...) for a in args[2:end]]
+    rev_map = Expr[Expr(:tuple, esc.(reverse(a.args))...) for a in args[2:end]]
+
+    #! Convert functions generation
+    result_expr = Expr(:block)
+
+    #* Forward conversions from ArchGDAL typeids
+    T1_to_T2_map_name = esc(Symbol(T1_string * "_to_" * T2_string * "_map"))
+    push!(result_expr.args, :(const $T1_to_T2_map_name = Dict([$(fwd_map...)])))
     push!(
         result_expr.args,
         :(function Base.convert(::Type{$type2}, ft::$type1)
-            return get($type1_to_type2_map_name, ft) do
+            return get($T1_to_T2_map_name, ft) do
                 return error("Unknown type: $ft")
             end
         end),
     )
-    # Reverse conversion
-    if type1_isenum_and_type2_equaldatatype_or_isaunionall
-        for stypes in rev_to_enum_map
-            eval(type2_symbol) isa UnionAll &&
-                @assert eval(stypes[1].args[1]) <: eval(type2_symbol)
+
+    #* Reverse conversions to ArchGDAL typeids
+    # Optimization for conversion from types
+    if !(eval(T2) <: CEnum.Cenum)
+        for stypes in [Tuple(esc.(reverse(a.args))) for a in args[2:end]]
+            eval(T2) isa UnionAll && @assert eval(stypes[1].args[1]) <: eval(T2)
             push!(
                 result_expr.args,
                 :(
@@ -128,22 +138,23 @@ macro convert(args...)
                 ),
             )
         end
+        # Conversion from typeids
     else
-        type2_to_type1_map_name =
-            esc(Symbol(type2_string * "_to_" * type1_string * "_map"))
+        T2_to_T1_map_name = esc(Symbol(T2_string * "_to_" * T1_string * "_map"))
         push!(
             result_expr.args,
-            :(const $type2_to_type1_map_name = Dict([$(rev_map...)])),
+            :(const $T2_to_T1_map_name = Dict([$(rev_map...)])),
         )
         push!(
             result_expr.args,
             :(function Base.convert(::Type{$type1}, ft::$type2)
-                return get($type2_to_type1_map_name, ft) do
+                return get($T2_to_T1_map_name, ft) do
                     return error("Unknown type: $ft")
                 end
             end),
         )
     end
+
     return result_expr
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 # An ImmutableDict constructor based on a list of Pair arguments has been introduced in Julia 1.6.0 and backported to Julia 1.5
 if VERSION < v"1.5"
-    function ImmutableDict(KV::Pair, rest::Pair...)
-        return ImmutableDict(ImmutableDict(KV), rest...)
+    function Base.ImmutableDict(KV::Pair, rest::Pair...)
+        return Base.ImmutableDict(ImmutableDict(KV), rest...)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,13 +1,3 @@
-
-# Helper constructor for building an ImmutableDict from a list of Pair arguments
-function Base.ImmutableDict(KV::Pair{K,V}, KVs::Pair{K,V}...) where {K,V}
-    d = Base.ImmutableDict(KV)
-    for p in KVs
-        d = Base.ImmutableDict(d, p)
-    end
-    return d
-end
-
 """
     @convert(<T1>::<T2>, 
         <conversions>

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -4,46 +4,46 @@ const AG = ArchGDAL;
 import ImageCore
 
 @testset "test_types.jl" begin
+    @testset "Testing convert macro" begin
+        @testset "Basic conversions" begin
+            @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
+        end
+
+        @testset "Error on conversion non implemented" begin
+            @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
+            @test_throws KeyError Base.convert(
+                DataType,
+                AG.GDT_TypeCount,
+            )
+            @test_throws KeyError Base.convert(
+                ImageCore.Normed,
+                AG.GDT_Float32,
+            )
+            @test_throws KeyError Base.convert(
+                DataType,
+                AG.OFSTMaxSubType,
+            )
+        end
+
+        @testset "Default types for non bijective conversion mapset" begin
+            # Default type for AG.OFTInteger is Int32
+            @test Base.convert(AG.OGRFieldType, Bool) == AG.OFTInteger
+            @test Base.convert(AG.OGRFieldType, Int16) == AG.OFTInteger
+            @test Base.convert(AG.OGRFieldType, Int32) == AG.OFTInteger
+            @test Base.convert(DataType, AG.OFTInteger) == Int32
+
+            # Default type for AG.OFTReal is Float64 
+            @test Base.convert(AG.OGRFieldType, Float32) == AG.OFTReal
+            @test Base.convert(AG.OGRFieldType, Float64) == AG.OFTReal
+            @test Base.convert(DataType, AG.OFTReal) == Float64
+        end
+    end
+
     @testset "Testing GDAL Type Methods" begin
         @testset "GDAL Open Flags" begin
             @test AG.OF_READONLY | 0x04 == 0x04
             @test 0x06 | AG.OF_READONLY == 0x06
             @test AG.OF_READONLY | AG.OF_GNM == AG.OF_READONLY | AG.OF_GNM
-        end
-
-        @testset "Convert macro" begin
-            @testset "Basic conversions" begin
-                @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
-            end
-
-            @testset "Error on conversion non implemented" begin
-                @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
-                @test_throws ErrorException Base.convert(
-                    DataType,
-                    AG.GDT_TypeCount,
-                )
-                @test_throws ErrorException Base.convert(
-                    ImageCore.Normed,
-                    AG.GDT_Float32,
-                )
-                @test_throws ErrorException Base.convert(
-                    DataType,
-                    AG.OFSTMaxSubType,
-                )
-            end
-
-            @testset "Default types for non bijective conversion mapset" begin
-                # Default type for AG.OFTInteger is Int32
-                @test Base.convert(AG.OGRFieldType, Bool) == AG.OFTInteger
-                @test Base.convert(AG.OGRFieldType, Int16) == AG.OFTInteger
-                @test Base.convert(AG.OGRFieldType, Int32) == AG.OFTInteger
-                @test Base.convert(DataType, AG.OFTInteger) == Int32
-
-                # Default type for AG.OFTReal is Float64 
-                @test Base.convert(AG.OGRFieldType, Float32) == AG.OFTReal
-                @test Base.convert(AG.OGRFieldType, Float64) == AG.OFTReal
-                @test Base.convert(DataType, AG.OFTReal) == Float64
-            end
         end
 
         @testset "GDAL Data Types" begin

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -15,10 +15,13 @@ import ImageCore
             @testset "Basic conversions" begin
                 @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
             end
-            
+
             @testset "Error on conversion non implemented" begin
                 @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
-                @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)
+                @test_throws ErrorException Base.convert(
+                    DataType,
+                    AG.GDT_TypeCount,
+                )
                 @test_throws ErrorException Base.convert(
                     ImageCore.Normed,
                     AG.GDT_Float32,

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -11,6 +11,38 @@ import ImageCore
             @test AG.OF_READONLY | AG.OF_GNM == AG.OF_READONLY | AG.OF_GNM
         end
 
+        @testset "Convert macro" begin
+            @testset "Basic conversions" begin
+                @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
+            end
+            
+            @testset "Error on conversion non implemented" begin
+                @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
+                @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)
+                @test_throws ErrorException Base.convert(
+                    ImageCore.Normed,
+                    AG.GDT_Float32,
+                )
+                @test_throws ErrorException Base.convert(
+                    DataType,
+                    AG.OFSTMaxSubType,
+                )
+            end
+
+            @testset "Default types for non bijective conversion mapset" begin
+                # Default type for AG.OFTInteger is Int32
+                @test Base.convert(AG.OGRFieldType, Bool) == AG.OFTInteger
+                @test Base.convert(AG.OGRFieldType, Int16) == AG.OFTInteger
+                @test Base.convert(AG.OGRFieldType, Int32) == AG.OFTInteger
+                @test Base.convert(DataType, AG.OFTInteger) == Int32
+
+                # Default type for AG.OFTReal is Float64 
+                @test Base.convert(AG.OGRFieldType, Float32) == AG.OFTReal
+                @test Base.convert(AG.OGRFieldType, Float64) == AG.OFTReal
+                @test Base.convert(DataType, AG.OFTReal) == Float64
+            end
+        end
+
         @testset "GDAL Data Types" begin
             @test AG.typesize(AG.GDT_UInt16) == 16
             @test AG.typename(AG.GDT_UInt16) == "UInt16"
@@ -21,18 +53,6 @@ import ImageCore
 
             @test AG.iscomplex(AG.GDT_CFloat32) == true
             @test AG.iscomplex(AG.GDT_CFloat64) == true
-
-            @test Base.convert(AG.GDALDataType, UInt8) == AG.GDT_Byte
-            @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
-            @test_throws ErrorException Base.convert(DataType, AG.GDT_TypeCount)
-            @test_throws ErrorException Base.convert(
-                ImageCore.Normed,
-                AG.GDT_Float32,
-            )
-            @test_throws ErrorException Base.convert(
-                DataType,
-                AG.OFSTMaxSubType,
-            )
         end
 
         @testset "GDAL Colors and Palettes" begin

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -11,18 +11,9 @@ import ImageCore
 
         @testset "Error on conversion non implemented" begin
             @test_throws MethodError Base.convert(AG.GDALDataType, Int64)
-            @test_throws KeyError Base.convert(
-                DataType,
-                AG.GDT_TypeCount,
-            )
-            @test_throws KeyError Base.convert(
-                ImageCore.Normed,
-                AG.GDT_Float32,
-            )
-            @test_throws KeyError Base.convert(
-                DataType,
-                AG.OFSTMaxSubType,
-            )
+            @test_throws KeyError Base.convert(DataType, AG.GDT_TypeCount)
+            @test_throws KeyError Base.convert(ImageCore.Normed, AG.GDT_Float32)
+            @test_throws KeyError Base.convert(DataType, AG.OFSTMaxSubType)
         end
 
         @testset "Default types for non bijective conversion mapset" begin


### PR DESCRIPTION
Fixes #232
Assert "default type comes last" for mappings that are not bijective
- [x] Include it in the docstring for the convert macro
- [x] Add unit tests for them.
- [x] Rewrite the implementation to enforce it by construction

I have enriched the `@convert` macro's docstring with some explanations and added a note on "default type comes last"

---
Before going further, @yeesian could you elaborate on:
>  asserting "default type comes last" for mappings that are not bijective.

Should we enforce it with something like:
1) enhance the readability of the macro call
```julia
@convert(
    OGRFieldType::DataType,
    OFTInteger::(Bool, Int16, Int32, ) # default type comes last
    OFTInteger64::Int64,
)
```
and assert that all type ids of type 1 and all type ids / subtypes of type 2 are unique?

2) Or is it enough to assert that all type id <-> type id / subtype mappings are unique in `args`? 
3) Or something else?