### PR TITLE
Setup of a first PkgBenchmark.jl benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test/spatialite/
 .DS_Store
 Manifest.toml
 *.tif
+benchmark/tune.json
+benchmark/data

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,44 @@
+using BenchmarkTools
+using ZipFile
+using ArchGDAL;
+const AG = ArchGDAL;
+using Tables
+using Shapefile
+
+const SUITE = BenchmarkGroup()
+
+SUITE["shapefile_to_table"] = BenchmarkGroup() 
+
+# Data preparation
+road_shapefile_ziparchive = joinpath(@__DIR__, "data/road.zip")
+!isfile(road_shapefile_ziparchive) && download(
+    "https://www.data.gouv.fr/fr/datasets/r/ea2b85d7-b29e-4bb4-baa5-ac3bb618c67e",
+    road_shapefile_ziparchive,
+)
+road_shapefile_dir = splitext(road_shapefile_ziparchive)[1]
+!isdir(road_shapefile_dir) && mkdir(road_shapefile_dir)
+ziparchive = ZipFile.Reader(road_shapefile_ziparchive)
+for file in ziparchive.files
+    extracted_file = joinpath(road_shapefile_dir, file.name)
+    !isfile(extracted_file) && write(extracted_file, read(file))
+end
+close(ziparchive)
+road_shapefile_file = joinpath(road_shapefile_dir, splitpath(road_shapefile_dir)[end] * ".shp")
+
+# Benchmarks
+SUITE["shapefile_to_table"]["frenchroads_with_GDAL.jl_via_vsizip"] = @benchmarkable Tables.columns(
+    AG.getlayer(
+        AG.read("/vsizip/" * relpath($road_shapefile_ziparchive)), # relpath is a workaround in case there are spaces in local fullpath (incompatible with /vsizip usage) when benchmarkpkg is run locally
+        0,
+    ),
+)
+SUITE["shapefile_to_table"]["frenchroads_with_GDAL.jl"] = @benchmarkable Tables.columns(
+    AG.getlayer(
+        AG.read($road_shapefile_file),
+        0,
+    ),
+)
+SUITE["shapefile_to_table"]["frenchroads_with_Shapefile.jl"] = @benchmarkable begin
+    Tables.columns(Shapefile.Table($road_shapefile_file))
+end
+


### PR DESCRIPTION
Fixes https://github.com/yeesian/ArchGDAL.jl/issues/193#issue-892504558

Here is a first step with a PkgBenchmark.jl benchmark suite benchmarking shapefile reading and converting to table with GDAL.jl (w or w/o vsizip) and Shapefile.jl

```julia
julia> using PkgBenchmark

julia> using ArchGDAL

julia> benchmarkpkg(ArchGDAL)
PkgBenchmark: Running benchmarks...
PkgBenchmark: using benchmark tuning data in /Users/Mathieu/.../dev/ArchGDAL/benchmark/tune.json

(1/1) benchmarking "shapefile_to_table"...
  (1/3) benchmarking "frenchroads_with_GDAL.jl_via_vsizip"...
  done (took 5.725868093 seconds)
  (2/3) benchmarking "frenchroads_with_GDAL.jl"...
  done (took 5.672228116 seconds)
  (3/3) benchmarking "frenchroads_with_Shapefile.jl"...
  done (took 5.685400644 seconds)
done (took 17.703220046 seconds)
Benchmarking 100%|█████████████████████████████████████████████████████| Time: 0:00:19
Benchmarkresults:
    Package: /Users/Mathieu/OneDrive - Altice Campus SFR/code_julia/radio_sites_near_motorways/dev/ArchGDAL
    Date: 5 Oct 2021 - 10:47
    Package commit: 1e5fe5
    Julia commit: ae8452
    BenchmarkGroup:
        1-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "shapefile_to_table" => 3-element BenchmarkTools.BenchmarkGroup:
                  tags: []
                  "frenchroads_with_GDAL.jl_via_vsizip" => Trial(304.691 ms)
                  "frenchroads_with_GDAL.jl" => Trial(194.496 ms)
                  "frenchroads_with_Shapefile.jl" => Trial(66.557 ms)
```

Next step: integrate it with Github actions with BenchmarkCI.jl