### PR TITLE
Modified benchmark.yml to benchmark last commit against master, instead of against itself as has to be done in jumpstart PR #248

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   Benchmark:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
In commit #248, I had to restrict benchmark of  the last commit to itself since the benchmark configuration as not present in master before merge.

Now every new commit should be benchmarked to master