### PR TITLE
Added a new method to `AG.getlayer` without index or name arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Manifest.toml
 benchmark/data/
 .benchmarkci
 benchmark/*.json
+lcov.info

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -510,23 +510,35 @@ filelist(dataset::AbstractDataset)::Vector{String} =
 
 Fetch the layer at index `i` (between `0` and `nlayer(dataset)-1`)
 
-The returned layer remains owned by the `Dataset` and should not be deleted by
+The returned layer remains owned by the `dataset` and should not be deleted by
 the application.
 """
 getlayer(dataset::AbstractDataset, i::Integer)::IFeatureLayer =
     IFeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i), ownedby = dataset)
+
+    """
+    getlayer(dataset::AbstractDataset)
+
+Fetch the first layer and raise a waning if `dataset` contains more than one layer
+
+The returned layer remains owned by the `dataset` and should not be deleted by
+the application.
+"""
+function getlayer(dataset::AbstractDataset)::IFeatureLayer
+    layer = IFeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0), ownedby = dataset)
+    nlayer(dataset) == 1 || @warn "Dataset has multiple layers, getting the first layer"
+    return layer
+end
 
 unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
     FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i))
 
 """
     getlayer(dataset::AbstractDataset, name::AbstractString)
-    getlayer(table::Table)
 
-Fetch the feature layer corresponding to the given name. If it is called on a
-Table, which supports only one layer, a name is not needed.
+Fetch the feature layer corresponding to the given name
 
-The returned layer remains owned by the `Dataset` and should not be deleted by
+The returned layer remains owned by the `dataset` and should not be deleted by
 the application.
 """
 function getlayer(dataset::AbstractDataset, name::AbstractString)::IFeatureLayer

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -530,7 +530,7 @@ function getlayer(dataset::AbstractDataset)::IFeatureLayer
         ownedby = dataset,
     )
     nlayer(dataset) == 1 ||
-        @warn "Dataset has multiple layers, getting the first layer"
+        @warn "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning"
     return layer
 end
 
@@ -539,7 +539,7 @@ unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
 function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
     layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
     nlayer(dataset) == 1 ||
-        @warn "Dataset has multiple layers, getting the first layer"
+        @warn "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning"
     return layer
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -530,7 +530,7 @@ function getlayer(dataset::AbstractDataset)::IFeatureLayer
         ownedby = dataset,
     )
     nlayer(dataset) == 1 ||
-        error("Dataset has multiple layers.\nSpecify the layer number or name")
+        error("Dataset has multiple layers. Specify the layer number or name")
     return layer
 end
 
@@ -539,7 +539,7 @@ unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
 function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
     layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
     nlayer(dataset) == 1 ||
-        error("Dataset has multiple layers.\nSpecify the layer number or name")
+        error("Dataset has multiple layers. Specify the layer number or name")
     return layer
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -525,22 +525,21 @@ The returned layer remains owned by the `dataset` and should not be deleted by
 the application.
 """
 function getlayer(dataset::AbstractDataset)::IFeatureLayer
-    layer = IFeatureLayer(
+    nlayer(dataset) == 1 ||
+        error("Dataset has multiple layers. Specify the layer number or name")
+    return IFeatureLayer(
         GDAL.gdaldatasetgetlayer(dataset.ptr, 0),
         ownedby = dataset,
     )
-    nlayer(dataset) == 1 ||
-        error("Dataset has multiple layers. Specify the layer number or name")
-    return layer
+    
 end
 
 unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
     FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i))
 function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
-    layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
     nlayer(dataset) == 1 ||
         error("Dataset has multiple layers. Specify the layer number or name")
-    return layer
+    return FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
 end
 
 """

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -519,7 +519,7 @@ getlayer(dataset::AbstractDataset, i::Integer)::IFeatureLayer =
 """
     getlayer(dataset::AbstractDataset)
 
-Fetch the first layer and raise a waning if `dataset` contains more than one layer
+Fetch the first layer and raise an error if `dataset` contains more than one layer
 
 The returned layer remains owned by the `dataset` and should not be deleted by
 the application.

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -532,6 +532,11 @@ end
 
 unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
     FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i))
+function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
+    layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
+    nlayer(dataset) == 1 || @warn "Dataset has multiple layers, getting the first layer"
+    return layer
+end
 
 """
     getlayer(dataset::AbstractDataset, name::AbstractString)

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -530,7 +530,7 @@ function getlayer(dataset::AbstractDataset)::IFeatureLayer
         ownedby = dataset,
     )
     nlayer(dataset) == 1 ||
-        @warn "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning"
+        error("Dataset has multiple layers.\nSpecify the layer number or name")
     return layer
 end
 
@@ -539,7 +539,7 @@ unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
 function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
     layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
     nlayer(dataset) == 1 ||
-        @warn "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning"
+        error("Dataset has multiple layers.\nSpecify the layer number or name")
     return layer
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -516,7 +516,7 @@ the application.
 getlayer(dataset::AbstractDataset, i::Integer)::IFeatureLayer =
     IFeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i), ownedby = dataset)
 
-    """
+"""
     getlayer(dataset::AbstractDataset)
 
 Fetch the first layer and raise a waning if `dataset` contains more than one layer
@@ -525,8 +525,12 @@ The returned layer remains owned by the `dataset` and should not be deleted by
 the application.
 """
 function getlayer(dataset::AbstractDataset)::IFeatureLayer
-    layer = IFeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0), ownedby = dataset)
-    nlayer(dataset) == 1 || @warn "Dataset has multiple layers, getting the first layer"
+    layer = IFeatureLayer(
+        GDAL.gdaldatasetgetlayer(dataset.ptr, 0),
+        ownedby = dataset,
+    )
+    nlayer(dataset) == 1 ||
+        @warn "Dataset has multiple layers, getting the first layer"
     return layer
 end
 
@@ -534,7 +538,8 @@ unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =
     FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i))
 function unsafe_getlayer(dataset::AbstractDataset)::FeatureLayer
     layer = FeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, 0))
-    nlayer(dataset) == 1 || @warn "Dataset has multiple layers, getting the first layer"
+    nlayer(dataset) == 1 ||
+        @warn "Dataset has multiple layers, getting the first layer"
     return layer
 end
 

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -47,14 +47,14 @@ const AG = ArchGDAL;
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_throws ErrorException("Dataset has multiple layers.\nSpecify the layer number or name") AG.getlayer(new_ds)
+            @test_throws ErrorException("Dataset has multiple layers. Specify the layer number or name") AG.getlayer(new_ds)
         end
 
         AG.read("data/point.geojson") do ds
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_throws ErrorException("Dataset has multiple layers.\nSpecify the layer number or name") AG.getlayer(new_ds) do layer
+            @test_throws ErrorException("Dataset has multiple layers. Specify the layer number or name") AG.getlayer(new_ds) do layer
                 return nothing
             end
         end

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -43,6 +43,13 @@ const AG = ArchGDAL;
     end
 
     @testset "Test methods for vector dataset" begin
+        AG.read("data/point.geojson") do ds
+            layer = AG.getlayer(ds)
+            new_ds = AG.copy(layer; name="duplicated layer 1").ownedby
+            AG.copy(layer; dataset = new_ds, name="duplicated layer 2")
+            @test_logs (:warn, "Dataset has multiple layers, getting the first layer") AG.getlayer(new_ds)
+        end
+
         dataset1 = AG.read("data/point.geojson")
         @test AG.nlayer(dataset1) == 1
         layer1 = AG.getlayer(dataset1, 0)

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -63,11 +63,16 @@ const AG = ArchGDAL;
             end
         end
 
+        # AG.read("data/point.geojson") do ds
+        #     layer = AG.getlayer(ds)
+        #     @test 
+        # end
+
         dataset1 = AG.read("data/point.geojson")
         @test AG.nlayer(dataset1) == 1
         layer1 = AG.getlayer(dataset1, 0)
         @test AG.nfeature(layer1) == 4
-        AG.getlayer(dataset1) do layer1
+        AG.getlayer(dataset1, 0) do layer1
             @test AG.nfeature(layer1) == 4
         end
         @test AG.getgeotransform(dataset1) ≈ [0, 1, 0, 0, 0, 1]

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -45,17 +45,23 @@ const AG = ArchGDAL;
     @testset "Test methods for vector dataset" begin
         AG.read("data/point.geojson") do ds
             layer = AG.getlayer(ds)
-            new_ds = AG.copy(layer; name="duplicated layer 1").ownedby
-            AG.copy(layer; dataset = new_ds, name="duplicated layer 2")
-            @test_logs (:warn, "Dataset has multiple layers, getting the first layer") AG.getlayer(new_ds)
+            new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
+            AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
+            @test_logs (
+                :warn,
+                "Dataset has multiple layers, getting the first layer",
+            ) AG.getlayer(new_ds)
         end
 
         AG.read("data/point.geojson") do ds
             layer = AG.getlayer(ds)
-            new_ds = AG.copy(layer; name="duplicated layer 1").ownedby
-            AG.copy(layer; dataset = new_ds, name="duplicated layer 2")
-            @test_logs (:warn, "Dataset has multiple layers, getting the first layer") AG.getlayer(new_ds) do layer
-                nothing
+            new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
+            AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
+            @test_logs (
+                :warn,
+                "Dataset has multiple layers, getting the first layer",
+            ) AG.getlayer(new_ds) do layer
+                return nothing
             end
         end
 

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -53,20 +53,16 @@ const AG = ArchGDAL;
         end
 
         AG.read("data/point.geojson") do ds
-            layer = AG.getlayer(ds)
-            new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
-            AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_throws ErrorException(
-                "Dataset has multiple layers. Specify the layer number or name",
-            ) AG.getlayer(new_ds) do layer
-                return nothing
+            AG.getlayer(ds) do layer
+                new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
+                AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
+                @test_throws ErrorException(
+                    "Dataset has multiple layers. Specify the layer number or name",
+                ) AG.getlayer(new_ds) do layer
+                    return nothing
+                end
             end
         end
-
-        # AG.read("data/point.geojson") do ds
-        #     layer = AG.getlayer(ds)
-        #     @test 
-        # end
 
         dataset1 = AG.read("data/point.geojson")
         @test AG.nlayer(dataset1) == 1

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -47,20 +47,14 @@ const AG = ArchGDAL;
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_logs (
-                :warn,
-                "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning",
-            ) AG.getlayer(new_ds)
+            @test_throws ErrorException("Dataset has multiple layers.\nSpecify the layer number or name") AG.getlayer(new_ds)
         end
 
         AG.read("data/point.geojson") do ds
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_logs (
-                :warn,
-                "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning",
-            ) AG.getlayer(new_ds) do layer
+            @test_throws ErrorException("Dataset has multiple layers.\nSpecify the layer number or name") AG.getlayer(new_ds) do layer
                 return nothing
             end
         end
@@ -69,7 +63,7 @@ const AG = ArchGDAL;
         @test AG.nlayer(dataset1) == 1
         layer1 = AG.getlayer(dataset1, 0)
         @test AG.nfeature(layer1) == 4
-        AG.getlayer(dataset1, 0) do layer1
+        AG.getlayer(dataset1) do layer1
             @test AG.nfeature(layer1) == 4
         end
         @test AG.getgeotransform(dataset1) ≈ [0, 1, 0, 0, 0, 1]

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -49,7 +49,7 @@ const AG = ArchGDAL;
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
             @test_logs (
                 :warn,
-                "Dataset has multiple layers, getting the first layer",
+                "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning",
             ) AG.getlayer(new_ds)
         end
 
@@ -59,7 +59,7 @@ const AG = ArchGDAL;
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
             @test_logs (
                 :warn,
-                "Dataset has multiple layers, getting the first layer",
+                "Dataset has multiple layers, getting the first layer\nSpecify the layer number or name to avoid the warning",
             ) AG.getlayer(new_ds) do layer
                 return nothing
             end

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -50,6 +50,15 @@ const AG = ArchGDAL;
             @test_logs (:warn, "Dataset has multiple layers, getting the first layer") AG.getlayer(new_ds)
         end
 
+        AG.read("data/point.geojson") do ds
+            layer = AG.getlayer(ds)
+            new_ds = AG.copy(layer; name="duplicated layer 1").ownedby
+            AG.copy(layer; dataset = new_ds, name="duplicated layer 2")
+            @test_logs (:warn, "Dataset has multiple layers, getting the first layer") AG.getlayer(new_ds) do layer
+                nothing
+            end
+        end
+
         dataset1 = AG.read("data/point.geojson")
         @test AG.nlayer(dataset1) == 1
         layer1 = AG.getlayer(dataset1, 0)

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -47,14 +47,18 @@ const AG = ArchGDAL;
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_throws ErrorException("Dataset has multiple layers. Specify the layer number or name") AG.getlayer(new_ds)
+            @test_throws ErrorException(
+                "Dataset has multiple layers. Specify the layer number or name",
+            ) AG.getlayer(new_ds)
         end
 
         AG.read("data/point.geojson") do ds
             layer = AG.getlayer(ds)
             new_ds = AG.copy(layer; name = "duplicated layer 1").ownedby
             AG.copy(layer; dataset = new_ds, name = "duplicated layer 2")
-            @test_throws ErrorException("Dataset has multiple layers. Specify the layer number or name") AG.getlayer(new_ds) do layer
+            @test_throws ErrorException(
+                "Dataset has multiple layers. Specify the layer number or name",
+            ) AG.getlayer(new_ds) do layer
                 return nothing
             end
         end


### PR DESCRIPTION
Fixes #256

Added:
- a new method to `AG.getlayer` without index or name arg
  it raises a warning when called on a dataset with more than one layer 
- a test on the above warning

Cleaned some remaining mentions of Table in `getlayer` methods

```julia
julia> AG.read("test/data/point.geojson") do ds
           layer = AG.getlayer(ds)
           println(layer)
           new_ds = AG.copy(layer; name="duplicated layer 1").ownedby
           AG.copy(layer; dataset = new_ds, name="duplicated layer 2")
           println("Number of layers: $(AG.nlayer(new_ds))")
           println(AG.getlayer(new_ds))
       end
Layer: point
  Geometry 0 (): [wkbPoint], POINT (100 0), POINT (100.2785 0.0893), ...
     Field 0 (FID): [OFTReal], 2.0, 3.0, 0.0, 3.0
     Field 1 (pointname): [OFTString], point-a, point-b, a, b

Number of layers: 2
┌ Warning: Dataset has multiple layers, getting the first layer
└ @ ArchGDAL ~/.../dev/ArchGDAL/src/dataset.jl:529
Layer: duplicated layer 1
  Geometry 0 (): [wkbPoint], POINT (100 0), POINT (100.2785 0.0893), ...
     Field 0 (FID): [OFTReal], 2.0, 3.0, 0.0, 3.0
     Field 1 (pointname): [OFTString], point-a, point-b, a, b

```