### PR TITLE
Fixes a dead link in docs/src/projections.md + an additional example on reprojecting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,4 +61,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
         run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Manifest.toml
 benchmark/data/
 .benchmarkci
 benchmark/*.json
+lcov.info

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,7 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GDAL = "add2ef01-049f-52c4-9ee2-e494f65e021a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Documenter = "0.26.2"

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -63,11 +63,12 @@ end
 ```
 
 ## Reprojecting from a layer
-```@example projections
+```@setup projections
 # Getting vector data
 ds = AG.read("/vsicurl/https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/metropole.geojson")
 layer = AG.getlayer(ds, 0)
-
+```
+```@example projections
 # Plotting with native GEOJSON geographic CRS
 p_WGS_84 = AG.getfeature(layer, 0) do feature
     AG.getgeom(feature, 0) do geom

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -2,7 +2,7 @@
 
 ```@setup projections
 using ArchGDAL; const AG = ArchGDAL
-using Plots; gr()
+using Plots
 ```
 
 (This is based entirely on the [GDAL/OSR Tutorial](https://gdal.org/tutorials/osr_api_tut.html) and [Python GDAL/OGR Cookbook](https://pcjericks.github.io/py-gdalogr-cookbook/projection.html).)

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -62,13 +62,12 @@ ArchGDAL.createcoordtrans(source, target) do transform
 end
 ```
 
-## Reprojecting a layer
-```@setup projections
+## Reprojecting from a layer
+```@example projections
 # Getting vector data
 ds = AG.read("/vsicurl/https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/metropole.geojson")
 layer = AG.getlayer(ds, 0)
-```
-```@example projections
+
 # Plotting with native GEOJSON geographic CRS
 p_WGS_84 = AG.getfeature(layer, 0) do feature
     AG.getgeom(feature, 0) do geom

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -65,7 +65,7 @@ end
 ## Reprojecting from a layer
 ```@setup projections
 # Getting vector data
-ds = AG.read("/vsicurl/https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/metropole.geojson")
+ds = AG.read("/vsicurl/https://raw.githubusercontent.com/yeesian/ArchGDALDatasets/master/data/metropole.geojson")
 layer = AG.getlayer(ds, 0)
 ```
 ```@example projections

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -2,7 +2,7 @@
 
 ```@setup projections
 using ArchGDAL; const AG = ArchGDAL
-using Plots
+using Plots; gr()
 ```
 
 (This is based entirely on the [GDAL/OSR Tutorial](https://gdal.org/tutorials/osr_api_tut.html) and [Python GDAL/OGR Cookbook](https://pcjericks.github.io/py-gdalogr-cookbook/projection.html).)

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -1,10 +1,11 @@
 # Spatial Projections
 
 ```@setup projections
-using ArchGDAL
+using ArchGDAL; const AG = ArchGDAL
+using Plots
 ```
 
-(This is based entirely on the [GDAL/OSR Tutorial](http://www.gdal.org/osr_tutorial.html) and [Python GDAL/OGR Cookbook](https://pcjericks.github.io/py-gdalogr-cookbook/projection.html).)
+(This is based entirely on the [GDAL/OSR Tutorial](https://gdal.org/tutorials/osr_api_tut.html) and [Python GDAL/OGR Cookbook](https://pcjericks.github.io/py-gdalogr-cookbook/projection.html).)
 
 The `ArchGDAL.SpatialRef`, and `ArchGDAL.CoordTransform` types are lightweight wrappers around GDAL objects that represent coordinate systems (projections and datums) and provide services to transform between them. These services are loosely modeled on the OpenGIS Coordinate Transformations specification, and use the same Well Known Text format for describing coordinate systems.
 
@@ -59,6 +60,34 @@ ArchGDAL.createcoordtrans(source, target) do transform
     ArchGDAL.transform!(point, transform)
     println("After: $(ArchGDAL.toWKT(point))")
 end
+```
+
+## Reprojecting a layer
+```@setup projections
+# Getting vector data
+ds = AG.read("/vsicurl/https://raw.githubusercontent.com/gregoiredavid/france-geojson/master/metropole.geojson")
+layer = AG.getlayer(ds, 0)
+```
+```@example projections
+# Plotting with native GEOJSON geographic CRS
+p_WGS_84 = AG.getfeature(layer, 0) do feature
+    AG.getgeom(feature, 0) do geom
+        plot(geom; fa=0.1, title="WGS 84")
+    end
+end
+
+# Plotting with local projected CRS
+p_Lambert_93 = AG.getfeature(layer, 0) do feature
+    AG.getgeom(feature, 0) do geom
+        source = AG.getspatialref(geom)
+        target = AG.importEPSG(2154)
+        AG.createcoordtrans(source, target) do transform
+            plot(AG.transform!(geom, transform); fa=0.1, title="Lambert 93")
+        end
+    end
+end
+
+plot(p_WGS_84, p_Lambert_93; size=(600, 200), layout=(1,2))
 ```
 
 ## References


### PR DESCRIPTION
- Fixed a dead link to GDAL tutorial on CRS and transformations in docs/src/projections.md
- Added a subset of Python GDAL/OGR Cookbook, to illustrate reprojecting on features obtained from a read dataset/layer

@visr and @yeesian: is there a way to embed a preview on documentation modifications in Github comments ?