### PR TITLE
add detailed error messages to @ogrerr

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -184,7 +184,30 @@ end
 macro ogrerr(code, message)
     return quote
         if $(esc(code)) != GDAL.OGRERR_NONE
-            error($message)
+            # find the detailed error message
+            if $(esc(code)) == GDAL.OGRERR_NOT_ENOUGH_DATA
+                detailmsg = "Not enough data."
+            elseif $(esc(code)) == GDAL.OGRERR_NOT_ENOUGH_MEMORY
+                detailmsg = "Not enough memory."
+            elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_GEOMETRY_TYPE
+                detailmsg = "Unsupported geometry type."
+            elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_OPERATION
+                detailmsg = "Unsupported operation."
+            elseif $(esc(code)) == GDAL.OGRERR_CORRUPT_DATA
+                detailmsg = "Corrupt data."
+            elseif $(esc(code)) == GDAL.OGRERR_FAILURE
+                detailmsg = "Failure."
+            elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_SRS
+                detailmsg = "Unsupported spatial reference system."
+            elseif $(esc(code)) == GDAL.OGRERR_INVALID_HANDLE
+                detailmsg = "Invalid handle."
+            elseif $(esc(code)) == GDAL.OGRERR_NON_EXISTING_FEATURE
+                detailmsg = "Non-existing feature."
+            else
+                detailmsg = "Unknown error."
+            end
+
+            error($message * " ($detailmsg)")
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -185,26 +185,26 @@ macro ogrerr(code, message)
     return quote
         if $(esc(code)) != GDAL.OGRERR_NONE
             # find the detailed error message
-            if $(esc(code)) == GDAL.OGRERR_NOT_ENOUGH_DATA
-                detailmsg = "Not enough data."
+            detailmsg = if $(esc(code)) == GDAL.OGRERR_NOT_ENOUGH_DATA
+                "Not enough data."
             elseif $(esc(code)) == GDAL.OGRERR_NOT_ENOUGH_MEMORY
-                detailmsg = "Not enough memory."
+                "Not enough memory."
             elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_GEOMETRY_TYPE
-                detailmsg = "Unsupported geometry type."
+                "Unsupported geometry type."
             elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_OPERATION
-                detailmsg = "Unsupported operation."
+                "Unsupported operation."
             elseif $(esc(code)) == GDAL.OGRERR_CORRUPT_DATA
-                detailmsg = "Corrupt data."
+                "Corrupt data."
             elseif $(esc(code)) == GDAL.OGRERR_FAILURE
-                detailmsg = "Failure."
+                "Failure."
             elseif $(esc(code)) == GDAL.OGRERR_UNSUPPORTED_SRS
-                detailmsg = "Unsupported spatial reference system."
+                "Unsupported spatial reference system."
             elseif $(esc(code)) == GDAL.OGRERR_INVALID_HANDLE
-                detailmsg = "Invalid handle."
+                "Invalid handle."
             elseif $(esc(code)) == GDAL.OGRERR_NON_EXISTING_FEATURE
-                detailmsg = "Non-existing feature."
+                "Non-existing feature."
             else
-                detailmsg = "Unknown error."
+                "Unknown error."
             end
 
             error($message * " ($detailmsg)")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,10 @@
 using Test
+import GDAL
 import ArchGDAL;
 const AG = ArchGDAL;
+
+"Test both that an ErrorException is thrown and that the message is as expected"
+eval_ogrerr(err, expected_message) = @test (@test_throws ErrorException AG.@ogrerr err "e:").value.msg == "e: ($expected_message)"
 
 @testset "test_utils.jl" begin
     @testset "metadataitem" begin
@@ -8,5 +12,21 @@ const AG = ArchGDAL;
         @test AG.metadataitem(driver, "DMD_EXTENSIONS") == ""
         driver = AG.getdriver("GTiff")
         @test AG.metadataitem(driver, "DMD_EXTENSIONS") == "tif tiff"
+    end
+
+    @testset "OGR Errors" begin
+        @test isnothing(AG.@ogrerr GDAL.OGRERR_NONE "not an error")
+        eval_ogrerr(GDAL.OGRERR_NOT_ENOUGH_DATA, "Not enough data.")
+        eval_ogrerr(GDAL.OGRERR_NOT_ENOUGH_MEMORY, "Not enough memory.")
+        eval_ogrerr(GDAL.OGRERR_UNSUPPORTED_GEOMETRY_TYPE, "Unsupported geometry type.")
+        eval_ogrerr(GDAL.OGRERR_UNSUPPORTED_OPERATION, "Unsupported operation.")
+        eval_ogrerr(GDAL.OGRERR_CORRUPT_DATA, "Corrupt data.")
+        eval_ogrerr(GDAL.OGRERR_FAILURE, "Failure.")
+        eval_ogrerr(GDAL.OGRERR_UNSUPPORTED_SRS, "Unsupported spatial reference system.")
+        eval_ogrerr(GDAL.OGRERR_INVALID_HANDLE, "Invalid handle.")
+        eval_ogrerr(GDAL.OGRERR_NON_EXISTING_FEATURE, "Non-existing feature.")
+        # OGRERR_NON_EXISTING_FEATURE is the highest error code currently in GDAL. If another one is
+        # added this test will fail.
+        eval_ogrerr(GDAL.OGRERR_NON_EXISTING_FEATURE + 1, "Unknown error.")
     end
 end


### PR DESCRIPTION
The @ogrerr macro just printed whatever was passed to it in the source, which was often unhelpful (for instance, in `setfeature!`, "Failed to set feature." This change prints a human-readable message based on the OGR error code, in addition to the message passed to ogrerr.