### PR TITLE
Enhance ArchGDAL OGR objects with parametric composite types

### DIFF
--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -107,7 +107,7 @@ function Base.show(
 end
 
 # assumes that the layer is reset, and will reset it after display
-function Base.show(io::IO, layer::AbstractFeatureLayer)::Nothing
+function Base.show(io::IO, layer::DUAL_AbstractFeatureLayer)::Nothing
     if layer.ptr == C_NULL
         print(io, "NULL FeatureLayer")
         return nothing
@@ -213,7 +213,7 @@ function Base.show(io::IO, gfd::AbstractGeomFieldDefn)::Nothing
     return nothing
 end
 
-function Base.show(io::IO, feature::Feature)::Nothing
+function Base.show(io::IO, feature::DUAL_AbstractFeature)::Nothing
     if feature.ptr == C_NULL
         print(io, "NULL Feature")
         return nothing

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,4 +1,19 @@
 const StringList = Ptr{Cstring}
+"""
+    @exported_enum EnumName[::BaseType] value1[=x] value2[=y]
+
+Call `@enum` on arguments, export `EnumName`` and all its instances
+"""
+#TODO: debug macro
+macro exported_enum(T, syms...)
+    return esc(quote
+        @enum($T, $(syms...))
+        export $T
+        for inst in Symbol.(instances($T))
+            eval($(Expr(:quote, :(export $(Expr(:$, :inst))))))
+        end
+    end)
+end
 
 """
 The value of `GDALDataType` could be different from `GDAL.GDALDataType`.

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -515,6 +515,12 @@ the application.
 """
 getlayer(dataset::AbstractDataset, i::Integer)::IFeatureLayer =
     IFeatureLayer(GDAL.gdaldatasetgetlayer(dataset.ptr, i), ownedby = dataset)
+function getFDPlayer(dataset::AbstractDataset, i::Integer)::FDP_IFeatureLayer
+    ptr::GDAL.OGRLayerH = GDAL.gdaldatasetgetlayer(dataset.ptr, i)
+    fd_ptr = GDAL.ogr_l_getlayerdefn(ptr)
+    FD = getFDType(fd_ptr)
+    return FDP_IFeatureLayer{FD}(ptr, ownedby = dataset)
+end
 
 """
     getlayer(dataset::AbstractDataset)
@@ -531,7 +537,6 @@ function getlayer(dataset::AbstractDataset)::IFeatureLayer
         GDAL.gdaldatasetgetlayer(dataset.ptr, 0),
         ownedby = dataset,
     )
-    
 end
 
 unsafe_getlayer(dataset::AbstractDataset, i::Integer)::FeatureLayer =

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,21 +1,32 @@
-function Tables.schema(layer::AbstractFeatureLayer)::Nothing
+function Tables.schema(::DUAL_AbstractFeatureLayer)::Nothing
     return nothing
 end
 
-Tables.istable(::Type{<:AbstractFeatureLayer})::Bool = true
-Tables.rowaccess(::Type{<:AbstractFeatureLayer})::Bool = true
+Tables.istable(::Type{<:DUAL_AbstractFeatureLayer})::Bool = true
+Tables.rowaccess(::Type{<:DUAL_AbstractFeatureLayer})::Bool = true
 
-function Tables.rows(layer::T)::T where {T<:AbstractFeatureLayer}
+function Tables.rows(layer::T)::T where {T<:DUAL_AbstractFeatureLayer}
     return layer
 end
 
-function Tables.getcolumn(row::Feature, i::Int)
+function Tables.getcolumn(row::AbstractFeature, i::Int)
     if i > nfield(row)
-        return getgeom(row, i - nfield(row) - 1)
+        return stealgeom(row, i - nfield(row) - 1)
     elseif i > 0
         return getfield(row, i - 1)
     else
         return missing
+    end
+end
+
+function Tables.getcolumn(
+    row::FDP_AbstractFeature{FD},
+    i::T,
+) where {FD<:FDType,T<:Integer}
+    if i > nfield(row)
+        return stealgeom(row, i - nfield(row) - 1)
+    else
+        return getfield(row, i - 1)
     end
 end
 
@@ -24,7 +35,22 @@ function Tables.getcolumn(row::Feature, name::Symbol)
     if !ismissing(field)
         return field
     end
-    geom = getgeom(row, name)
+    geom = stealgeom(row, name)
+    if geom.ptr != C_NULL
+        return geom
+    end
+    return missing
+end
+
+function Tables.getcolumn(
+    row::FDP_AbstractFeature{FD},
+    name::Symbol,
+) where {FD<:FDType}
+    field = getfield(row, name)
+    if !ismissing(field)
+        return field
+    end
+    geom = stealgeom(row, name)
     if geom.ptr != C_NULL
         return geom
     end
@@ -32,7 +58,7 @@ function Tables.getcolumn(row::Feature, name::Symbol)
 end
 
 function Tables.columnnames(
-    row::Feature,
+    row::DUAL_AbstractFeature,
 )::NTuple{Int64(nfield(row) + ngeom(row)),Symbol}
     geom_names, field_names = schema_names(getfeaturedefn(row))
     return (geom_names..., field_names...)
@@ -46,4 +72,18 @@ function schema_names(featuredefn::IFeatureDefnView)
         i in 1:ngeom(featuredefn)
     )
     return (geom_names, field_names, featuredefn, fielddefns)
+end
+
+#TODO: check wether some functions used in schema_names could be optimized
+function schema_names(
+    fdp_featuredefn::FDP_IFeatureDefnView{FD},
+) where {FD<:FDType}
+    fielddefns =
+        (getfielddefn(fdp_featuredefn, i) for i in 0:nfield(fdp_featuredefn)-1)
+    field_names = (Symbol(getname(fielddefn)) for fielddefn in fielddefns)
+    geom_names = collect(
+        Symbol(getname(getgeomdefn(fdp_featuredefn, i - 1))) for
+        i in 1:ngeom(fdp_featuredefn)
+    )
+    return (geom_names, field_names, fdp_featuredefn, fielddefns)
 end


### PR DESCRIPTION
Here is a draft for review, demonstrating:
1. a way to dispatch on type in `getfield` (to fix issue #246) bring for a 20% performance gain on layer to table conversion
2. the use of `ogr_f_stealgeometry` for a gain of an additionnal 20%

<details><summary>Performance results</summary><p>
```julia
julia> using ArchGDAL
       const AG = ArchGDAL
       using BenchmarkTools
       using Tables
       using Shapefile

julia> ds = AG.read("../../tmp/road/road.shp")
       layer = AG.getlayer(ds, 0)
       fdp_layer = AG.getFDPlayer(ds, 0)
Layer: road
  Geometry 0 (): [wkbLineString], LINESTRING (874644.4...), ...
     Field 0 (gid): [OFTInteger], 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, ...
     Field 1 (roadcode): [OFTString], 01A903905CD, 01A903905CD, 01A903905CD, ...
     Field 2 (plod): [OFTString], DB1, DB2, DB3, DB4, DB1, DB2, DB1, DB2, ...
     Field 3 (absd): [OFTReal], 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ...
     Field 4 (plof): [OFTString], FB1, FB2, FB3, FB4, FB1, FB2, FB1, FB2, ...
...
 Number of Fields: 7

julia> @benchmark Tables.columns(Shapefile.Table("../../tmp/road/road.shp")
       )
BenchmarkTools.Trial: 71 samples with 1 evaluation.
 Range (min … max):  65.360 ms … 79.845 ms  ┊ GC (min … max): 0.00% … 12.70%
 Time  (median):     68.829 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   70.556 ms ±  3.834 ms  ┊ GC (mean ± σ):  4.00% ±  4.75%

    ▂ ▂  ▂ █  █  █▂                    ▂   █  ▂                
  ▅▁█▅██▅███▁███▅██▅▁▅▁▁▅▁▁▅▁▁▁▁▅▅▁▁▅▁▅█▁▅██▁▅██▅▁▁▁▁▁█▅▁▁▁▁█ ▁
  65.4 ms         Histogram: frequency by time        78.2 ms <

 Memory estimate: 25.48 MiB, allocs estimate: 54329.

julia> @benchmark Tables.columns($layer)
BenchmarkTools.Trial: 42 samples with 1 evaluation.
 Range (min … max):   97.639 ms … 230.930 ms  ┊ GC (min … max): 0.00% … 20.99%
 Time  (median):     101.620 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   120.142 ms ±  42.069 ms  ┊ GC (mean ± σ):  5.93% ±  7.61%

  ▂█▁                                                            
  ███▄▁▃▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▃▁▁▁▃▁▁▄▁▁▁▁▁▃▃ ▁
  97.6 ms          Histogram: frequency by time          231 ms <

 Memory estimate: 8.98 MiB, allocs estimate: 373870.

julia> @benchmark Tables.columns($fdp_layer)
BenchmarkTools.Trial: 53 samples with 1 evaluation.
 Range (min … max):  81.740 ms … 163.887 ms  ┊ GC (min … max): 0.00% … 9.56%
 Time  (median):     87.945 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   97.217 ms ±  24.621 ms  ┊ GC (mean ± σ):  2.62% ± 3.99%

    ▄▇█▇                                                        
  ▅█████▅▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▁▃▁▁▁▁▅▁▁▁▅ ▁
  81.7 ms         Histogram: frequency by time          161 ms <

 Memory estimate: 7.75 MiB, allocs estimate: 279326.

```
</p></details>

## 1. ArchGDAL OGR related types moved to parametric composite types

Trying to dispatch on types required: 

### 1.1 Creation of two parametric singleton types for fields and geomfields, and of a featuredefn like type alias
- **`FType`** for fields, which is paramaterized by a tuple of `OGRFieldType` and `OGRFieldSubType`
- **`GType`** for geomfields, which is parameterized by an `OGRwkbGeometryType`
- **`FDType`** for featuredefn, which is a 2-tuple of a tuple of `GType` and a tuple of `FType`

_Note 1: I have added convert functions from `FType` and `DataType` which yields a more readable correspondance between Julia DataTypes and GDAL Field type ids, than the current separated convert functions from `OGRFieldType` and `OGRFieldSubType` to `DataType`_

_Note 2: I have also added a commented draft of new `Geometry` parametric singleon type (named `Geom`) based on `GType` but not used it since I have not identified any benefit_

### 1.2 Duplication of most of OGR related composite types and parameterization with `FType`, `GType` and `FDType`
The duplicated types have the `FDP` prefix
- **`FDP_GeomFieldDefn`** and **`FDP_FieldDefn`** types are parameterized by `GType` and `FType`
- **`FDP_FeatureDefn`**, **`FDP_Feature`** and **`FDP_FeatureLayer`** types are parameterized by `FDType`  

All of them have been set as subtypes of corresponding abstract supertypes **`DUAL_AbstractXXX`**, in order to limit the duplication of functions code when not necessary.

_Note: A plain FeatureDefn parametric composite type could later be used as type parameter for Feature and FeatureLayer_ 

### 1.3 Modification of a few functions, used to show a layer and convert it to a table
- `getFDPlayer` to handle a feature layer data source with all the newly introduced parametric composite types
- Some functions, which do not have any gain on using the `FDType` information, have just been **extended to accept `DUAL_AbstractXXX`**
- Most of the functions benefiting for the `FDType` information, have been **duplicated as generated functions**

_Note: In the event of the **unlikely use case where there would be too many generated functions** (a lot of different data sources with different featuredefn) for compilation to be performed in a reasonable time or even to succeed, the **generated functions could be moved to optionally-generated functions**. The fallbacks being the legacy functions_

### 1.4 Side additions
1. I have added a macro to export `Enum` type id for user convenience. Disabled in the PR because it is not convenient when developping using revise.jl because it redefines the related constants. I have not found a way to inhibit the latter
2. I have generalized the `ownedby` field in feature layer related types which may serve as a basis to fix issue #215, but @yeesian is tackling this one. For all intents and purposes here are below the relationships which are proposed:  
   <details><summary>Ownership relations graph</summary><p>
   ![OGR Julia objects ownership relations diagram V1]()
   </p></details>

   `destroy` functions for `FDP_XXX` types have been created accordingly


## 2. Steal geometry instead of cloning for the first geometry in features
There appears that `Tables.rows(layer)` makes a copy of the layer.  
Since `ogr_f_stealgeometry` is faster than the composition of `ogr_f_getgeomfieldref` and `ogr_g_clone`, I have modified `Tables.getcolumn` to use a `stealgeom` function instead of the current `getgeom` function.

Unfortunately, `ogr_f_getgeomfieldref` is implemented in GDAL C interface only for the default (first) geometry. Datasources with only one geometry per feature is the general case, but that could be an issue to raise in GDAL. 

## 3. Further performance optimizations to investigate, regarding the layer to table conversion performance
- Include field and geomfieldnames in feature definition type `FDType` to avoid calling `ogr_f_getfieldindex`
- Count the number of calls to `ogr_l_getnextfeature` to ensure there is no unnecessary call to it