### PR TITLE
support imview for Unsigned besides UInt8

### DIFF
--- a/src/raster/array.jl
+++ b/src/raster/array.jl
@@ -59,6 +59,7 @@ for f in (
     :buildoverviews!,
     :metadata,
     :metadatadomainlist,
+    :imread,
 )
     eval(:(function $(f)(x::RasterDataset, args...; kwargs...)
         return $(f)(x.ds, args...; kwargs...)

--- a/src/raster/images.jl
+++ b/src/raster/images.jl
@@ -2,7 +2,12 @@ function imview(colortype::Type{<:ColorTypes.Colorant}, imgvalues...)
     return PermutedDimsArray(
         ImageCore.colorview(
             colortype,
-            (ImageCore.normedview(img) for img in imgvalues)...,
+            (
+                ImageCore.normedview(
+                    ImageCore.Normed{eltype(img),8 * sizeof(eltype(img))},
+                    img,
+                ) for img in imgvalues
+            )...,
         ),
         (2, 1),
     )

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -14,6 +14,8 @@ import GDAL
     AG.read("gdalworkshop/world.tif") do dataset
         @testset "Test RGB colors" begin
             @test eltype(AG.imread(dataset)) == ColorTypes.RGB{ImageCore.N0f8}
+            rasterdataset = AG.RasterDataset(dataset)
+            @test eltype(AG.imread(rasterdataset)) == ColorTypes.RGB{ImageCore.N0f8}
         end
     end
 


### PR DESCRIPTION
The single argument normedview is only for UInt8.
This assumes that the full range will be used to go from 0 to 1.

https://juliaimages.org/stable/function_reference/#ImageCore.normedview

I ran into this with a UInt16 landsat image, and with this change I can `imread` it. Though I see that the tests only cover UInt8.

EDIT: added a second commit to make imread work on RasterDataset