### PR TITLE
import ArchGDAL as AG

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,7 +1,6 @@
 using BenchmarkTools
 using ZipFile
-using ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 using Tables
 using Shapefile
 

--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -4,7 +4,7 @@
 using ArchGDAL
 ```
 
-In this section, we consider some of the common kinds of geometries that arises in applications. These include `Point`, `LineString`, `Polygon`, `GeometryCollection`, `MultiPolygon`, `MultiPoint`, and `MultiLineString`. For brevity in the examples, we will use the prefix `const AG = ArchGDAL`.
+In this section, we consider some of the common kinds of geometries that arises in applications. These include `Point`, `LineString`, `Polygon`, `GeometryCollection`, `MultiPolygon`, `MultiPoint`, and `MultiLineString`.
 
 ## Geometry Creation
 To create geometries of different types, 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,8 +34,7 @@ julia> using ArchGDAL
 
 In the documentation `AG` is often used as a shorthand for `ArchGDAL`. To use this shorthand you can use:
 ```julia
-using ArchGDAL
-const AG = ArchGDAL
+import ArchGDAL as AG
 ```
 
 ## Contents

--- a/docs/src/rasters.md
+++ b/docs/src/rasters.md
@@ -1,8 +1,7 @@
 # Raster Data
 
 ```@setup rasters
-using ArchGDAL
-const AG = ArchGDAL
+using ArchGDAL; const AG = ArchGDAL
 ```
 
 In this section, we revisit the [`gdalworkshop/world.tif`](https://github.com/yeesian/ArchGDALDatasets/blob/307f8f0e584a39a050c042849004e6a2bd674f99/gdalworkshop/world.tif) dataset.

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -1,7 +1,6 @@
 using Test
 using DiskArrays: eachchunk, haschunks, Chunked, GridChunks, readblock!
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_array.jl" begin
     @testset "RasterDataset Type" begin

--- a/test/test_convert.jl
+++ b/test/test_convert.jl
@@ -1,8 +1,6 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
-import GeoFormatTypes;
-const GFT = GeoFormatTypes;
+import ArchGDAL as AG
+import GeoFormatTypes as GFT
 
 @testset "test_convert.jl" begin
 
@@ -41,7 +39,7 @@ const GFT = GeoFormatTypes;
             ),
         ) == proj4326
         @test convert(GFT.CoordSys, GFT.CRS(), proj4326) isa GFT.CoordSys
-        @test convert(GFT.GML, GFT.CRS(), proj4326) isa GeoFormatTypes.GML
+        @test convert(GFT.GML, GFT.CRS(), proj4326) isa GFT.GML
     end
 
     @testset "geometry conversions" begin

--- a/test/test_cookbook_geometry.jl
+++ b/test/test_cookbook_geometry.jl
@@ -1,8 +1,7 @@
 # adapted from http://pcjericks.github.io/py-gdalogr-cookbook/geometry.html
 using Test
 import GeoInterface
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_cookbook_geometry.jl" begin
     @testset "Create a Point" begin

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -1,7 +1,7 @@
 using Test
-import GeoInterface, GeoFormatTypes, ArchGDAL
-const AG = ArchGDAL
-const GFT = GeoFormatTypes
+import GeoInterface
+import ArchGDAL as AG
+import GeoFormatTypes as GFT
 
 @testset "test_cookbook_projection.jl" begin
     @testset "Reproject a Geometry" begin

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_dataset.jl" begin
     @testset "Test methods for raster dataset" begin

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_display.jl" begin
     @testset "Testing Displays for NULL objects" begin

--- a/test/test_drivers.jl
+++ b/test/test_drivers.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_drivers.jl" begin
     @testset "Testing ConfigOptions" begin

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_feature.jl" begin
     AG.read("data/point.geojson") do dataset

--- a/test/test_featurelayer.jl
+++ b/test/test_featurelayer.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_featurelayer.jl" begin
     @testset "Testing FeatureLayer Methods" begin

--- a/test/test_fielddefn.jl
+++ b/test/test_fielddefn.jl
@@ -16,7 +16,7 @@ const AG = ArchGDAL;
             @test AG.getfieldtype(fd) == AG.OFTDate
             AG.settype!(fd, AG.OFTInteger)
             @test AG.getsubtype(fd) == AG.OFSTNone
-            @test AG.getfieldtype(fd) == ArchGDAL.OFTInteger
+            @test AG.getfieldtype(fd) == AG.OFTInteger
             AG.setsubtype!(fd, AG.OFSTInt16)
             @test AG.getsubtype(fd) == AG.OFSTInt16
             @test AG.getfieldtype(fd) == AG.OFSTInt16

--- a/test/test_fielddefn.jl
+++ b/test/test_fielddefn.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_fielddefn.jl" begin
     @testset "Tests for field defn" begin

--- a/test/test_gdal_tutorials.jl
+++ b/test/test_gdal_tutorials.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_gdal_tutorials.jl" begin
     @testset "Raster Tutorial" begin

--- a/test/test_gdalutilities.jl
+++ b/test/test_gdalutilities.jl
@@ -1,5 +1,5 @@
-import ArchGDAL, GDAL;
-const AG = ArchGDAL
+import GDAL
+import ArchGDAL as AG
 using Test
 
 @testset "test_gdalutilities.jl" begin

--- a/test/test_gdalutilities_errors.jl
+++ b/test/test_gdalutilities_errors.jl
@@ -1,5 +1,5 @@
-import ArchGDAL, GDAL;
-const AG = ArchGDAL
+import GDAL
+import ArchGDAL as AG
 using Test
 
 @testset "test_gdalutilities_errors.jl" begin

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1,7 +1,7 @@
 using Test
-import GeoInterface, GeoFormatTypes, ArchGDAL;
-const AG = ArchGDAL
-const GFT = GeoFormatTypes
+import GeoInterface
+import ArchGDAL as AG
+import GeoFormatTypes as GFT
 
 @testset "test_geometry.jl" begin
     @testset "Incomplete GeoInterface geometries" begin

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_geos_operations.jl" begin
     function equivalent_to_wkt(geom::AG.Geometry, wkt::String)

--- a/test/test_geotransform.jl
+++ b/test/test_geotransform.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_geotransform.jl" begin
     function f(gt, pixel, line)

--- a/test/test_images.jl
+++ b/test/test_images.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 import ImageCore
 import ColorTypes
 import GDAL

--- a/test/test_iterators.jl
+++ b/test/test_iterators.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_iterators.jl" begin
     @testset "Iterator interface Window Iterator" begin

--- a/test/test_ospy_examples.jl
+++ b/test/test_ospy_examples.jl
@@ -1,7 +1,6 @@
 using Test
 using Statistics
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_ospy_examples.jl" begin
     """

--- a/test/test_rasterattrtable.jl
+++ b/test/test_rasterattrtable.jl
@@ -1,7 +1,6 @@
 using Test
 import GDAL
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_rasterattrtable.jl" begin
     @testset "Testing Raster Attribute Tables" begin

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -1,7 +1,6 @@
 using Test
 import GDAL
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_rasterband.jl" begin
     @testset "Test methods for rasterband" begin

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_rasterio.jl" begin
     AG.read("ospy/data4/aster.img") do ds

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -1,8 +1,6 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
-import GeoFormatTypes;
-const GFT = GeoFormatTypes;
+import ArchGDAL as AG
+import GeoFormatTypes as GFT
 
 @testset "test_spatialref.jl" begin
     @testset "Test Formats for Spatial Reference Systems" begin

--- a/test/test_styletable.jl
+++ b/test/test_styletable.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 @testset "test_styletable.jl" begin
     @testset "Testing StyleTable Methods" begin

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -20,9 +20,9 @@ using Tables
                 "KEEP_GEOM_COLUMNS=NO",
             ],
         )
-        @test dataset isa ArchGDAL.IDataset
-        @test dataset1 isa ArchGDAL.IDataset
-        @test dataset2 isa ArchGDAL.IDataset
+        @test dataset isa AG.IDataset
+        @test dataset1 isa AG.IDataset
+        @test dataset2 isa AG.IDataset
         layer = AG.getlayer(dataset, 0)
         layer1 = AG.getlayer(dataset1, 0)
         layer2 = AG.getlayer(dataset2, 0)
@@ -530,7 +530,7 @@ using Tables
                 ESRI_Shapefile_test_reference_geotable = (
                     names = (Symbol(""), :id, :name),
                     types = (
-                        Union{Missing,ArchGDAL.IGeometry},
+                        Union{Missing,AG.IGeometry},
                         Union{Missing,Int64},
                         String,
                     ),
@@ -559,7 +559,7 @@ using Tables
                     types = (
                         Union{
                             Missing,
-                            ArchGDAL.IGeometry{ArchGDAL.wkbLineString},
+                            AG.IGeometry{AG.wkbLineString},
                         },
                         Union{Missing,Int64},
                         String,
@@ -589,7 +589,7 @@ using Tables
                 GeoJSON_test_reference_geotable = (
                     names = (Symbol(""), :id, :name),
                     types = (
-                        Union{Missing,ArchGDAL.IGeometry},
+                        Union{Missing,AG.IGeometry},
                         Union{Missing,Int32},
                         String,
                     ),
@@ -618,7 +618,7 @@ using Tables
                     types = (
                         Union{
                             Missing,
-                            ArchGDAL.IGeometry{ArchGDAL.wkbLineString},
+                            AG.IGeometry{AG.wkbLineString},
                         },
                         Union{Missing,Int32},
                         String,
@@ -648,7 +648,7 @@ using Tables
                 GML_test_reference_geotable = (
                     names = (:geometryProperty, :gml_id, :id, :name),
                     types = (
-                        Union{Missing,ArchGDAL.IGeometry},
+                        Union{Missing,AG.IGeometry},
                         String,
                         Union{Missing,Int64},
                         String,
@@ -684,7 +684,7 @@ using Tables
                 GPKG_test_reference_geotable = (
                     names = (:geom, :id, :name),
                     types = (
-                        Union{Missing,ArchGDAL.IGeometry},
+                        Union{Missing,AG.IGeometry},
                         Union{Missing,Int64},
                         String,
                     ),
@@ -712,7 +712,7 @@ using Tables
             @testset "Conversion to table for KML driver" begin
                 KML_test_reference_geotable = (
                     names = (Symbol(""), :Name, :Description),
-                    types = (ArchGDAL.IGeometry, String, String),
+                    types = (AG.IGeometry, String, String),
                     values = (
                         [
                             "LINESTRING (1 2,2 3,3 4)",
@@ -736,7 +736,7 @@ using Tables
             @testset "Conversion to table for FlatGeobuf driver" begin
                 FlatGeobuf_test_reference_geotable = (
                     names = (Symbol(""), :id, :name),
-                    types = (ArchGDAL.IGeometry, Union{Nothing,Int64}, String),
+                    types = (AG.IGeometry, Union{Nothing,Int64}, String),
                     values = (
                         [
                             "LINESTRING (5 6,6 7,7 8)",
@@ -769,8 +769,8 @@ using Tables
                     CSV_multigeom_test_reference_geotable = (
                         names = (:point, :linestring, :id, :zoom, :location),
                         types = (
-                            ArchGDAL.IGeometry{ArchGDAL.wkbPoint},
-                            ArchGDAL.IGeometry{ArchGDAL.wkbLineString},
+                            AG.IGeometry{AG.wkbPoint},
+                            AG.IGeometry{AG.wkbLineString},
                             String,
                             String,
                             String,

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 using Tables
 
 @testset "test_tables.jl" begin

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,6 +1,5 @@
 using Test
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 import ImageCore
 
 @testset "test_types.jl" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,7 +1,6 @@
 using Test
 import GDAL
-import ArchGDAL;
-const AG = ArchGDAL;
+import ArchGDAL as AG
 
 "Test both that an ErrorException is thrown and that the message is as expected"
 function eval_ogrerr(err, expected_message)


### PR DESCRIPTION
Purely cosmetic change / increasing the consistency.

The AG abbreviation was already used almost everywhere in the tests. This changes the last few, and changes the import over to `import ArchGDAL as AG`. Since in the docs there is mixed usage, I didn't change it there, sticking to `using ArchGDAL; const AG = ArchGDAL` which gets both ArchGDAL and AG in the namespace. Same for GeoFormatTypes.