### PR TITLE
remove DiskArrays 0.2.4 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 CEnum = "0.4"
 ColorTypes = "0.10, 0.11"
-DiskArrays = "0.2.4, 0.3"
+DiskArrays = "0.3"
 GDAL = "1.3"
 GeoFormatTypes = "0.3"
 GeoInterface = "0.4, 0.5"


### PR DESCRIPTION
I just removed the DiskArrays 0.2.4 compat entry in the Project toml, because ArchGDAL is not compatible with the old version. You would have to tag a new version and remove the broken one from the registry. Closes https://github.com/rafaqz/Rasters.jl/issues/244 and https://github.com/yeesian/ArchGDAL.jl/issues/277