### PR TITLE
Enable preperation of geometry

### DIFF
--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -164,6 +164,15 @@ The following predicates return a `Bool`.
 * [`ArchGDAL.contains(g1, g2)`](@ref)
 * [`ArchGDAL.overlaps(g1, g2)`](@ref)
 
+### Prepared geometry
+When repeatedly calling [`ArchGDAL.intersects(g1, g2)`](@ref) and [`ArchGDAL.contains(g1, g2)`](@ref) on the same
+geometry, for example, when intersecting 50 points with a 100 polygons, it is possible to increase performance
+by caching required--otherwise repeatedly calculated--information on geometries.
+You can do this by *preparing* a geometry by calling [`ArchGDAL.preparegeom(geom)`](@ref) and using the
+resulting prepared geometry as the first argument for [`ArchGDAL.intersects(g1, g2)`](@ref) or [`ArchGDAL.contains(g1, g2)`](@ref).
+
+If you use a custom GDAL installation, you can check whether it supports prepared geometries by calling [`ArchGDAL.has_preparedgeom_support()`](@ref).
+
 ### Immutable Operations
 The following methods do not mutate the input geomteries `g1` and `g2`.
 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -87,6 +87,18 @@ function destroy(geom::AbstractGeometry)::Nothing
 end
 
 """
+Destroy prepared geometry object.
+
+Equivalent to invoking delete on a prepared geometry, but it guaranteed to take place
+within the context of the GDAL/OGR heap.
+"""
+function destroy(geom::AbstractPreparedGeometry)::Nothing
+    GDAL.ogrdestroypreparedgeometry(geom.ptr)
+    geom.ptr = C_NULL
+    return nothing
+end
+
+"""
     clone(geom::AbstractGeometry)
 
 Returns a copy of the geometry with the original spatial reference system.
@@ -120,6 +132,18 @@ creategeom(geomtype::OGRwkbGeometryType)::IGeometry =
 
 unsafe_creategeom(geomtype::OGRwkbGeometryType)::Geometry =
     Geometry(GDAL.ogr_g_creategeometry(geomtype))
+
+"""
+    preparegeom(geom::AbstractGeometry)
+
+Create an prepared geometry of a geometry. This can speed up operations which interact
+with the geometry multiple times, by storing caches of calculated geometry information.
+"""
+preparegeom(geom::AbstractGeometry)::IPreparedGeometry =
+    IPreparedGeometry(GDAL.ogrcreatepreparedgeometry(geom.ptr))
+
+unsafe_preparegeom(geom::AbstractGeometry)::PreparedGeometry =
+    PreparedGeometry(GDAL.ogrcreatepreparedgeometry(geom.ptr))
 
 """
     forceto(geom::AbstractGeometry, targettype::OGRwkbGeometryType, [options])
@@ -608,6 +632,9 @@ boxes) of the two geometries overlap.
 intersects(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
     Bool(GDAL.ogr_g_intersects(g1.ptr, g2.ptr))
 
+intersects(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
+    Bool(GDAL.ogrpreparedgeometryintersects(g1.ptr, g2.ptr))
+
 """
     equals(g1::AbstractGeometry, g2::AbstractGeometry)
 
@@ -655,6 +682,9 @@ Returns `true` if g1 contains g2.
 """
 contains(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
     Bool(GDAL.ogr_g_contains(g1.ptr, g2.ptr))
+
+contains(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
+    Bool(GDAL.ogrpreparedgeometrycontains(g1.ptr, g2.ptr))
 
 """
     overlaps(g1::AbstractGeometry, g2::AbstractGeometry)

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -134,6 +134,13 @@ unsafe_creategeom(geomtype::OGRwkbGeometryType)::Geometry =
     Geometry(GDAL.ogr_g_creategeometry(geomtype))
 
 """
+    haspreparedgeomsupport()
+
+Check whether the current GDAL instance has support for prepared geometries.
+"""
+has_preparedgeom_support() = Bool(GDAL.ogrhaspreparedgeometrysupport())
+
+"""
     preparegeom(geom::AbstractGeometry)
 
 Create an prepared geometry of a geometry. This can speed up operations which interact

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,6 +4,9 @@ import Base.convert
 abstract type AbstractGeometry <: GeoInterface.AbstractGeometry end
 # needs to have a `ptr::GDAL.OGRGeometryH` attribute
 
+abstract type AbstractPreparedGeometry <: AbstractGeometry end
+# needs to have a `ptr::GDAL.OGRPreparedGeometryH` attribute
+
 abstract type AbstractSpatialRef end
 # needs to have a `ptr::GDAL.OGRSpatialReferenceH` attribute
 
@@ -230,6 +233,20 @@ mutable struct IGeometry{OGRwkbGeometryType} <: AbstractGeometry
     end
 end
 _geomtype(::IGeometry{T}) where {T} = T
+
+mutable struct PreparedGeometry <: AbstractPreparedGeometry
+    ptr::GDAL.OGRPreparedGeometryH
+end
+
+mutable struct IPreparedGeometry <: AbstractPreparedGeometry
+    ptr::GDAL.OGRPreparedGeometryH
+
+    function IPreparedGeometry(ptr::GDAL.OGRPreparedGeometryH)
+        geom = new(ptr)
+        finalizer(destroy, geom)
+        return geom
+    end
+end
 
 mutable struct ColorTable
     ptr::GDAL.GDALColorTableH

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ include("remotefiles.jl")
         include("test_geotransform.jl")
         include("test_images.jl")
         include("test_utils.jl")
+        include("test_prepared_geometry.jl")
         return nothing
     end
 end

--- a/test/test_prepared_geometry.jl
+++ b/test/test_prepared_geometry.jl
@@ -1,0 +1,16 @@
+using Test
+import ArchGDAL as AG
+
+@testset "Prepared Geometry" begin
+    point = AG.createpoint(1.0, 1.0)
+    polygon = AG.createpolygon([
+        [1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0],
+        [7.0, 8.0, 9.0],
+        [1.0, 2.0, 3.0],
+    ])
+    r1 = AG.intersects(polygon, point)
+    prep_polygon = AG.preparegeom(polygon)
+    r2 = AG.intersects(prep_polygon, point)
+    @test r1 == r2
+end

--- a/test/test_prepared_geometry.jl
+++ b/test/test_prepared_geometry.jl
@@ -9,8 +9,19 @@ import ArchGDAL as AG
         [7.0, 8.0, 9.0],
         [1.0, 2.0, 3.0],
     ])
-    r1 = AG.intersects(polygon, point)
+
+    @test AG.has_preparedgeom_support()
+
     prep_polygon = AG.preparegeom(polygon)
-    r2 = AG.intersects(prep_polygon, point)
-    @test r1 == r2
+    unsafe_prep_polygon = AG.unsafe_preparegeom(polygon)
+    @test isa(unsafe_prep_polygon, AG.PreparedGeometry)
+    AG.destroy(unsafe_prep_polygon)
+
+    ir1 = AG.intersects(polygon, point)
+    ir2 = AG.intersects(prep_polygon, point)
+    @test ir1 === ir2
+
+    or1 = AG.contains(polygon, point)
+    or2 = AG.contains(prep_polygon, point)
+    @test or1 === or2
 end


### PR DESCRIPTION
Preparing geometry is useful when you repeat spatial operations on a geometry, as required, calculated, information needed for said operation is cached. See https://blog.cleverelephant.ca/2008/10/postgis-performance-prepared-geometry.html

The open question is if/where we check for the remaining GDAL `ogrhaspreparedgeometrysupport` method in all these calls. Maybe a warning on init? I'm not sure what happens when a non-Yggdrasil GDAL doesn't have prepgeom support.

