### PR TITLE
Added IFeature type. Fixed memory leakage for `Feature`s.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/base/display.jl
+++ b/src/base/display.jl
@@ -213,7 +213,7 @@ function Base.show(io::IO, gfd::AbstractGeomFieldDefn)::Nothing
     return nothing
 end
 
-function Base.show(io::IO, feature::Feature)::Nothing
+function Base.show(io::IO, feature::AbstractFeature)::Nothing
     if feature.ptr == C_NULL
         print(io, "NULL Feature")
         return nothing

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -1,7 +1,7 @@
 function Base.iterate(
     layer::AbstractFeatureLayer,
     state::Integer = 0,
-)::Union{Nothing,Tuple{Feature,Int64}}
+)::Union{Nothing,Tuple{IFeature,Int64}}
     layer.ptr == C_NULL && return nothing
     state == 0 && resetreading!(layer)
     ptr = GDAL.ogr_l_getnextfeature(layer.ptr)
@@ -9,11 +9,11 @@ function Base.iterate(
         resetreading!(layer)
         nothing
     else
-        (Feature(ptr), state + 1)
+        (IFeature(ptr), state + 1)
     end
 end
 
-Base.eltype(layer::AbstractFeatureLayer)::DataType = Feature
+Base.eltype(layer::AbstractFeatureLayer)::DataType = IFeature
 
 Base.IteratorSize(::Type{<:AbstractFeatureLayer}) = Base.SizeUnknown()
 

--- a/src/ogr/featuredefn.jl
+++ b/src/ogr/featuredefn.jl
@@ -364,9 +364,9 @@ function unsafe_createfeature(featuredefn::AbstractFeatureDefn)::Feature
 end
 
 """
-    getfeaturedefn(feature::Feature)
+    getfeaturedefn(feature::AbstractFeature)
 
 Fetch feature definition.
 """
-getfeaturedefn(feature::Feature)::IFeatureDefnView =
+getfeaturedefn(feature::AbstractFeature)::IFeatureDefnView =
     IFeatureDefnView(GDAL.ogr_f_getdefnref(feature.ptr))

--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -456,7 +456,7 @@ unsafe_getfeature(layer::AbstractFeatureLayer, i::Integer)::Feature =
     Feature(GDAL.ogr_l_getfeature(layer.ptr, i))
 
 """
-    setfeature!(layer::AbstractFeatureLayer, feature::Feature)
+    setfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)
 
 Rewrite an existing feature.
 
@@ -467,7 +467,7 @@ the OGRFeature.
 Use OGR_L_TestCapability(OLCRandomWrite) to establish if this layer supports
 random access writing via OGR_L_SetFeature().
 """
-function setfeature!(layer::AbstractFeatureLayer, feature::Feature)
+function setfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)
     result = GDAL.ogr_l_setfeature(layer.ptr, feature.ptr)
     # OGRERR_NONE if the operation works, otherwise an appropriate error code
     # (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
@@ -476,7 +476,7 @@ function setfeature!(layer::AbstractFeatureLayer, feature::Feature)
 end
 
 """
-    addfeature!(layer::AbstractFeatureLayer, feature::Feature)
+    addfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)
 
 Write a new feature within a layer.
 
@@ -489,7 +489,7 @@ will have been updated with the new feature id.
 """
 function addfeature!(
     layer::L,
-    feature::Feature,
+    feature::AbstractFeature,
 )::L where {L<:AbstractFeatureLayer}
     result = GDAL.ogr_l_createfeature(layer.ptr, feature.ptr)
     @ogrerr result "Failed to create and write feature in layer."

--- a/src/ogr/fielddefn.jl
+++ b/src/ogr/fielddefn.jl
@@ -336,7 +336,7 @@ function destroy(geomdefn::GeomFieldDefn)::Nothing
     return nothing
 end
 
-"Destroy a geometry field definition."
+"Destroy a geometry field definition view."
 function destroy(geomdefn::IGeomFieldDefnView)::Nothing
     geomdefn.ptr = C_NULL
     return nothing

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -9,7 +9,7 @@ function Tables.rows(layer::T)::T where {T<:AbstractFeatureLayer}
     return layer
 end
 
-function Tables.getcolumn(row::Feature, i::Int)
+function Tables.getcolumn(row::AbstractFeature, i::Int)
     if i > nfield(row)
         return getgeom(row, i - nfield(row) - 1)
     elseif i > 0
@@ -19,7 +19,7 @@ function Tables.getcolumn(row::Feature, i::Int)
     end
 end
 
-function Tables.getcolumn(row::Feature, name::Symbol)
+function Tables.getcolumn(row::AbstractFeature, name::Symbol)
     field = getfield(row, name)
     if !ismissing(field)
         return field
@@ -32,7 +32,7 @@ function Tables.getcolumn(row::Feature, name::Symbol)
 end
 
 function Tables.columnnames(
-    row::Feature,
+    row::AbstractFeature,
 )::NTuple{Int64(nfield(row) + ngeom(row)),Symbol}
     geom_names, field_names = schema_names(getfeaturedefn(row))
     return (geom_names..., field_names...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -13,6 +13,9 @@ abstract type AbstractSpatialRef end
 abstract type AbstractDataset end
 # needs to have a `ptr::GDAL.GDALDatasetH` attribute
 
+abstract type AbstractFeature end
+# needs to have a `ptr::GDAL.OGRFeatureH` attribute
+
 abstract type AbstractFeatureDefn end
 # needs to have a `ptr::GDAL.OGRFeatureDefnH` attribute
 
@@ -142,8 +145,18 @@ mutable struct IFeatureLayer <: AbstractFeatureLayer
     end
 end
 
-mutable struct Feature
+mutable struct Feature <: AbstractFeature
     ptr::GDAL.OGRFeatureH
+end
+
+mutable struct IFeature <: AbstractFeature
+    ptr::GDAL.OGRFeatureH
+
+    function IFeature(ptr::GDAL.OGRFeatureH = C_NULL)
+        feature = new(ptr)
+        finalizer(destroy, feature)
+        return feature
+    end
 end
 
 mutable struct FeatureDefn <: AbstractFeatureDefn


### PR DESCRIPTION
Triggered by out of memory errors when working with a *lot* of GeoDataFrames.

It seems that `iterate` just allocates `Feature`s without anyone ever cleaning them. This PR introduces an `IFeature` (and its parent `AbstractFeature`), which should align nicely with the other types.

Since GeoDataFrames goes through quite some calls, it is a bit hard to find these things, but I expect this is not the only memory leak remaining.