### PR TITLE
Return extent based on dimensionality.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -267,12 +267,18 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     end
 
     function GeoInterface.extent(::GeometryTraits, a::AbstractGeometry)
-        env = envelope3d(a)
-        return Extent(
-            X = (env.MinX, env.MaxX),
-            Y = (env.MinY, env.MaxY),
-            Z = (env.MinZ, env.MaxZ),
-        )
+        nc = getcoorddim(a)
+        if nc == 2
+            env = envelope(a)
+            return Extent(X = (env.MinX, env.MaxX), Y = (env.MinY, env.MaxY))
+        else
+            env = envelope3d(a)
+            return Extent(
+                X = (env.MinX, env.MaxX),
+                Y = (env.MinY, env.MaxY),
+                Z = (env.MinZ, env.MaxZ),
+            )
+        end
     end
 
     function GeoInterface.asbinary(::GeometryTraits, geom::AbstractGeometry)

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -267,17 +267,16 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     end
 
     function GeoInterface.extent(::GeometryTraits, a::AbstractGeometry)
-        nc = getcoorddim(a)
-        if nc == 2
-            env = envelope(a)
-            return Extent(X = (env.MinX, env.MaxX), Y = (env.MinY, env.MaxY))
-        else
+        if GeoInterface.is3d(a)
             env = envelope3d(a)
             return Extent(
                 X = (env.MinX, env.MaxX),
                 Y = (env.MinY, env.MaxY),
                 Z = (env.MinZ, env.MaxZ),
             )
+        else
+            env = envelope(a)
+            return Extent(X = (env.MinX, env.MaxX), Y = (env.MinY, env.MaxY))
         end
     end
 

--- a/test/test_geos_operations.jl
+++ b/test/test_geos_operations.jl
@@ -280,7 +280,11 @@ using Extents
         ) == "POLYGON ((0 0,0 10,10 10,10 0,0 0))"
 
         @test GI.extent(AG.fromWKT("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))")) ==
-              Extent(X = (0.0, 10.0), Y = (0.0, 10.0), Z = (0.0, 0.0))
+              Extent(X = (0.0, 10.0), Y = (0.0, 10.0))
+
+        @test GI.extent(
+            AG.fromWKT("POLYGON((0 0 0, 10 0 0, 10 10 0, 0 10 0, 0 0 1))"),
+        ) == Extent(X = (0.0, 10.0), Y = (0.0, 10.0), Z = (0.0, 1.0))
 
         @test GI.asbinary(
             AG.fromWKT("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"),


### PR DESCRIPTION
Before we always returned the 3d extent, even on 2d geometries.