### PR TITLE
Add conversion for Enum types.

### DIFF
--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -619,6 +619,14 @@ end
 function setfield!(
     feature::AbstractFeature,
     i::Integer,
+    value::Enum,
+)::AbstractFeature
+    return setfield!(feature, i, Integer(value))
+end
+
+function setfield!(
+    feature::AbstractFeature,
+    i::Integer,
     value::Union{Float16,Float32,Float64},
 )::AbstractFeature
     GDAL.ogr_f_setfielddouble(feature.ptr, i, value)

--- a/src/types.jl
+++ b/src/types.jl
@@ -351,6 +351,10 @@ end
     OFTInteger64List::Vector{Int64},
 )
 
+function Base.convert(og::Type{OGRFieldType}, ::Type{<:Enum{T}}) where {T}
+    return Base.convert(og, T)
+end
+
 @convert(
     OGRFieldSubType::GDAL.OGRFieldSubType,
     OFSTNone::GDAL.OFSTNone,
@@ -392,6 +396,10 @@ end
     # Lacking OFSTUUID and OFSTJSON defined in GDAL ≥ v"3.3"
     OFSTNone::Nothing, # default type comes last
 )
+
+function Base.convert(og::Type{OGRFieldSubType}, ::Type{<:Enum{T}}) where {T}
+    return Base.convert(og, T)
+end
 
 @convert(
     OGRJustification::GDAL.OGRJustification,

--- a/test/test_feature.jl
+++ b/test/test_feature.jl
@@ -2,6 +2,10 @@ using Test
 import ArchGDAL as AG
 import GeoInterface as GI
 
+@enum TestEnum::Bool begin
+    EnumValue = false
+end
+
 @testset "test_feature.jl" begin
     AG.read("data/point.geojson") do dataset
         layer = AG.getlayer(dataset, 0)
@@ -246,6 +250,10 @@ import GeoInterface as GI
             AG.createfielddefn("uint32subfield", AG.OFTInteger64) do fielddefn
                 return AG.addfielddefn!(layer, fielddefn)
             end
+            AG.createfielddefn("booleanenumfield", AG.OFTInteger) do fielddefn
+                AG.setsubtype!(fielddefn, AG.OFSTBoolean)
+                return AG.addfielddefn!(layer, fielddefn)
+            end
             AG.createfeature(layer) do feature
                 AG.setfield!(feature, 0, Int64(1))
                 AG.setfield!(feature, 1, Float64(1.0))
@@ -264,6 +272,7 @@ import GeoInterface as GI
                 AG.setfield!(feature, 14, Float16(1.0))
                 AG.setfield!(feature, 15, UInt16(1.0))
                 AG.setfield!(feature, 16, UInt32(1.0))
+                AG.setfield!(feature, 17, EnumValue)
                 for i in 1:AG.nfield(feature)
                     @test !AG.isfieldnull(feature, i - 1)
                     @test AG.isfieldsetandnotnull(feature, i - 1)
@@ -282,6 +291,7 @@ import GeoInterface as GI
                 @test AG.getfield(feature, 14) === Float32(1.0) # Widened from Float16
                 @test AG.getfield(feature, 15) === Int32(1) # Widened from UInt16
                 @test AG.getfield(feature, 16) === Int64(1) # Widened from UInt32
+                @test AG.getfield(feature, 17) === false  # Enum is lost
 
                 AG.addfeature(layer) do newfeature
                     AG.setfrom!(newfeature, feature)

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -22,10 +22,15 @@ import ImageCore
             @test Base.convert(AG.OGRFieldType, Int32) == AG.OFTInteger
             @test Base.convert(DataType, AG.OFTInteger) == Int32
 
-            # Default type for AG.OFTReal is Float64 
+            # Default type for AG.OFTReal is Float64
             @test Base.convert(AG.OGRFieldType, Float32) == AG.OFTReal
             @test Base.convert(AG.OGRFieldType, Float64) == AG.OFTReal
             @test Base.convert(DataType, AG.OFTReal) == Float64
+
+            # Manual defined convert for Enums
+            @enum TestEnum::Bool EnumValue = false
+            @test convert(ArchGDAL.OGRFieldType, TestEnum) == AG.OFTInteger
+            @test convert(ArchGDAL.OGRFieldSubType, TestEnum) == AG.OFSTBoolean
         end
     end
 


### PR DESCRIPTION
As a table with an Vector{<:Enum} now can't be written. Enum stores the flags as Integer, so we already have the means to write its values. The only drawback is that we cannot restore the Enum once the value has been written.