### PR TITLE
Revert "Create a new minor release"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.9.3"
+version = "0.9.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"


### PR DESCRIPTION
Reverts yeesian/ArchGDAL.jl#328.

I realize I forgot to release the previous minor version (i.e. `v0.9.2`); so revert to it. See https://github.com/JuliaRegistries/General/pull/69387#issuecomment-1264730866 