### PR TITLE
fix segfaults on nightly

### DIFF
--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -554,8 +554,9 @@ Returns a view of the schema information for this layer.
 ### Remarks
 The `featuredefn` is owned by the `layer` and should not be modified.
 """
-layerdefn(layer::AbstractFeatureLayer)::IFeatureDefnView =
-    IFeatureDefnView(GDAL.ogr_l_getlayerdefn(layer.ptr))
+function layerdefn(layer::AbstractFeatureLayer)::IFeatureDefnView
+    return GC.@preserve layer IFeatureDefnView(GDAL.ogr_l_getlayerdefn(layer.ptr))
+end
 
 """
     findfieldindex(layer::AbstractFeatureLayer,
@@ -585,8 +586,9 @@ Fetch the feature count in this layer, or `-1` if the count is not known.
 * `force`: flag indicating whether the count should be computed even if it is
     expensive. (`false` by default.)
 """
-nfeature(layer::AbstractFeatureLayer, force::Bool = false)::Integer =
-    GDAL.ogr_l_getfeaturecount(layer.ptr, force)
+function nfeature(layer::AbstractFeatureLayer, force::Bool = false)::Integer
+    return GC.@preserve layer GDAL.ogr_l_getfeaturecount(layer.ptr, force)
+end
 
 """
     ngeom(layer::AbstractFeatureLayer)

--- a/src/ogr/fielddefn.jl
+++ b/src/ogr/fielddefn.jl
@@ -22,21 +22,23 @@ end
 
 "Set the name of this field."
 function setname!(fielddefn::FieldDefn, name::AbstractString)::FieldDefn
-    GDAL.ogr_fld_setname(fielddefn.ptr, name)
+    GC.@preserve fielddefn GDAL.ogr_fld_setname(fielddefn.ptr, name)
     return fielddefn
 end
 
 "Fetch the name of this field."
-getname(fielddefn::AbstractFieldDefn)::String =
-    GDAL.ogr_fld_getnameref(fielddefn.ptr)
+function getname(fielddefn::AbstractFieldDefn)::String
+    return GC.@preserve fielddefn GDAL.ogr_fld_getnameref(fielddefn.ptr)
+end
 
 "Fetch the type of this field."
-gettype(fielddefn::AbstractFieldDefn)::OGRFieldType =
-    GDAL.ogr_fld_gettype(fielddefn.ptr)
+function gettype(fielddefn::AbstractFieldDefn)::OGRFieldType
+    return GC.@preserve fielddefn GDAL.ogr_fld_gettype(fielddefn.ptr)
+end
 
 "Set the type of this field."
 function settype!(fielddefn::FieldDefn, etype::OGRFieldType)::FieldDefn
-    GDAL.ogr_fld_settype(fielddefn.ptr, etype)
+    GC.@preserve fielddefn GDAL.ogr_fld_settype(fielddefn.ptr, etype)
     return fielddefn
 end
 
@@ -51,8 +53,9 @@ Fetch subtype of this field.
 ### Returns
 field subtype.
 """
-getsubtype(fielddefn::AbstractFieldDefn)::OGRFieldSubType =
-    GDAL.ogr_fld_getsubtype(fielddefn.ptr)
+function getsubtype(fielddefn::AbstractFieldDefn)::OGRFieldSubType
+    return GC.@preserve fielddefn GDAL.ogr_fld_getsubtype(fielddefn.ptr)
+end
 
 """
     setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)
@@ -70,7 +73,7 @@ OGRFeatureDefn.
 * https://gdal.org/development/rfc/rfc50_ogr_field_subtype.html
 """
 function setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)::FieldDefn
-    GDAL.ogr_fld_setsubtype(fielddefn.ptr, subtype)
+    GC.@preserve fielddefn GDAL.ogr_fld_setsubtype(fielddefn.ptr, subtype)
     return fielddefn
 end
 
@@ -106,8 +109,9 @@ Get the justification for this field.
 
 Note: no driver is know to use the concept of field justification.
 """
-getjustify(fielddefn::AbstractFieldDefn)::OGRJustification =
-    GDAL.ogr_fld_getjustify(fielddefn.ptr)
+function getjustify(fielddefn::AbstractFieldDefn)::OGRJustification
+    GC.@preserve fielddefn GDAL.ogr_fld_getjustify(fielddefn.ptr)
+end
 
 """
     setjustify!(fielddefn::FieldDefn, ejustify::OGRJustification)
@@ -120,7 +124,7 @@ function setjustify!(
     fielddefn::FieldDefn,
     ejustify::OGRJustification,
 )::FieldDefn
-    GDAL.ogr_fld_setjustify(fielddefn.ptr, ejustify)
+    GC.@preserve fielddefn GDAL.ogr_fld_setjustify(fielddefn.ptr, ejustify)
     return fielddefn
 end
 
@@ -132,8 +136,9 @@ Get the formatting width for this field.
 ### Returns
 the width, zero means no specified width.
 """
-getwidth(fielddefn::AbstractFieldDefn)::Integer =
-    GDAL.ogr_fld_getwidth(fielddefn.ptr)
+function getwidth(fielddefn::AbstractFieldDefn)::Integer
+    return GC.@preserve fielddefn GDAL.ogr_fld_getwidth(fielddefn.ptr)
+end
 
 """
     setwidth!(fielddefn::FieldDefn, width::Integer)
@@ -144,7 +149,7 @@ This should never be done to an OGRFieldDefn that is already part of an
 OGRFeatureDefn.
 """
 function setwidth!(fielddefn::FieldDefn, width::Integer)::FieldDefn
-    GDAL.ogr_fld_setwidth(fielddefn.ptr, width)
+    GC.@preserve fielddefn GDAL.ogr_fld_setwidth(fielddefn.ptr, width)
     return fielddefn
 end
 
@@ -155,8 +160,9 @@ Get the formatting precision for this field.
 
 This should normally be zero for fields of types other than OFTReal.
 """
-getprecision(fielddefn::AbstractFieldDefn)::Integer =
-    GDAL.ogr_fld_getprecision(fielddefn.ptr)
+function getprecision(fielddefn::AbstractFieldDefn)::Integer
+    return GC.@preserve fielddefn GDAL.ogr_fld_getprecision(fielddefn.ptr)
+end
 
 """
     setprecision!(fielddefn::FieldDefn, precision::Integer)
@@ -166,7 +172,7 @@ Set the formatting precision for this field in characters.
 This should normally be zero for fields of types other than OFTReal.
 """
 function setprecision!(fielddefn::FieldDefn, precision::Integer)::FieldDefn
-    GDAL.ogr_fld_setprecision(fielddefn.ptr, precision)
+    GC.@preserve fielddefn GDAL.ogr_fld_setprecision(fielddefn.ptr, precision)
     return fielddefn
 end
 
@@ -191,7 +197,9 @@ function setparams!(
     nprecision::Integer = 0,
     justify::OGRJustification = OJUndefined,
 )::FieldDefn
-    GDAL.ogr_fld_set(fielddefn.ptr, name, etype, nwidth, nprecision, justify)
+    GC.@preserve fielddefn begin
+        GDAL.ogr_fld_set(fielddefn.ptr, name, etype, nwidth, nprecision, justify)
+    end
     return fielddefn
 end
 
@@ -200,8 +208,9 @@ end
 
 Return whether this field should be omitted when fetching features.
 """
-isignored(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isignored(fielddefn.ptr))
+function isignored(fielddefn::AbstractFieldDefn)::Bool
+    return GC.@preserve fielddefn Bool(GDAL.ogr_fld_isignored(fielddefn.ptr))
+end
 
 """
     setignored!(fielddefn::FieldDefn, ignore::Bool)
@@ -228,8 +237,9 @@ OGRLayer::CreateFeature()/SetFeature() is called.
 ### References
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
-isnullable(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isnullable(fielddefn.ptr))
+function isnullable(fielddefn::AbstractFieldDefn)::Bool
+    return GC.@preserve fielddefn Bool(GDAL.ogr_fld_isnullable(fielddefn.ptr))
+end
 
 """
     setnullable!(fielddefn::FieldDefn, nullable::Bool)
@@ -249,7 +259,7 @@ function setnullable!(
     fielddefn::T,
     nullable::Bool,
 )::T where {T<:AbstractFieldDefn}
-    GDAL.ogr_fld_setnullable(fielddefn.ptr, nullable)
+    GC.@preserve fielddefn GDAL.ogr_fld_setnullable(fielddefn.ptr, nullable)
     return fielddefn
 end
 
@@ -262,7 +272,7 @@ Get default field value
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
 function getdefault(fielddefn::AbstractFieldDefn)::Union{String,Nothing}
-    result =
+    GC.@preserve fielddefn result =
         @gdal(OGR_Fld_GetDefault::Cstring, fielddefn.ptr::GDAL.OGRFieldDefnH)
     return if result == C_NULL
         nothing
@@ -297,7 +307,7 @@ GDAL_DCAP_DEFAULT_FIELDS driver metadata item.
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
 function setdefault!(fielddefn::T, default)::T where {T<:AbstractFieldDefn}
-    GDAL.ogr_fld_setdefault(fielddefn.ptr, default)
+    GC.@preserve fielddefn GDAL.ogr_fld_setdefault(fielddefn.ptr, default)
     return fielddefn
 end
 
@@ -313,8 +323,11 @@ CURRENT_TIME, CURRENT_DATE or datetime literal value.
 ### References
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
-isdefaultdriverspecific(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isdefaultdriverspecific(fielddefn.ptr))
+function isdefaultdriverspecific(fielddefn::AbstractFieldDefn)::Bool
+    return GC.@preserve fielddefn begin
+        Bool(GDAL.ogr_fld_isdefaultdriverspecific(fielddefn.ptr))
+    end
+end
 
 """
     unsafe_creategeomdefn(name::AbstractString, etype::OGRwkbGeometryType)
@@ -405,8 +418,10 @@ function setspatialref!(
     spatialref::AbstractSpatialRef,
 )::GeomFieldDefn
     clonespatialref = clone(spatialref)
-    GDAL.ogr_gfld_setspatialref(geomdefn.ptr, clonespatialref.ptr)
-    geomdefn.spatialref = clonespatialref
+    GC.@preserve geomdefn clonespatialref begin
+        GDAL.ogr_gfld_setspatialref(geomdefn.ptr, clonespatialref.ptr)
+        geomdefn.spatialref = clonespatialref
+    end
     return geomdefn
 end
 
@@ -424,8 +439,9 @@ OGRLayer::CreateFeature()/SetFeature() is called.
 
 Note that not-nullable geometry fields might also contain 'empty' geometries.
 """
-isnullable(geomdefn::AbstractGeomFieldDefn)::Bool =
-    Bool(GDAL.ogr_gfld_isnullable(geomdefn.ptr))
+function isnullable(geomdefn::AbstractGeomFieldDefn)::Bool
+    return GC.@preserve geomdefn Bool(GDAL.ogr_gfld_isnullable(geomdefn.ptr))
+end
 
 """
     setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)
@@ -439,7 +455,7 @@ Drivers that support writing not-null constraint will advertize the
 GDAL_DCAP_NOTNULL_GEOMFIELDS driver metadata item.
 """
 function setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)::GeomFieldDefn
-    GDAL.ogr_gfld_setnullable(geomdefn.ptr, nullable)
+    GC.@preserve geomdefn GDAL.ogr_gfld_setnullable(geomdefn.ptr, nullable)
     return geomdefn
 end
 
@@ -448,8 +464,9 @@ end
 
 Return whether this field should be omitted when fetching features.
 """
-isignored(geomdefn::AbstractGeomFieldDefn)::Bool =
-    Bool(GDAL.ogr_gfld_isignored(geomdefn.ptr))
+function isignored(geomdefn::AbstractGeomFieldDefn)::Bool
+    return GC.@preserve geomdefn Bool(GDAL.ogr_gfld_isignored(geomdefn.ptr))
+end
 
 """
     setignored!(geomdefn::GeomFieldDefn, ignore::Bool)

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -117,7 +117,7 @@ import ArchGDAL as AG
                 AG.getoverview(destband, 0) do overview
                     return AG.regenerateoverviews!(
                         destband,
-                        ArchGDAL.AbstractRasterBand{UInt8}[
+                        AG.AbstractRasterBand{UInt8}[
                             overview,
                             AG.getoverview(destband, 2),
                         ],

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -273,10 +273,9 @@ using Tables
                         # Add geom and field defn
                         AG.addfielddefn!(newlayer, "id", AG.OFTInteger64)
                         AG.addfielddefn!(newlayer, "name", AG.OFTString)
-                        featuredefn = AG.layerdefn(newlayer)
-                        id_idx = AG.findfieldindex(featuredefn, "id")
+                        id_idx = AG.findfieldindex(AG.layerdefn(newlayer), "id")
                         name_idx =
-                            AG.findfieldindex(featuredefn, "name")
+                            AG.findfieldindex(AG.layerdefn(newlayer), "name")
                         # Add features
                         AG.addfeature(newlayer) do newfeature
                             AG.setfield!(newfeature, id_idx, 1)

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -273,9 +273,10 @@ using Tables
                         # Add geom and field defn
                         AG.addfielddefn!(newlayer, "id", AG.OFTInteger64)
                         AG.addfielddefn!(newlayer, "name", AG.OFTString)
-                        id_idx = AG.findfieldindex(AG.layerdefn(newlayer), "id")
+                        featuredefn = AG.layerdefn(newlayer)
+                        id_idx = AG.findfieldindex(featuredefn, "id")
                         name_idx =
-                            AG.findfieldindex(AG.layerdefn(newlayer), "name")
+                            AG.findfieldindex(featuredefn, "name")
                         # Add features
                         AG.addfeature(newlayer) do newfeature
                             AG.setfield!(newfeature, id_idx, 1)

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -29,8 +29,8 @@ import ImageCore
 
             # Manual defined convert for Enums
             @enum TestEnum::Bool EnumValue = false
-            @test convert(ArchGDAL.OGRFieldType, TestEnum) == AG.OFTInteger
-            @test convert(ArchGDAL.OGRFieldSubType, TestEnum) == AG.OFSTBoolean
+            @test convert(AG.OGRFieldType, TestEnum) == AG.OFTInteger
+            @test convert(AG.OGRFieldSubType, TestEnum) == AG.OFSTBoolean
         end
     end
 


### PR DESCRIPTION
It seems that the featuredefinition was finalized too soon. This seems to be fine, also works if I put a GC in between. Edit: no, see below, basically we need `f(obj.ptr)` to `GC.@preserve obj f(obj.ptr)` everywhere.

Partially fixes #347, let's close that and remove ArchGDAL from the PkgEval exceptions when all tests are working again in nightly.