### PR TITLE
let ccall get the pointers using unsafe_convert

### DIFF
--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -45,7 +45,7 @@ mutable struct RasterBand <: AbstractRasterBand
 end
 
 unsafe_getband(dataset::AbstractDataset, i::Integer) =
-    RasterBand(GDAL.getrasterband(dataset.ptr, i))
+    RasterBand(GDAL.getrasterband(dataset, i))
 
 function destroy(rb::AbstractRasterBand)
     rb.ptr = C_NULL
@@ -79,7 +79,7 @@ mutable struct IRasterBand <: AbstractRasterBand
 end
 
 getband(dataset::AbstractDataset, i::Integer) =
-    IRasterBand(GDAL.getrasterband(dataset.ptr, i), ownedby = dataset)
+    IRasterBand(GDAL.getrasterband(dataset, i), ownedby = dataset)
 
 function destroy(rasterband::IRasterBand)
     rasterband.ptr = C_NULL

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -4,7 +4,7 @@ function Base.iterate(
 )::Union{Nothing,Tuple{IFeature,Int64}}
     layer.ptr == C_NULL && return nothing
     state == 0 && resetreading!(layer)
-    ptr = GDAL.ogr_l_getnextfeature(layer.ptr)
+    ptr = GDAL.ogr_l_getnextfeature(layer)
     return if ptr == C_NULL
         resetreading!(layer)
         nothing

--- a/src/driver.jl
+++ b/src/driver.jl
@@ -18,7 +18,7 @@ getdriver(name::AbstractString)::Driver = Driver(GDAL.gdalgetdriverbyname(name))
 Register a driver for use.
 """
 function register(drv::Driver)::Nothing
-    GDAL.gdalregisterdriver(drv.ptr)
+    GDAL.gdalregisterdriver(drv)
     return nothing
 end
 
@@ -28,7 +28,7 @@ end
 Deregister the passed driver.
 """
 function deregister(drv::Driver)::Nothing
-    GDAL.gdalderegisterdriver(drv.ptr)
+    GDAL.gdalderegisterdriver(drv)
     return nothing
 end
 
@@ -37,7 +37,7 @@ end
 
 Return the list of creation options of the driver [an XML string].
 """
-options(drv::Driver)::String = GDAL.gdalgetdrivercreationoptionlist(drv.ptr)
+options(drv::Driver)::String = GDAL.gdalgetdrivercreationoptionlist(drv)
 
 driveroptions(name::AbstractString)::String = options(getdriver(name))
 
@@ -46,14 +46,14 @@ driveroptions(name::AbstractString)::String = options(getdriver(name))
 
 Return the short name of a driver (e.g. `GTiff`).
 """
-shortname(drv::Driver)::String = GDAL.gdalgetdrivershortname(drv.ptr)
+shortname(drv::Driver)::String = GDAL.gdalgetdrivershortname(drv)
 
 """
     longname(drv::Driver)
 
 Return the long name of a driver (e.g. `GeoTIFF`), or empty string.
 """
-longname(drv::Driver)::String = GDAL.gdalgetdriverlongname(drv.ptr)
+longname(drv::Driver)::String = GDAL.gdalgetdriverlongname(drv)
 
 """
     ndriver()
@@ -116,7 +116,7 @@ function validate(
     drv::Driver,
     options::Vector{T},
 )::Bool where {T<:AbstractString}
-    return Bool(GDAL.gdalvalidatecreationoptions(drv.ptr, options))
+    return Bool(GDAL.gdalvalidatecreationoptions(drv, options))
 end
 
 """
@@ -132,7 +132,7 @@ function copyfiles(
     new::AbstractString,
     old::AbstractString,
 )::Nothing
-    result = GDAL.gdalcopydatasetfiles(drv.ptr, new, old)
+    result = GDAL.gdalcopydatasetfiles(drv, new, old)
     @cplerr result "Failed to copy dataset files"
     return nothing
 end
@@ -168,7 +168,7 @@ end
 
 """
     extensiondriver(filename::AbstractString)
- 
+
 Returns a driver shortname that matches the filename extension.
 
 So `extensiondriver("/my/file.tif") == "GTiff"`.

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -7,7 +7,7 @@ The newly created feature is owned by the caller, and will have its own
 reference to the OGRFeatureDefn.
 """
 unsafe_clone(feature::AbstractFeature)::AbstractFeature =
-    Feature(GDAL.ogr_f_clone(feature.ptr))
+    Feature(GDAL.ogr_f_clone(feature))
 
 """
     destroy(feature::AbstractFeature)
@@ -21,7 +21,7 @@ application the memory will be freed onto the application heap which is
 inappropriate.
 """
 function destroy(feature::AbstractFeature)::Nothing
-    GDAL.ogr_f_destroy(feature.ptr)
+    GDAL.ogr_f_destroy(feature)
     feature.ptr = C_NULL
     return nothing
 end
@@ -47,7 +47,7 @@ function setgeom!(
     feature::AbstractFeature,
     geom::AbstractGeometry,
 )::AbstractFeature
-    result = GDAL.ogr_f_setgeometry(feature.ptr, geom.ptr)
+    result = GDAL.ogr_f_setgeometry(feature, geom)
     @ogrerr result "OGRErr $result: Failed to set feature geometry."
     return feature
 end
@@ -58,7 +58,7 @@ end
 Returns a clone of the geometry corresponding to the feature.
 """
 function getgeom(feature::AbstractFeature)::IGeometry
-    result = GDAL.ogr_f_getgeometryref(feature.ptr)
+    result = GDAL.ogr_f_getgeometryref(feature)
     return if result == C_NULL
         IGeometry()
     else
@@ -67,7 +67,7 @@ function getgeom(feature::AbstractFeature)::IGeometry
 end
 
 function unsafe_getgeom(feature::AbstractFeature)::Geometry
-    result = GDAL.ogr_f_getgeometryref(feature.ptr)
+    result = GDAL.ogr_f_getgeometryref(feature)
     return if result == C_NULL
         Geometry()
     else
@@ -83,7 +83,7 @@ Fetch number of fields on this feature.
 This will always be the same as the field count for the OGRFeatureDefn.
 """
 nfield(feature::AbstractFeature)::Integer =
-    GDAL.ogr_f_getfieldcount(feature.ptr)
+    GDAL.ogr_f_getfieldcount(feature)
 
 """
     keys(feature::AbstractFeature)
@@ -117,7 +117,7 @@ an handle to the field definition (from the `FeatureDefn`). This is an
 internal reference, and should not be deleted or modified.
 """
 getfielddefn(feature::AbstractFeature, i::Integer)::IFieldDefnView =
-    IFieldDefnView(GDAL.ogr_f_getfielddefnref(feature.ptr, i))
+    IFieldDefnView(GDAL.ogr_f_getfielddefnref(feature, i))
 
 """
     findfieldindex(feature::AbstractFeature, name::Union{AbstractString, Symbol})
@@ -138,7 +138,7 @@ function findfieldindex(
     feature::AbstractFeature,
     name::Union{AbstractString,Symbol},
 )::Union{Integer,Nothing}
-    i = GDAL.ogr_f_getfieldindex(feature.ptr, name)
+    i = GDAL.ogr_f_getfieldindex(feature, name)
     return if i == -1
         nothing
     else
@@ -156,7 +156,7 @@ Test if a field has ever been assigned a value or not.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 isfieldset(feature::AbstractFeature, i::Integer)::Bool =
-    Bool(GDAL.ogr_f_isfieldset(feature.ptr, i))
+    Bool(GDAL.ogr_f_isfieldset(feature, i))
 
 """
     unsetfield!(feature::AbstractFeature, i::Integer)
@@ -168,7 +168,7 @@ Clear a field, marking it as unset.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 function unsetfield!(feature::AbstractFeature, i::Integer)::AbstractFeature
-    GDAL.ogr_f_unsetfield(feature.ptr, i)
+    GDAL.ogr_f_unsetfield(feature, i)
     return feature
 end
 
@@ -188,7 +188,7 @@ Test if a field is null.
 * https://gdal.org/development/rfc/rfc67_nullfieldvalues.html
 """
 isfieldnull(feature::AbstractFeature, i::Integer)::Bool =
-    Bool(GDAL.ogr_f_isfieldnull(feature.ptr, i))
+    Bool(GDAL.ogr_f_isfieldnull(feature, i))
 
 """
     isfieldsetandnotnull(feature::AbstractFeature, i::Integer)
@@ -206,7 +206,7 @@ Test if a field is set and not null.
 * https://gdal.org/development/rfc/rfc67_nullfieldvalues.html
 """
 isfieldsetandnotnull(feature::AbstractFeature, i::Integer)::Bool =
-    Bool(GDAL.ogr_f_isfieldsetandnotnull(feature.ptr, i))
+    Bool(GDAL.ogr_f_isfieldsetandnotnull(feature, i))
 
 """
     setfieldnull!(feature::AbstractFeature, i::Integer)
@@ -221,7 +221,7 @@ Clear a field, marking it as null.
 * https://gdal.org/development/rfc/rfc67_nullfieldvalues.html
 """
 function setfieldnull!(feature::AbstractFeature, i::Integer)::AbstractFeature
-    GDAL.ogr_f_setfieldnull(feature.ptr, i)
+    GDAL.ogr_f_setfieldnull(feature, i)
     return feature
 end
 
@@ -251,7 +251,7 @@ Fetch field value as a boolean
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asbool(feature::AbstractFeature, i::Integer)::Bool =
-    convert(Bool, GDAL.ogr_f_getfieldasinteger(feature.ptr, i))
+    convert(Bool, GDAL.ogr_f_getfieldasinteger(feature, i))
 
 """
     asint16(feature::AbstractFeature, i::Integer)
@@ -263,7 +263,7 @@ Fetch field value as integer 16 bit.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asint16(feature::AbstractFeature, i::Integer)::Int16 =
-    convert(Int16, GDAL.ogr_f_getfieldasinteger(feature.ptr, i))
+    convert(Int16, GDAL.ogr_f_getfieldasinteger(feature, i))
 
 """
     asint(feature::AbstractFeature, i::Integer)
@@ -275,7 +275,7 @@ Fetch field value as integer.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asint(feature::AbstractFeature, i::Integer)::Int32 =
-    GDAL.ogr_f_getfieldasinteger(feature.ptr, i)
+    GDAL.ogr_f_getfieldasinteger(feature, i)
 
 """
     asint64(feature::AbstractFeature, i::Integer)
@@ -287,7 +287,7 @@ Fetch field value as integer 64 bit.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asint64(feature::AbstractFeature, i::Integer)::Int64 =
-    GDAL.ogr_f_getfieldasinteger64(feature.ptr, i)
+    GDAL.ogr_f_getfieldasinteger64(feature, i)
 
 """
 assingle(feature::AbstractFeature, i::Integer)
@@ -299,7 +299,7 @@ Fetch field value as a single.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 assingle(feature::AbstractFeature, i::Integer)::Float32 =
-    convert(Float32, GDAL.ogr_f_getfieldasdouble(feature.ptr, i))
+    convert(Float32, GDAL.ogr_f_getfieldasdouble(feature, i))
 
 """
     asdouble(feature::AbstractFeature, i::Integer)
@@ -311,7 +311,7 @@ Fetch field value as a double.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asdouble(feature::AbstractFeature, i::Integer)::Float64 =
-    GDAL.ogr_f_getfieldasdouble(feature.ptr, i)
+    GDAL.ogr_f_getfieldasdouble(feature, i)
 
 """
     asstring(feature::AbstractFeature, i::Integer)
@@ -323,7 +323,7 @@ Fetch field value as a string.
 * `i`: the field to fetch, from 0 to GetFieldCount()-1.
 """
 asstring(feature::AbstractFeature, i::Integer)::String =
-    GDAL.ogr_f_getfieldasstring(feature.ptr, i)
+    GDAL.ogr_f_getfieldasstring(feature, i)
 
 """
     asintlist(feature::AbstractFeature, i::Integer)
@@ -342,7 +342,7 @@ pointer may be NULL or non-NULL.
 """
 function asintlist(feature::AbstractFeature, i::Integer)::Vector{Int32}
     n = Ref{Cint}()
-    ptr = GDAL.ogr_f_getfieldasintegerlist(feature.ptr, i, n)
+    ptr = GDAL.ogr_f_getfieldasintegerlist(feature, i, n)
     return (n.x == 0) ? Int32[] : unsafe_wrap(Vector{Int32}, ptr, n.x)
 end
 
@@ -363,7 +363,7 @@ pointer may be NULL or non-NULL.
 """
 function asint64list(feature::AbstractFeature, i::Integer)::Vector{Int64}
     n = Ref{Cint}()
-    ptr = GDAL.ogr_f_getfieldasinteger64list(feature.ptr, i, n)
+    ptr = GDAL.ogr_f_getfieldasinteger64list(feature, i, n)
     return (n.x == 0) ? Int64[] : unsafe_wrap(Vector{Int64}, ptr, n.x)
 end
 
@@ -384,7 +384,7 @@ pointer may be NULL or non-NULL.
 """
 function asdoublelist(feature::AbstractFeature, i::Integer)::Vector{Float64}
     n = Ref{Cint}()
-    ptr = GDAL.ogr_f_getfieldasdoublelist(feature.ptr, i, n)
+    ptr = GDAL.ogr_f_getfieldasdoublelist(feature, i, n)
     return (n.x == 0) ? Float64[] : unsafe_wrap(Vector{Float64}, ptr, n.x)
 end
 
@@ -402,7 +402,7 @@ the field value. This list is internal, and should not be modified, or freed.
 Its lifetime may be very brief.
 """
 asstringlist(feature::AbstractFeature, i::Integer)::Vector{String} =
-    GDAL.ogr_f_getfieldasstringlist(feature.ptr, i)
+    GDAL.ogr_f_getfieldasstringlist(feature, i)
 
 """
     asbinary(feature::AbstractFeature, i::Integer)
@@ -419,7 +419,7 @@ Its lifetime may be very brief.
 """
 function asbinary(feature::AbstractFeature, i::Integer)::Vector{UInt8}
     n = Ref{Cint}()
-    ptr = GDAL.ogr_f_getfieldasbinary(feature.ptr, i, n)
+    ptr = GDAL.ogr_f_getfieldasbinary(feature, i, n)
     return (n.x == 0) ? UInt8[] : unsafe_wrap(Vector{UInt8}, ptr, n.x)
 end
 
@@ -446,7 +446,7 @@ function asdatetime(feature::AbstractFeature, i::Integer)::DateTime
     ptz = Ref{Cint}()
     result = Bool(
         GDAL.ogr_f_getfieldasdatetime(
-            feature.ptr,
+            feature,
             i,
             pyr,
             pmth,
@@ -604,7 +604,7 @@ function setfield!(
     i::Integer,
     value::Union{Bool,UInt8,Int8,UInt16,Int16,Int32},
 )::AbstractFeature
-    GDAL.ogr_f_setfieldinteger(feature.ptr, i, value)
+    GDAL.ogr_f_setfieldinteger(feature, i, value)
     return feature
 end
 
@@ -613,7 +613,7 @@ function setfield!(
     i::Integer,
     value::Union{UInt32,Int64},
 )::AbstractFeature
-    GDAL.ogr_f_setfieldinteger64(feature.ptr, i, value)
+    GDAL.ogr_f_setfieldinteger64(feature, i, value)
     return feature
 end
 
@@ -630,7 +630,7 @@ function setfield!(
     i::Integer,
     value::Union{Float16,Float32,Float64},
 )::AbstractFeature
-    GDAL.ogr_f_setfielddouble(feature.ptr, i, value)
+    GDAL.ogr_f_setfielddouble(feature, i, value)
     return feature
 end
 
@@ -639,7 +639,7 @@ function setfield!(
     i::Integer,
     value::AbstractString,
 )::AbstractFeature
-    GDAL.ogr_f_setfieldstring(feature.ptr, i, value)
+    GDAL.ogr_f_setfieldstring(feature, i, value)
     return feature
 end
 
@@ -648,7 +648,7 @@ function setfield!(
     i::Integer,
     value::Vector{Int32},
 )::AbstractFeature
-    GDAL.ogr_f_setfieldintegerlist(feature.ptr, i, length(value), value)
+    GDAL.ogr_f_setfieldintegerlist(feature, i, length(value), value)
     return feature
 end
 
@@ -657,7 +657,7 @@ function setfield!(
     i::Integer,
     value::Vector{Int64},
 )::AbstractFeature
-    GDAL.ogr_f_setfieldinteger64list(feature.ptr, i, length(value), value)
+    GDAL.ogr_f_setfieldinteger64list(feature, i, length(value), value)
     return feature
 end
 
@@ -666,7 +666,7 @@ function setfield!(
     i::Integer,
     value::Vector{Float64},
 )::AbstractFeature
-    GDAL.ogr_f_setfielddoublelist(feature.ptr, i, length(value), value)
+    GDAL.ogr_f_setfielddoublelist(feature, i, length(value), value)
     return feature
 end
 
@@ -675,7 +675,7 @@ function setfield!(
     i::Integer,
     value::Vector{T},
 )::AbstractFeature where {T<:AbstractString}
-    GDAL.ogr_f_setfieldstringlist(feature.ptr, i, value)
+    GDAL.ogr_f_setfieldstringlist(feature, i, value)
     return feature
 end
 
@@ -699,7 +699,7 @@ function setfield!(
     i::Integer,
     value::Vector{UInt8},
 )::AbstractFeature
-    GDAL.ogr_f_setfieldbinary(feature.ptr, i, sizeof(value), value)
+    GDAL.ogr_f_setfieldbinary(feature, i, sizeof(value), value)
     return feature
 end
 
@@ -710,7 +710,7 @@ function setfield!(
     tzflag::Int = 0,
 )::AbstractFeature
     GDAL.ogr_f_setfielddatetime(
-        feature.ptr,
+        feature,
         i,
         Dates.year(dt),
         Dates.month(dt),
@@ -731,7 +731,7 @@ Fetch number of geometry fields on this feature.
 This will always be the same as the geometry field count for OGRFeatureDefn.
 """
 ngeom(feature::AbstractFeature)::Integer =
-    GDAL.ogr_f_getgeomfieldcount(feature.ptr)
+    GDAL.ogr_f_getgeomfieldcount(feature)
 
 """
     getgeomdefn(feature::AbstractFeature, i::Integer)
@@ -747,7 +747,7 @@ The field definition (from the OGRFeatureDefn). This is an
 internal reference, and should not be deleted or modified.
 """
 function getgeomdefn(feature::AbstractFeature, i::Integer)::IGeomFieldDefnView
-    return IGeomFieldDefnView(GDAL.ogr_f_getgeomfielddefnref(feature.ptr, i))
+    return IGeomFieldDefnView(GDAL.ogr_f_getgeomfielddefnref(feature, i))
 end
 
 """
@@ -769,7 +769,7 @@ function findgeomindex(
     feature::AbstractFeature,
     name::Union{AbstractString,Symbol} = "",
 )::Integer
-    return GDAL.ogr_f_getgeomfieldindex(feature.ptr, name)
+    return GDAL.ogr_f_getgeomfieldindex(feature, name)
 end
 
 """
@@ -782,7 +782,7 @@ Returns a clone of the feature geometry at index `i`.
 * `i`: geometry field to get.
 """
 function getgeom(feature::AbstractFeature, i::Integer)::IGeometry
-    result = GDAL.ogr_f_getgeomfieldref(feature.ptr, i)
+    result = GDAL.ogr_f_getgeomfieldref(feature, i)
     return if result == C_NULL
         IGeometry()
     else
@@ -791,7 +791,7 @@ function getgeom(feature::AbstractFeature, i::Integer)::IGeometry
 end
 
 function unsafe_getgeom(feature::AbstractFeature, i::Integer)::Geometry
-    result = GDAL.ogr_f_getgeomfieldref(feature.ptr, i)
+    result = GDAL.ogr_f_getgeomfieldref(feature, i)
     return if result == C_NULL
         Geometry()
     else
@@ -846,7 +846,7 @@ function setgeom!(
     i::Integer,
     geom::AbstractGeometry,
 )::AbstractFeature
-    result = GDAL.ogr_f_setgeomfield(feature.ptr, i, geom.ptr)
+    result = GDAL.ogr_f_setgeomfield(feature, i, geom)
     @ogrerr result "OGRErr $result: Failed to set feature geometry"
     return feature
 end
@@ -859,7 +859,7 @@ Get feature identifier.
 ### Returns
 feature id or `OGRNullFID` (`-1`) if none has been assigned.
 """
-getfid(feature::AbstractFeature) = GDAL.ogr_f_getfid(feature.ptr)::Integer
+getfid(feature::AbstractFeature) = GDAL.ogr_f_getfid(feature)::Integer
 
 """
     setfid!(feature::AbstractFeature, i::Integer)
@@ -874,7 +874,7 @@ Set the feature identifier.
 On success OGRERR_NONE, or on failure some other value.
 """
 function setfid!(feature::AbstractFeature, i::Integer)::AbstractFeature
-    result = GDAL.ogr_f_setfid(feature.ptr, i)
+    result = GDAL.ogr_f_setfid(feature, i)
     @ogrerr result "OGRErr $result: Failed to set FID $i"
     return feature
 end
@@ -908,7 +908,7 @@ function setfrom!(
     feature2::AbstractFeature,
     forgiving::Bool = false,
 )::AbstractFeature
-    result = GDAL.ogr_f_setfrom(feature1.ptr, feature2.ptr, forgiving)
+    result = GDAL.ogr_f_setfrom(feature1, feature2, forgiving)
     @ogrerr result "OGRErr $result: Failed to set feature"
     return feature1
 end
@@ -920,8 +920,8 @@ function setfrom!(
     forgiving::Bool = false,
 )::AbstractFeature
     result = GDAL.ogr_f_setfromwithmap(
-        feature1.ptr,
-        feature2.ptr,
+        feature1,
+        feature2,
         forgiving,
         indices,
     )
@@ -935,7 +935,7 @@ end
 Fetch style string for this feature.
 """
 getstylestring(feature::AbstractFeature)::String =
-    GDAL.ogr_f_getstylestring(feature.ptr)
+    GDAL.ogr_f_getstylestring(feature)
 
 """
     setstylestring!(feature::AbstractFeature, style::AbstractString)
@@ -949,7 +949,7 @@ function setstylestring!(
     feature::AbstractFeature,
     style::AbstractString,
 )::AbstractFeature
-    GDAL.ogr_f_setstylestring(feature.ptr, style)
+    GDAL.ogr_f_setstylestring(feature, style)
     return feature
 end
 
@@ -959,7 +959,7 @@ end
 Fetch style table for this feature.
 """
 getstyletable(feature::AbstractFeature)::StyleTable =
-    StyleTable(GDAL.ogr_f_getstyletable(feature.ptr))
+    StyleTable(GDAL.ogr_f_getstyletable(feature))
 
 """
     setstyletable!(feature::AbstractFeature, styletable::StyleTable)
@@ -970,7 +970,7 @@ function setstyletable!(
     feature::AbstractFeature,
     styletable::StyleTable,
 )::AbstractFeature
-    GDAL.ogr_f_setstyletable(feature.ptr, styletable.ptr)
+    GDAL.ogr_f_setstyletable(feature, styletable)
     return feature
 end
 
@@ -994,7 +994,7 @@ round-tripping scenarios where some characteristics of the underlying format
 are not captured otherwise by the OGR abstraction.
 """
 getnativedata(feature::AbstractFeature)::String =
-    GDAL.ogr_f_getnativedata(feature.ptr)
+    GDAL.ogr_f_getnativedata(feature)
 
 """
     setnativedata!(feature::AbstractFeature, data::AbstractString)
@@ -1010,7 +1010,7 @@ function setnativedata!(
     feature::AbstractFeature,
     data::AbstractString,
 )::AbstractFeature
-    GDAL.ogr_f_setnativedata(feature.ptr, data)
+    GDAL.ogr_f_setnativedata(feature, data)
     return feature
 end
 
@@ -1024,7 +1024,7 @@ follows the IANA RFC 2045 (see https://en.wikipedia.org/wiki/Media_type),
 e.g. \"application/vnd.geo+json\" for JSON.
 """
 getmediatype(feature::AbstractFeature)::String =
-    GDAL.ogr_f_getnativemediatype(feature.ptr)
+    GDAL.ogr_f_getnativemediatype(feature)
 
 """
     setmediatype!(feature::AbstractFeature, mediatype::AbstractString)
@@ -1039,7 +1039,7 @@ function setmediatype!(
     feature::AbstractFeature,
     mediatype::AbstractString,
 )::AbstractFeature
-    GDAL.ogr_f_setnativemediatype(feature.ptr, mediatype)
+    GDAL.ogr_f_setnativemediatype(feature, mediatype)
     return feature
 end
 
@@ -1062,7 +1062,7 @@ function fillunsetwithdefault!(
     notnull::Bool = true,
     options = StringList(C_NULL),
 )::AbstractFeature
-    GDAL.ogr_f_fillunsetwithdefault(feature.ptr, notnull, options)
+    GDAL.ogr_f_fillunsetwithdefault(feature, notnull, options)
     return feature
 end
 
@@ -1095,4 +1095,4 @@ validate(
     feature::AbstractFeature,
     flags::FieldValidation,
     emiterror::Bool,
-)::Bool = Bool(GDAL.ogr_f_validate(feature.ptr, flags, emiterror))
+)::Bool = Bool(GDAL.ogr_f_validate(feature, flags, emiterror))

--- a/src/ogr/featuredefn.jl
+++ b/src/ogr/featuredefn.jl
@@ -20,7 +20,7 @@ The count is used to track the number of `Feature`s referencing this definition.
 The updated reference count.
 """
 reference(featuredefn::FeatureDefn)::Integer =
-    GDAL.ogr_fd_reference(featuredefn.ptr)
+    GDAL.ogr_fd_reference(featuredefn)
 
 """
     dereference(featuredefn::FeatureDefn)
@@ -28,7 +28,7 @@ reference(featuredefn::FeatureDefn)::Integer =
 Decrements the reference count by one, and returns the updated count.
 """
 dereference(featuredefn::FeatureDefn)::Integer =
-    GDAL.ogr_fd_dereference(featuredefn.ptr)
+    GDAL.ogr_fd_dereference(featuredefn)
 
 """
     nreference(featuredefn::AbstractFeatureDefn)
@@ -36,11 +36,11 @@ dereference(featuredefn::FeatureDefn)::Integer =
 Fetch the current reference count.
 """
 nreference(featuredefn::AbstractFeatureDefn)::Integer =
-    GDAL.ogr_fd_getreferencecount(featuredefn.ptr)
+    GDAL.ogr_fd_getreferencecount(featuredefn)
 
 "Destroy a feature definition object and release all memory associated with it"
 function destroy(featuredefn::FeatureDefn)::Nothing
-    GDAL.ogr_fd_destroy(featuredefn.ptr)
+    GDAL.ogr_fd_destroy(featuredefn)
     featuredefn.ptr = C_NULL
     return nothing
 end
@@ -57,7 +57,7 @@ end
 Drop a reference, and destroy if unreferenced.
 """
 function release(featuredefn::FeatureDefn)::Nothing
-    GDAL.ogr_fd_release(featuredefn.ptr)
+    GDAL.ogr_fd_release(featuredefn)
     return nothing
 end
 
@@ -67,7 +67,7 @@ end
 Get name of the OGRFeatureDefn passed as an argument.
 """
 getname(featuredefn::AbstractFeatureDefn)::String =
-    GDAL.ogr_fd_getname(featuredefn.ptr)
+    GDAL.ogr_fd_getname(featuredefn)
 
 """
     nfield(featuredefn::AbstractFeatureDefn)
@@ -75,7 +75,7 @@ getname(featuredefn::AbstractFeatureDefn)::String =
 Fetch number of fields on the passed feature definition.
 """
 nfield(featuredefn::AbstractFeatureDefn)::Integer =
-    GDAL.ogr_fd_getfieldcount(featuredefn.ptr)
+    GDAL.ogr_fd_getfieldcount(featuredefn)
 
 """
     getfielddefn(featuredefn::FeatureDefn, i::Integer)
@@ -91,10 +91,10 @@ an handle to an internal field definition object or NULL if invalid index. This
 object should not be modified or freed by the application.
 """
 getfielddefn(featuredefn::FeatureDefn, i::Integer)::FieldDefn =
-    FieldDefn(GDAL.ogr_fd_getfielddefn(featuredefn.ptr, i))
+    FieldDefn(GDAL.ogr_fd_getfielddefn(featuredefn, i))
 
 getfielddefn(featuredefn::IFeatureDefnView, i::Integer)::IFieldDefnView =
-    IFieldDefnView(GDAL.ogr_fd_getfielddefn(featuredefn.ptr, i))
+    IFieldDefnView(GDAL.ogr_fd_getfielddefn(featuredefn, i))
 
 """
     findfieldindex(featuredefn::AbstractFeatureDefn,
@@ -112,7 +112,7 @@ function findfieldindex(
     featuredefn::AbstractFeatureDefn,
     name::Union{AbstractString,Symbol},
 )::Integer
-    return GDAL.ogr_fd_getfieldindex(featuredefn.ptr, name)
+    return GDAL.ogr_fd_getfieldindex(featuredefn, name)
 end
 
 """
@@ -131,7 +131,7 @@ function addfielddefn!(
     featuredefn::FeatureDefn,
     fielddefn::FieldDefn,
 )::FeatureDefn
-    GDAL.ogr_fd_addfielddefn(featuredefn.ptr, fielddefn.ptr)
+    GDAL.ogr_fd_addfielddefn(featuredefn, fielddefn)
     return featuredefn
 end
 
@@ -147,7 +147,7 @@ This method should only be called while there are no OGRFeature objects in
 existence based on this OGRFeatureDefn.
 """
 function deletefielddefn!(featuredefn::FeatureDefn, i::Integer)::FeatureDefn
-    result = GDAL.ogr_fd_deletefielddefn(featuredefn.ptr, i)
+    result = GDAL.ogr_fd_deletefielddefn(featuredefn, i)
     @ogrerr result "Failed to delete field $i in the feature definition"
     return featuredefn
 end
@@ -174,7 +174,7 @@ function reorderfielddefns!(
     featuredefn::FeatureDefn,
     indices::Vector{Cint},
 )::FeatureDefn
-    result = GDAL.ogr_fd_reorderfielddefns(featuredefn.ptr, indices)
+    result = GDAL.ogr_fd_reorderfielddefns(featuredefn, indices)
     @ogrerr result "Failed to reorder $indices in the feature definition"
     return featuredefn
 end
@@ -195,7 +195,7 @@ type of the first geometry column. For other columns, use
     `OGR_GFld_GetType(OGR_FD_GetGeomFieldDefn(OGR_L_GetLayerDefn(hLayer), i))`.
 """
 getgeomtype(featuredefn::AbstractFeatureDefn)::OGRwkbGeometryType =
-    GDAL.ogr_fd_getgeomtype(featuredefn.ptr)
+    GDAL.ogr_fd_getgeomtype(featuredefn)
 
 """
     setgeomtype!(featuredefn::FeatureDefn, etype::OGRwkbGeometryType)
@@ -211,7 +211,7 @@ function setgeomtype!(
     featuredefn::FeatureDefn,
     etype::OGRwkbGeometryType,
 )::FeatureDefn
-    GDAL.ogr_fd_setgeomtype(featuredefn.ptr, etype)
+    GDAL.ogr_fd_setgeomtype(featuredefn, etype)
     return featuredefn
 end
 
@@ -221,7 +221,7 @@ end
 Determine whether the geometry can be omitted when fetching features.
 """
 isgeomignored(featuredefn::AbstractFeatureDefn)::Bool =
-    Bool(GDAL.ogr_fd_isgeometryignored(featuredefn.ptr))
+    Bool(GDAL.ogr_fd_isgeometryignored(featuredefn))
 
 """
     setgeomignored!(featuredefn::FeatureDefn, ignore::Bool)
@@ -229,7 +229,7 @@ isgeomignored(featuredefn::AbstractFeatureDefn)::Bool =
 Set whether the geometry can be omitted when fetching features.
 """
 function setgeomignored!(featuredefn::FeatureDefn, ignore::Bool)::FeatureDefn
-    GDAL.ogr_fd_setgeometryignored(featuredefn.ptr, ignore)
+    GDAL.ogr_fd_setgeometryignored(featuredefn, ignore)
     return featuredefn
 end
 
@@ -239,7 +239,7 @@ end
 Determine whether the style can be omitted when fetching features.
 """
 isstyleignored(featuredefn::AbstractFeatureDefn)::Bool =
-    Bool(GDAL.ogr_fd_isstyleignored(featuredefn.ptr))
+    Bool(GDAL.ogr_fd_isstyleignored(featuredefn))
 
 """
     setstyleignored!(featuredefn::FeatureDefn, ignore::Bool)
@@ -247,7 +247,7 @@ isstyleignored(featuredefn::AbstractFeatureDefn)::Bool =
 Set whether the style can be omitted when fetching features.
 """
 function setstyleignored!(featuredefn::FeatureDefn, ignore::Bool)::FeatureDefn
-    GDAL.ogr_fd_setstyleignored(featuredefn.ptr, ignore)
+    GDAL.ogr_fd_setstyleignored(featuredefn, ignore)
     return featuredefn
 end
 
@@ -257,7 +257,7 @@ end
 Fetch number of geometry fields on the passed feature definition.
 """
 ngeom(featuredefn::AbstractFeatureDefn)::Integer =
-    GDAL.ogr_fd_getgeomfieldcount(featuredefn.ptr)
+    GDAL.ogr_fd_getgeomfieldcount(featuredefn)
 
 """
     getgeomdefn(featuredefn::FeatureDefn, i::Integer = 0)
@@ -272,10 +272,10 @@ an internal field definition object or `NULL` if invalid index. This object
 should not be modified or freed by the application.
 """
 getgeomdefn(featuredefn::FeatureDefn, i::Integer = 0)::GeomFieldDefn =
-    GeomFieldDefn(GDAL.ogr_fd_getgeomfielddefn(featuredefn.ptr, i))
+    GeomFieldDefn(GDAL.ogr_fd_getgeomfielddefn(featuredefn, i))
 
 getgeomdefn(featuredefn::IFeatureDefnView, i::Integer = 0)::IGeomFieldDefnView =
-    IGeomFieldDefnView(GDAL.ogr_fd_getgeomfielddefn(featuredefn.ptr, i))
+    IGeomFieldDefnView(GDAL.ogr_fd_getgeomfielddefn(featuredefn, i))
 
 """
     findgeomindex(featuredefn::AbstractFeatureDefn, name::AbstractString = "")
@@ -292,7 +292,7 @@ function findgeomindex(
     featuredefn::AbstractFeatureDefn,
     name::AbstractString = "",
 )::Integer
-    return GDAL.ogr_fd_getgeomfieldindex(featuredefn.ptr, name)
+    return GDAL.ogr_fd_getgeomfieldindex(featuredefn, name)
 end
 
 """
@@ -315,7 +315,7 @@ function addgeomdefn!(
     geomfielddefn::AbstractGeomFieldDefn,
 )::FeatureDefn
     # `geomfielddefn` is copied, and remains the responsibility of the caller.
-    GDAL.ogr_fd_addgeomfielddefn(featuredefn.ptr, geomfielddefn.ptr)
+    GDAL.ogr_fd_addgeomfielddefn(featuredefn, geomfielddefn)
     return featuredefn
 end
 
@@ -331,7 +331,7 @@ This method should only be called while there are no OGRFeature objects in
 existence based on this OGRFeatureDefn.
 """
 function deletegeomdefn!(featuredefn::FeatureDefn, i::Integer)::FeatureDefn
-    result = GDAL.ogr_fd_deletegeomfielddefn(featuredefn.ptr, i)
+    result = GDAL.ogr_fd_deletegeomfielddefn(featuredefn, i)
     @ogrerr result "Failed to delete geom field $i in the feature definition"
     return featuredefn
 end
@@ -345,7 +345,7 @@ function issame(
     featuredefn1::AbstractFeatureDefn,
     featuredefn2::AbstractFeatureDefn,
 )::Bool
-    return Bool(GDAL.ogr_fd_issame(featuredefn1.ptr, featuredefn2.ptr))
+    return Bool(GDAL.ogr_fd_issame(featuredefn1, featuredefn2))
 end
 
 """
@@ -360,7 +360,7 @@ OGRFeatures that depend on it is likely to result in a crash.
 Starting with GDAL 2.1, returns NULL in case out of memory situation.
 """
 function unsafe_createfeature(featuredefn::AbstractFeatureDefn)::Feature
-    return Feature(GDAL.ogr_f_create(featuredefn.ptr))
+    return Feature(GDAL.ogr_f_create(featuredefn))
 end
 
 """
@@ -369,4 +369,4 @@ end
 Fetch feature definition.
 """
 getfeaturedefn(feature::AbstractFeature)::IFeatureDefnView =
-    IFeatureDefnView(GDAL.ogr_f_getdefnref(feature.ptr))
+    IFeatureDefnView(GDAL.ogr_f_getdefnref(feature))

--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -126,7 +126,7 @@ getgeomtype(layer::AbstractFeatureLayer)::OGRwkbGeometryType =
 Returns the current spatial filter for this layer.
 """
 function getspatialfilter(layer::AbstractFeatureLayer)::IGeometry
-    result = GDAL.ogr_l_getspatialfilter(Ptr{Cvoid}(layer))
+    result = GDAL.ogr_l_getspatialfilter(layer)
     return if result == C_NULL
         IGeometry(result)
     else

--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -35,9 +35,9 @@ function createlayer(;
 )::IFeatureLayer
     return IFeatureLayer(
         GDAL.gdaldatasetcreatelayer(
-            dataset.ptr,
+            dataset,
             name,
-            spatialref.ptr,
+            spatialref,
             geom,
             options,
         ),
@@ -55,9 +55,9 @@ function unsafe_createlayer(;
 )::FeatureLayer
     return FeatureLayer(
         GDAL.gdaldatasetcreatelayer(
-            dataset.ptr,
+            dataset,
             name,
-            spatialref.ptr,
+            spatialref,
             geom,
             options,
         ),
@@ -89,7 +89,7 @@ function copy(
     options = StringList(C_NULL),
 )::IFeatureLayer
     return IFeatureLayer(
-        GDAL.gdaldatasetcopylayer(dataset.ptr, layer.ptr, name, options),
+        GDAL.gdaldatasetcopylayer(dataset, layer, name, options),
         ownedby = dataset,
     )
 end
@@ -101,7 +101,7 @@ function unsafe_copy(
     options = StringList(C_NULL),
 )::FeatureLayer
     return FeatureLayer(
-        GDAL.gdaldatasetcopylayer(dataset.ptr, layer.ptr, name, options),
+        GDAL.gdaldatasetcopylayer(dataset, layer, name, options),
     )
 end
 
@@ -110,7 +110,7 @@ end
 
 Return the layer name.
 """
-getname(layer::AbstractFeatureLayer)::String = GDAL.ogr_l_getname(layer.ptr)
+getname(layer::AbstractFeatureLayer)::String = GDAL.ogr_l_getname(layer)
 
 """
     getgeomtype(layer::AbstractFeatureLayer)
@@ -118,7 +118,7 @@ getname(layer::AbstractFeatureLayer)::String = GDAL.ogr_l_getname(layer.ptr)
 Return the layer geometry type.
 """
 getgeomtype(layer::AbstractFeatureLayer)::OGRwkbGeometryType =
-    GDAL.ogr_l_getgeomtype(layer.ptr)
+    GDAL.ogr_l_getgeomtype(layer)
 
 """
     getspatialfilter(layer::AbstractFeatureLayer)
@@ -126,7 +126,7 @@ getgeomtype(layer::AbstractFeatureLayer)::OGRwkbGeometryType =
 Returns the current spatial filter for this layer.
 """
 function getspatialfilter(layer::AbstractFeatureLayer)::IGeometry
-    result = GDAL.ogr_l_getspatialfilter(Ptr{Cvoid}(layer.ptr))
+    result = GDAL.ogr_l_getspatialfilter(Ptr{Cvoid}(layer))
     return if result == C_NULL
         IGeometry(result)
     else
@@ -142,7 +142,7 @@ end
 Returns a clone of the spatial reference system for this layer.
 """
 function getspatialref(layer::AbstractFeatureLayer)::ISpatialRef
-    result = GDAL.ogr_l_getspatialref(layer.ptr)
+    result = GDAL.ogr_l_getspatialref(layer)
     return if result == C_NULL
         ISpatialRef()
     else
@@ -153,7 +153,7 @@ function getspatialref(layer::AbstractFeatureLayer)::ISpatialRef
 end
 
 function unsafe_getspatialref(layer::AbstractFeatureLayer)::SpatialRef
-    result = GDAL.ogr_l_getspatialref(layer.ptr)
+    result = GDAL.ogr_l_getspatialref(layer)
     return if result == C_NULL
         SpatialRef()
     else
@@ -198,12 +198,12 @@ function setspatialfilter!(
 )::L where {L<:AbstractFeatureLayer}
     # This method makes an internal copy of `geom`. The input `geom` remains
     # the responsibility of the caller, and may be safely destroyed.
-    GDAL.ogr_l_setspatialfilter(layer.ptr, geom.ptr)
+    GDAL.ogr_l_setspatialfilter(layer, geom)
     return layer
 end
 
 function clearspatialfilter!(layer::L)::L where {L<:AbstractFeatureLayer}
-    GDAL.ogr_l_setspatialfilter(layer.ptr, C_NULL)
+    GDAL.ogr_l_setspatialfilter(layer, C_NULL)
     return layer
 end
 
@@ -231,7 +231,7 @@ function setspatialfilter!(
     xmax::Real,
     ymax::Real,
 )::L where {L<:AbstractFeatureLayer}
-    GDAL.ogr_l_setspatialfilterrect(layer.ptr, xmin, ymin, xmax, ymax)
+    GDAL.ogr_l_setspatialfilterrect(layer, xmin, ymin, xmax, ymax)
     return layer
 end
 
@@ -269,7 +269,7 @@ function setspatialfilter!(
 )::L where {L<:AbstractFeatureLayer}
     # This method makes an internal copy of `geom`. The input `geom` remains
     # the responsibility of the caller, and may be safely destroyed.
-    GDAL.ogr_l_setspatialfilterex(layer.ptr, i, geom.ptr)
+    GDAL.ogr_l_setspatialfilterex(layer, i, geom)
     return layer
 end
 
@@ -277,7 +277,7 @@ function clearspatialfilter!(
     layer::L,
     i::Integer,
 )::L where {L<:AbstractFeatureLayer}
-    GDAL.ogr_l_setspatialfilterex(layer.ptr, i, C_NULL)
+    GDAL.ogr_l_setspatialfilterex(layer, i, C_NULL)
     return layer
 end
 
@@ -303,7 +303,7 @@ function setspatialfilter!(
     xmax::Real,
     ymax::Real,
 )::L where {L<:AbstractFeatureLayer}
-    GDAL.ogr_l_setspatialfilterrectex(layer.ptr, i, xmin, ymin, xmax, ymax)
+    GDAL.ogr_l_setspatialfilterrectex(layer, i, xmin, ymin, xmax, ymax)
     return layer
 end
 
@@ -336,14 +336,14 @@ function setattributefilter!(
     layer::L,
     query::AbstractString,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_setattributefilter(layer.ptr, query)
+    result = GDAL.ogr_l_setattributefilter(layer, query)
     @ogrerr result """Failed to set a new attribute query. The query expression
     might be in error."""
     return layer
 end
 
 function clearattributefilter!(layer::L)::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_setattributefilter(layer.ptr, C_NULL)
+    result = GDAL.ogr_l_setattributefilter(layer, C_NULL)
     @ogrerr result "OGRErr $result: Failed to clear attribute query."
     return layer
 end
@@ -356,7 +356,7 @@ Reset feature reading to start on the first feature.
 This affects `nextfeature()`.
 """
 function resetreading!(layer::L)::L where {L<:AbstractFeatureLayer}
-    GDAL.ogr_l_resetreading(layer.ptr)
+    GDAL.ogr_l_resetreading(layer)
     return layer
 end
 
@@ -388,7 +388,7 @@ reading may or may not be valid after that operation and a call to
 `resetreading!()` might be needed.
 """
 function unsafe_nextfeature(layer::AbstractFeatureLayer)::Feature
-    return Feature(GDAL.ogr_l_getnextfeature(layer.ptr))
+    return Feature(GDAL.ogr_l_getnextfeature(layer))
 end
 
 """
@@ -418,7 +418,7 @@ function setnextbyindex!(
     layer::L,
     i::Integer,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_setnextbyindex(layer.ptr, i)
+    result = GDAL.ogr_l_setnextbyindex(layer, i)
     @ogrerr result "Failed to move the cursor to index $i"
     return layer
 end
@@ -453,7 +453,7 @@ The returned feature is now owned by the caller, and should be freed with
 `destroy()`.
 """
 unsafe_getfeature(layer::AbstractFeatureLayer, i::Integer)::Feature =
-    Feature(GDAL.ogr_l_getfeature(layer.ptr, i))
+    Feature(GDAL.ogr_l_getfeature(layer, i))
 
 """
     setfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)
@@ -468,7 +468,7 @@ Use OGR_L_TestCapability(OLCRandomWrite) to establish if this layer supports
 random access writing via OGR_L_SetFeature().
 """
 function setfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)
-    result = GDAL.ogr_l_setfeature(layer.ptr, feature.ptr)
+    result = GDAL.ogr_l_setfeature(layer, feature)
     # OGRERR_NONE if the operation works, otherwise an appropriate error code
     # (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
     @ogrerr result "Failed to set feature."
@@ -491,7 +491,7 @@ function addfeature!(
     layer::L,
     feature::AbstractFeature,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_createfeature(layer.ptr, feature.ptr)
+    result = GDAL.ogr_l_createfeature(layer, feature)
     @ogrerr result "Failed to create and write feature in layer."
     return layer
 end
@@ -539,7 +539,7 @@ OGRERR_UNSUPPORTED_OPERATION. The OGR_L_TestCapability() function may be called
 with OLCDeleteFeature to check if the driver supports feature deletion.
 """
 function deletefeature!(layer::L, i::Integer)::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_deletefeature(layer.ptr, i)
+    result = GDAL.ogr_l_deletefeature(layer, i)
     # OGRERR_NONE if the operation works, otherwise an appropriate error code
     # (e.g OGRERR_NON_EXISTING_FEATURE if the feature does not exist).
     @ogrerr result "OGRErr $result: Failed to delete feature $i"
@@ -555,7 +555,7 @@ Returns a view of the schema information for this layer.
 The `featuredefn` is owned by the `layer` and should not be modified.
 """
 layerdefn(layer::AbstractFeatureLayer)::IFeatureDefnView =
-    IFeatureDefnView(GDAL.ogr_l_getlayerdefn(layer.ptr))
+    IFeatureDefnView(GDAL.ogr_l_getlayerdefn(layer))
 
 """
     findfieldindex(layer::AbstractFeatureLayer,
@@ -572,7 +572,7 @@ function findfieldindex(
     field::Union{AbstractString,Symbol},
     exactmatch::Bool,
 )::Integer
-    return GDAL.ogr_l_findfieldindex(layer.ptr, field, exactmatch)
+    return GDAL.ogr_l_findfieldindex(layer, field, exactmatch)
 end
 
 """
@@ -586,7 +586,7 @@ Fetch the feature count in this layer, or `-1` if the count is not known.
     expensive. (`false` by default.)
 """
 nfeature(layer::AbstractFeatureLayer, force::Bool = false)::Integer =
-    GDAL.ogr_l_getfeaturecount(layer.ptr, force)
+    GDAL.ogr_l_getfeaturecount(layer, force)
 
 """
     ngeom(layer::AbstractFeatureLayer)
@@ -637,7 +637,7 @@ function envelope(
     force::Bool = false,
 )::GDAL.OGREnvelope
     envelope = Ref{GDAL.OGREnvelope}(GDAL.OGREnvelope(0, 0, 0, 0))
-    result = GDAL.ogr_l_getextentex(layer.ptr, i, envelope, force)
+    result = GDAL.ogr_l_getextentex(layer, i, envelope, force)
     @ogrerr result "Extent not known"
     return envelope[]
 end
@@ -647,7 +647,7 @@ function envelope(
     force::Bool = false,
 )::GDAL.OGREnvelope
     envelope = Ref{GDAL.OGREnvelope}(GDAL.OGREnvelope(0, 0, 0, 0))
-    result = GDAL.ogr_l_getextent(layer.ptr, envelope, force)
+    result = GDAL.ogr_l_getextent(layer, envelope, force)
     @ogrerr result "Extent not known"
     return envelope[]
 end
@@ -740,7 +740,7 @@ the caller.
     writing curve geometries or may return such geometries. (GDAL 2.0).
 """
 testcapability(layer::AbstractFeatureLayer, capability::AbstractString)::Bool =
-    Bool(GDAL.ogr_l_testcapability(layer.ptr, capability))
+    Bool(GDAL.ogr_l_testcapability(layer, capability))
 
 function listcapability(
     layer::AbstractFeatureLayer,
@@ -817,7 +817,7 @@ function addfielddefn!(
     field::AbstractFieldDefn,
     approx::Bool = false,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_createfield(layer.ptr, field.ptr, approx)
+    result = GDAL.ogr_l_createfield(layer, field, approx)
     @ogrerr result "Failed to create new field"
     return layer
 end
@@ -857,7 +857,7 @@ function addgeomdefn!(
     field::AbstractGeomFieldDefn,
     approx::Bool = false,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_creategeomfield(layer.ptr, field.ptr, approx)
+    result = GDAL.ogr_l_creategeomfield(layer, field, approx)
     # OGRERR_NONE on success.
     @ogrerr result "Failed to create new geometry field"
     return layer
@@ -884,7 +884,7 @@ end
 # * `i`: index of the field to delete.
 # """
 # function deletefield!(layer::AbstractFeatureLayer, i::Integer)
-#     result = GDAL.ogr_l_deletefield(layer.ptr, i)
+#     result = GDAL.ogr_l_deletefield(layer, i)
 #     @ogrerr result "Failed to delete field $i"
 #     layer
 # end
@@ -923,7 +923,7 @@ end
 #                 `[0, GetLayerDefn()->OGRFeatureDefn::GetFieldCount()-1]`.
 # """
 # function reorderfields!(layer::AbstractFeatureLayer, indices::Vector{Cint})
-#     result = GDAL.ogr_l_reorderfields(layer.ptr, indices)
+#     result = GDAL.ogr_l_reorderfields(layer, indices)
 #     @ogrerr result "Failed to reorder the fields of layer according to $indices"
 #     layer
 # end
@@ -967,7 +967,7 @@ end
 #         oldpos::Integer,
 #         newpos::Integer
 #     )
-#     result = GDAL.ogr_l_reorderfield(layer.ptr, oldpos, newpos)
+#     result = GDAL.ogr_l_reorderfield(layer, oldpos, newpos)
 #     @ogrerr result "Failed to reorder field from $oldpos to $newpos."
 #     layer
 # end
@@ -1005,21 +1005,21 @@ end
 #         newfielddefn::FieldDefn,
 #         flags::UInt8
 #     )
-#     result = OGR.alterfielddefn(layer.ptr, i, newfielddefn.ptr, flags)
+#     result = OGR.alterfielddefn(layer, i, newfielddefn, flags)
 #     @ogrerr result "Failed to alter fielddefn of field $i."
 #     layer
 # end
 
 # "For datasources which support transactions, creates a transaction."
 # function starttransaction(layer::AbstractFeatureLayer)
-#     result = GDAL.ogr_l_starttransaction(layer.ptr)
+#     result = GDAL.ogr_l_starttransaction(layer)
 #     @ogrerr result "Failed to start transaction."
 #     layer
 # end
 
 # "For datasources which support transactions, commits a transaction."
 # function committransaction(layer::AbstractFeatureLayer)
-#     result = GDAL.ogr_l_committransaction(layer.ptr)
+#     result = GDAL.ogr_l_committransaction(layer)
 #     @ogrerr result "Failed to commit transaction."
 #     layer
 # end
@@ -1029,7 +1029,7 @@ end
 # a datasource to its state before the start of the current transaction.
 # """
 # function rollbacktransaction(layer::AbstractFeatureLayer)
-#     result = GDAL.ogr_l_rollbacktransaction(layer.ptr)
+#     result = GDAL.ogr_l_rollbacktransaction(layer)
 #     @ogrerr result "Failed to rollback transaction."
 #     layer
 # end
@@ -1043,7 +1043,7 @@ Increment layer reference count.
 The reference count after incrementing.
 """
 reference(layer::AbstractFeatureLayer)::Integer =
-    GDAL.ogr_l_reference(layer.ptr)
+    GDAL.ogr_l_reference(layer)
 
 """
     dereference(layer::AbstractFeatureLayer)
@@ -1054,7 +1054,7 @@ Decrement layer reference count.
 The reference count after decrementing.
 """
 dereference(layer::AbstractFeatureLayer)::Integer =
-    GDAL.ogr_l_dereference(layer.ptr)
+    GDAL.ogr_l_dereference(layer)
 
 """
     nreference(layer::AbstractFeatureLayer)
@@ -1062,7 +1062,7 @@ dereference(layer::AbstractFeatureLayer)::Integer =
 The current reference count for the layer object itself.
 """
 nreference(layer::AbstractFeatureLayer)::Integer =
-    GDAL.ogr_l_getrefcount(layer.ptr)
+    GDAL.ogr_l_getrefcount(layer)
 
 # """
 # Flush pending changes to disk.
@@ -1082,7 +1082,7 @@ nreference(layer::AbstractFeatureLayer)::Integer =
 # OGRERR_NONE if no error occurs (even if nothing is done) or an error code.
 # """
 # function synctodisk!(layer::AbstractFeatureLayer)
-#     result = GDAL.ogr_l_synctodisk(layer.ptr)
+#     result = GDAL.ogr_l_synctodisk(layer)
 #     @ogrerr result "Failed to flush pending changes to disk"
 #     layer.ptr = C_NULL
 # end
@@ -1093,7 +1093,7 @@ nreference(layer::AbstractFeatureLayer)::Integer =
 # Warning: not all drivers seem to update this count properly.
 # """
 # getfeaturesread(layer::AbstractFeatureLayer) =
-#     GDAL.ogr_l_getfeaturesread(layer.ptr)
+#     GDAL.ogr_l_getfeaturesread(layer)
 
 """
     fidcolumnname(layer::AbstractFeatureLayer)
@@ -1101,7 +1101,7 @@ nreference(layer::AbstractFeatureLayer)::Integer =
 The name of the FID column in the database, or \"\" if not supported.
 """
 fidcolumnname(layer::AbstractFeatureLayer)::String =
-    GDAL.ogr_l_getfidcolumn(layer.ptr)
+    GDAL.ogr_l_getfidcolumn(layer)
 
 """
     geomcolumnname(layer::AbstractFeatureLayer)
@@ -1109,7 +1109,7 @@ fidcolumnname(layer::AbstractFeatureLayer)::String =
 The name of the geometry column in the database, or \"\" if not supported.
 """
 geomcolumnname(layer::AbstractFeatureLayer)::String =
-    GDAL.ogr_l_getgeometrycolumn(layer.ptr)
+    GDAL.ogr_l_getgeometrycolumn(layer)
 
 """
     setignoredfields!(layer::AbstractFeatureLayer, fieldnames)
@@ -1135,7 +1135,7 @@ function setignoredfields!(
     layer::L,
     fieldnames,
 )::L where {L<:AbstractFeatureLayer}
-    result = GDAL.ogr_l_setignoredfields(layer.ptr, fieldnames)
+    result = GDAL.ogr_l_setignoredfields(layer, fieldnames)
     # OGRERR_NONE if all field names have been resolved (even if the driver
     # does not support this method)
     @ogrerr result "Failed to set ignored fields $fieldnames."
@@ -1204,9 +1204,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_intersection(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1265,9 +1265,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_union(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1320,9 +1320,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_symdifference(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1381,9 +1381,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_identity(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1436,9 +1436,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_update(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1491,9 +1491,9 @@ end
 #         progressdata            = C_NULL
 #     )
 #     result = GDAL.ogr_l_clip(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata
@@ -1546,9 +1546,9 @@ end
 #         progressdata = C_NULL
 #     )
 #     result = GDAL.ogr_l_erase(
-#         input.ptr,
-#         method.ptr,
-#         output.ptr,
+#         input,
+#         method,
+#         output,
 #         options,
 #         @cplprogress(progressfunc),
 #         progressdata

--- a/src/ogr/fielddefn.jl
+++ b/src/ogr/fielddefn.jl
@@ -10,7 +10,7 @@ unsafe_createfielddefn(name::AbstractString, etype::OGRFieldType)::FieldDefn =
 
 "Destroy a field definition."
 function destroy(fielddefn::FieldDefn)::Nothing
-    GDAL.ogr_fld_destroy(fielddefn.ptr)
+    GDAL.ogr_fld_destroy(fielddefn)
     fielddefn.ptr = C_NULL
     return nothing
 end
@@ -22,21 +22,21 @@ end
 
 "Set the name of this field."
 function setname!(fielddefn::FieldDefn, name::AbstractString)::FieldDefn
-    GDAL.ogr_fld_setname(fielddefn.ptr, name)
+    GDAL.ogr_fld_setname(fielddefn, name)
     return fielddefn
 end
 
 "Fetch the name of this field."
 getname(fielddefn::AbstractFieldDefn)::String =
-    GDAL.ogr_fld_getnameref(fielddefn.ptr)
+    GDAL.ogr_fld_getnameref(fielddefn)
 
 "Fetch the type of this field."
 gettype(fielddefn::AbstractFieldDefn)::OGRFieldType =
-    GDAL.ogr_fld_gettype(fielddefn.ptr)
+    GDAL.ogr_fld_gettype(fielddefn)
 
 "Set the type of this field."
 function settype!(fielddefn::FieldDefn, etype::OGRFieldType)::FieldDefn
-    GDAL.ogr_fld_settype(fielddefn.ptr, etype)
+    GDAL.ogr_fld_settype(fielddefn, etype)
     return fielddefn
 end
 
@@ -52,7 +52,7 @@ Fetch subtype of this field.
 field subtype.
 """
 getsubtype(fielddefn::AbstractFieldDefn)::OGRFieldSubType =
-    GDAL.ogr_fld_getsubtype(fielddefn.ptr)
+    GDAL.ogr_fld_getsubtype(fielddefn)
 
 """
     setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)
@@ -70,7 +70,7 @@ OGRFeatureDefn.
 * https://gdal.org/development/rfc/rfc50_ogr_field_subtype.html
 """
 function setsubtype!(fielddefn::FieldDefn, subtype::OGRFieldSubType)::FieldDefn
-    GDAL.ogr_fld_setsubtype(fielddefn.ptr, subtype)
+    GDAL.ogr_fld_setsubtype(fielddefn, subtype)
     return fielddefn
 end
 
@@ -107,7 +107,7 @@ Get the justification for this field.
 Note: no driver is know to use the concept of field justification.
 """
 getjustify(fielddefn::AbstractFieldDefn)::OGRJustification =
-    GDAL.ogr_fld_getjustify(fielddefn.ptr)
+    GDAL.ogr_fld_getjustify(fielddefn)
 
 """
     setjustify!(fielddefn::FieldDefn, ejustify::OGRJustification)
@@ -120,7 +120,7 @@ function setjustify!(
     fielddefn::FieldDefn,
     ejustify::OGRJustification,
 )::FieldDefn
-    GDAL.ogr_fld_setjustify(fielddefn.ptr, ejustify)
+    GDAL.ogr_fld_setjustify(fielddefn, ejustify)
     return fielddefn
 end
 
@@ -133,7 +133,7 @@ Get the formatting width for this field.
 the width, zero means no specified width.
 """
 getwidth(fielddefn::AbstractFieldDefn)::Integer =
-    GDAL.ogr_fld_getwidth(fielddefn.ptr)
+    GDAL.ogr_fld_getwidth(fielddefn)
 
 """
     setwidth!(fielddefn::FieldDefn, width::Integer)
@@ -144,7 +144,7 @@ This should never be done to an OGRFieldDefn that is already part of an
 OGRFeatureDefn.
 """
 function setwidth!(fielddefn::FieldDefn, width::Integer)::FieldDefn
-    GDAL.ogr_fld_setwidth(fielddefn.ptr, width)
+    GDAL.ogr_fld_setwidth(fielddefn, width)
     return fielddefn
 end
 
@@ -156,7 +156,7 @@ Get the formatting precision for this field.
 This should normally be zero for fields of types other than OFTReal.
 """
 getprecision(fielddefn::AbstractFieldDefn)::Integer =
-    GDAL.ogr_fld_getprecision(fielddefn.ptr)
+    GDAL.ogr_fld_getprecision(fielddefn)
 
 """
     setprecision!(fielddefn::FieldDefn, precision::Integer)
@@ -166,7 +166,7 @@ Set the formatting precision for this field in characters.
 This should normally be zero for fields of types other than OFTReal.
 """
 function setprecision!(fielddefn::FieldDefn, precision::Integer)::FieldDefn
-    GDAL.ogr_fld_setprecision(fielddefn.ptr, precision)
+    GDAL.ogr_fld_setprecision(fielddefn, precision)
     return fielddefn
 end
 
@@ -191,7 +191,7 @@ function setparams!(
     nprecision::Integer = 0,
     justify::OGRJustification = OJUndefined,
 )::FieldDefn
-    GDAL.ogr_fld_set(fielddefn.ptr, name, etype, nwidth, nprecision, justify)
+    GDAL.ogr_fld_set(fielddefn, name, etype, nwidth, nprecision, justify)
     return fielddefn
 end
 
@@ -201,7 +201,7 @@ end
 Return whether this field should be omitted when fetching features.
 """
 isignored(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isignored(fielddefn.ptr))
+    Bool(GDAL.ogr_fld_isignored(fielddefn))
 
 """
     setignored!(fielddefn::FieldDefn, ignore::Bool)
@@ -209,7 +209,7 @@ isignored(fielddefn::AbstractFieldDefn)::Bool =
 Set whether this field should be omitted when fetching features.
 """
 function setignored!(fielddefn::FieldDefn, ignore::Bool)::FieldDefn
-    GDAL.ogr_fld_setignored(fielddefn.ptr, ignore)
+    GDAL.ogr_fld_setignored(fielddefn, ignore)
     return fielddefn
 end
 
@@ -229,7 +229,7 @@ OGRLayer::CreateFeature()/SetFeature() is called.
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
 isnullable(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isnullable(fielddefn.ptr))
+    Bool(GDAL.ogr_fld_isnullable(fielddefn))
 
 """
     setnullable!(fielddefn::FieldDefn, nullable::Bool)
@@ -249,7 +249,7 @@ function setnullable!(
     fielddefn::T,
     nullable::Bool,
 )::T where {T<:AbstractFieldDefn}
-    GDAL.ogr_fld_setnullable(fielddefn.ptr, nullable)
+    GDAL.ogr_fld_setnullable(fielddefn, nullable)
     return fielddefn
 end
 
@@ -263,7 +263,7 @@ Get default field value
 """
 function getdefault(fielddefn::AbstractFieldDefn)::Union{String,Nothing}
     result =
-        @gdal(OGR_Fld_GetDefault::Cstring, fielddefn.ptr::GDAL.OGRFieldDefnH)
+        @gdal(OGR_Fld_GetDefault::Cstring, fielddefn::GDAL.OGRFieldDefnH)
     return if result == C_NULL
         nothing
     else
@@ -297,7 +297,7 @@ GDAL_DCAP_DEFAULT_FIELDS driver metadata item.
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
 function setdefault!(fielddefn::T, default)::T where {T<:AbstractFieldDefn}
-    GDAL.ogr_fld_setdefault(fielddefn.ptr, default)
+    GDAL.ogr_fld_setdefault(fielddefn, default)
     return fielddefn
 end
 
@@ -314,7 +314,7 @@ CURRENT_TIME, CURRENT_DATE or datetime literal value.
 * https://gdal.org/development/rfc/rfc53_ogr_notnull_default.html
 """
 isdefaultdriverspecific(fielddefn::AbstractFieldDefn)::Bool =
-    Bool(GDAL.ogr_fld_isdefaultdriverspecific(fielddefn.ptr))
+    Bool(GDAL.ogr_fld_isdefaultdriverspecific(fielddefn))
 
 """
     unsafe_creategeomdefn(name::AbstractString, etype::OGRwkbGeometryType)
@@ -330,7 +330,7 @@ end
 
 "Destroy a geometry field definition."
 function destroy(geomdefn::GeomFieldDefn)::Nothing
-    GDAL.ogr_gfld_destroy(geomdefn.ptr)
+    GDAL.ogr_gfld_destroy(geomdefn)
     geomdefn.ptr = C_NULL
     geomdefn.spatialref = SpatialRef()
     return nothing
@@ -344,24 +344,24 @@ end
 
 "Set the name of this field."
 function setname!(geomdefn::GeomFieldDefn, name::AbstractString)::GeomFieldDefn
-    GDAL.ogr_gfld_setname(geomdefn.ptr, name)
+    GDAL.ogr_gfld_setname(geomdefn, name)
     return geomdefn
 end
 
 "Fetch name of this field."
 getname(geomdefn::AbstractGeomFieldDefn)::String =
-    GDAL.ogr_gfld_getnameref(geomdefn.ptr)
+    GDAL.ogr_gfld_getnameref(geomdefn)
 
 "Fetch geometry type of this field."
 gettype(geomdefn::AbstractGeomFieldDefn)::OGRwkbGeometryType =
-    GDAL.ogr_gfld_gettype(geomdefn.ptr)
+    GDAL.ogr_gfld_gettype(geomdefn)
 
 "Set the geometry type of this field."
 function settype!(
     geomdefn::GeomFieldDefn,
     etype::OGRwkbGeometryType,
 )::GeomFieldDefn
-    GDAL.ogr_gfld_settype(geomdefn.ptr, etype)
+    GDAL.ogr_gfld_settype(geomdefn, etype)
     return geomdefn
 end
 
@@ -371,7 +371,7 @@ end
 Returns a clone of the spatial reference system for this field. May be NULL.
 """
 function getspatialref(geomdefn::AbstractGeomFieldDefn)::ISpatialRef
-    result = GDAL.ogr_gfld_getspatialref(geomdefn.ptr)
+    result = GDAL.ogr_gfld_getspatialref(geomdefn)
     if result == C_NULL
         return ISpatialRef()
     else
@@ -382,7 +382,7 @@ function getspatialref(geomdefn::AbstractGeomFieldDefn)::ISpatialRef
 end
 
 function unsafe_getspatialref(geomdefn::AbstractGeomFieldDefn)::SpatialRef
-    result = GDAL.ogr_gfld_getspatialref(geomdefn.ptr)
+    result = GDAL.ogr_gfld_getspatialref(geomdefn)
     if result == C_NULL
         return SpatialRef()
     else
@@ -405,7 +405,7 @@ function setspatialref!(
     spatialref::AbstractSpatialRef,
 )::GeomFieldDefn
     clonespatialref = clone(spatialref)
-    GDAL.ogr_gfld_setspatialref(geomdefn.ptr, clonespatialref.ptr)
+    GDAL.ogr_gfld_setspatialref(geomdefn, clonespatialref)
     geomdefn.spatialref = clonespatialref
     return geomdefn
 end
@@ -425,7 +425,7 @@ OGRLayer::CreateFeature()/SetFeature() is called.
 Note that not-nullable geometry fields might also contain 'empty' geometries.
 """
 isnullable(geomdefn::AbstractGeomFieldDefn)::Bool =
-    Bool(GDAL.ogr_gfld_isnullable(geomdefn.ptr))
+    Bool(GDAL.ogr_gfld_isnullable(geomdefn))
 
 """
     setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)
@@ -439,7 +439,7 @@ Drivers that support writing not-null constraint will advertize the
 GDAL_DCAP_NOTNULL_GEOMFIELDS driver metadata item.
 """
 function setnullable!(geomdefn::GeomFieldDefn, nullable::Bool)::GeomFieldDefn
-    GDAL.ogr_gfld_setnullable(geomdefn.ptr, nullable)
+    GDAL.ogr_gfld_setnullable(geomdefn, nullable)
     return geomdefn
 end
 
@@ -449,7 +449,7 @@ end
 Return whether this field should be omitted when fetching features.
 """
 isignored(geomdefn::AbstractGeomFieldDefn)::Bool =
-    Bool(GDAL.ogr_gfld_isignored(geomdefn.ptr))
+    Bool(GDAL.ogr_gfld_isignored(geomdefn))
 
 """
     setignored!(geomdefn::GeomFieldDefn, ignore::Bool)
@@ -457,6 +457,6 @@ isignored(geomdefn::AbstractGeomFieldDefn)::Bool =
 Set whether this field should be omitted when fetching features.
 """
 function setignored!(geomdefn::GeomFieldDefn, ignore::Bool)::GeomFieldDefn
-    GDAL.ogr_gfld_setignored(geomdefn.ptr, ignore)
+    GDAL.ogr_gfld_setignored(geomdefn, ignore)
     return geomdefn
 end

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1729,11 +1729,11 @@ for (geom, wkbgeom) in (
     end
 end
 
-for f in (:create, :unsafe_create)
-    V = Vector{<:Real}
-    geomargs2d = (:xs, :ys), (:(xs::$V), :(ys::$V)), ""
-    geomargs3d = (:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"
-    for (args, typedargs, typesuffix) in (geomargs2d, geomargs3d)
+V = Vector{<:Real}
+geomargs2d = (:xs, :ys), (:(xs::$V), :(ys::$V)), ""
+geomargs3d = (:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"
+for (args, typedargs, typesuffix) in (geomargs2d, geomargs3d)
+    for f in (:create, :unsafe_create)
         f1 = Symbol("$(f)linestring")
         T = Symbol("wkbLineString" * typesuffix)
         @eval function $f1($(typedargs...))

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1729,10 +1729,11 @@ for (geom, wkbgeom) in (
     end
 end
 
-V = Vector{<:Real}
-geomargs2d = (:xs, :ys), (:(xs::$V), :(ys::$V)), ""
-geomargs3d = (:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"
-for (args, typedargs, typesuffix) in (geomargs2d, geomargs3d)
+let V = Vector{<:Real}
+for (args, typedargs, typesuffix) in (
+        ((:xs, :ys), (:(xs::$V), :(ys::$V)), ""), # geomargs2d
+        ((:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"), # geomargs3d
+    )
     for f in (:create, :unsafe_create)
         f1 = Symbol("$(f)linestring")
         T = Symbol("wkbLineString" * typesuffix)
@@ -1778,6 +1779,7 @@ for (args, typedargs, typesuffix) in (geomargs2d, geomargs3d)
             return geom
         end
     end
+end
 end
 
 for f in (:create, :unsafe_create)

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1734,19 +1734,24 @@ for (args, typedargs, typesuffix) in (
         ((:xs, :ys), (:(xs::$V), :(ys::$V)), ""), # geomargs2d
         ((:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"), # geomargs3d
     )
+    T = Symbol("wkbLineString" * typesuffix)
     @eval function createlinearring($(typedargs...))
-        geom = unsafe_createlinestring(Val{wkbLinearRing}())
+        return createlinestring(Val{wkbLinearRing}()) do geom
         for pt in zip($(args...))
             addpoint!(geom, pt...)
         end
-        return clone(geom) # rewrap LinearRing as the corrent LineString/LineString25D
+        # rewrap LinearRing as the corrent LineString/LineString25D
+        IGeometry{$T}(GDAL.ogr_g_clone(geom))
+        end
     end
     @eval function unsafe_createlinearring($(typedargs...))
-        geom = unsafe_createlinestring(Val{wkbLinearRing}())
+        return createlinestring(Val{wkbLinearRing}()) do geom
         for pt in zip($(args...))
             addpoint!(geom, pt...)
         end
-        return unsafe_clone(geom) # rewrap LinearRing as the corrent LineString/LineString25D
+        # rewrap LinearRing as the corrent LineString/LineString25D
+        Geometry{$T}(GDAL.ogr_g_clone(geom))
+        end
     end
     for f in (:create, :unsafe_create)
         f1 = Symbol("$(f)linestring")

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1734,6 +1734,20 @@ for (args, typedargs, typesuffix) in (
         ((:xs, :ys), (:(xs::$V), :(ys::$V)), ""), # geomargs2d
         ((:xs, :ys, :zs), (:(xs::$V), :(ys::$V), :(zs::$V)), "25D"), # geomargs3d
     )
+    @eval function createlinearring($(typedargs...))
+        geom = unsafe_createlinestring(Val{wkbLinearRing}())
+        for pt in zip($(args...))
+            addpoint!(geom, pt...)
+        end
+        return clone(geom) # rewrap LinearRing as the corrent LineString/LineString25D
+    end
+    @eval function unsafe_createlinearring($(typedargs...))
+        geom = unsafe_createlinestring(Val{wkbLinearRing}())
+        for pt in zip($(args...))
+            addpoint!(geom, pt...)
+        end
+        return unsafe_clone(geom) # rewrap LinearRing as the corrent LineString/LineString25D
+    end
     for f in (:create, :unsafe_create)
         f1 = Symbol("$(f)linestring")
         T = Symbol("wkbLineString" * typesuffix)
@@ -1743,20 +1757,6 @@ for (args, typedargs, typesuffix) in (
                 addpoint!(geom, pt...)
             end
             return geom
-        end
-        @eval function createlinearring($(typedargs...))
-            geom = $f1(Val{wkbLinearRing}())
-            for pt in zip($(args...))
-                addpoint!(geom, pt...)
-            end
-            return IGeometry{$T}(geom) # rewrap LinearRing as the corrent LineString/LineString25D
-        end
-        @eval function unsafe_createlinearring($(typedargs...))
-            geom = $f1(Val{wkbLinearRing}())
-            for pt in zip($(args...))
-                addpoint!(geom, pt...)
-            end
-            return Geometry{$T}(geom) # rewrap LinearRing as the corrent LineString/LineString25D
         end
         f1 = Symbol("$(f)polygon")
         T = Symbol("wkbPolygon" * typesuffix)

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -81,7 +81,7 @@ Equivalent to invoking delete on a geometry, but it guaranteed to take place
 within the context of the GDAL/OGR heap.
 """
 function destroy(geom::AbstractGeometry)::Nothing
-    GDAL.ogr_g_destroygeometry(geom.ptr)
+    GDAL.ogr_g_destroygeometry(geom)
     geom.ptr = C_NULL
     return nothing
 end
@@ -93,7 +93,7 @@ Equivalent to invoking delete on a prepared geometry, but it guaranteed to take 
 within the context of the GDAL/OGR heap.
 """
 function destroy(geom::AbstractPreparedGeometry)::Nothing
-    GDAL.ogrdestroypreparedgeometry(geom.ptr)
+    GDAL.ogrdestroypreparedgeometry(geom)
     geom.ptr = C_NULL
     return nothing
 end
@@ -107,7 +107,7 @@ function clone(geom::AbstractGeometry{T}) where {T}
     if geom.ptr == C_NULL
         return IGeometry{wkbUnknown}()
     else
-        return IGeometry{T}(GDAL.ogr_g_clone(geom.ptr))
+        return IGeometry{T}(GDAL.ogr_g_clone(geom))
     end
 end
 
@@ -115,7 +115,7 @@ function unsafe_clone(geom::AbstractGeometry{T}) where {T}
     if geom.ptr == C_NULL
         return Geometry{wkbUnknown}()
     else
-        return Geometry{T}(GDAL.ogr_g_clone(geom.ptr))
+        return Geometry{T}(GDAL.ogr_g_clone(geom))
     end
 end
 
@@ -133,8 +133,8 @@ creategeom(geomtype::OGRwkbGeometryType)::IGeometry =
 unsafe_creategeom(geomtype::OGRwkbGeometryType)::Geometry =
     Geometry(GDAL.ogr_g_creategeometry(geomtype))
 
-# When the geometry type `T` is known, pass it wrapped in `Val` for type 
-# stability. `T` is usually equal to `geomtype`, except in the case 
+# When the geometry type `T` is known, pass it wrapped in `Val` for type
+# stability. `T` is usually equal to `geomtype`, except in the case
 # of `geomtype == wkbLinearRing`, in which case `T` is `wkbLineString`
 creategeom(::Val{T}) where {T} = IGeometry{T}(GDAL.ogr_g_creategeometry(T))
 function unsafe_creategeom(::Val{T}) where {T}
@@ -169,11 +169,11 @@ Create an prepared geometry of a geometry. This can speed up operations which in
 with the geometry multiple times, by storing caches of calculated geometry information.
 """
 function preparegeom(geom::AbstractGeometry{T}) where {T}
-    return IPreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom.ptr))
+    return IPreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom))
 end
 
 function unsafe_preparegeom(geom::AbstractGeometry{T}) where {T}
-    return PreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom.ptr))
+    return PreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom))
 end
 
 """
@@ -202,7 +202,7 @@ function forceto(
     options = StringList(C_NULL),
 )::IGeometry
     return IGeometry(
-        GDAL.ogr_g_forceto(unsafe_clone(geom).ptr, targettype, options),
+        GDAL.ogr_g_forceto(unsafe_clone(geom), targettype, options),
     )
 end
 
@@ -212,7 +212,7 @@ function unsafe_forceto(
     options = StringList(C_NULL),
 )::Geometry
     return Geometry(
-        GDAL.ogr_g_forceto(unsafe_clone(geom).ptr, targettype, options),
+        GDAL.ogr_g_forceto(unsafe_clone(geom), targettype, options),
     )
 end
 
@@ -225,7 +225,7 @@ This function corresponds to the SFCOM IGeometry::GetDimension() method. It
 indicates the dimension of the geometry, but does not indicate the dimension of
 the underlying space (as indicated by OGR_G_GetCoordinateDimension() function).
 """
-geomdim(geom::AbstractGeometry)::Integer = GDAL.ogr_g_getdimension(geom.ptr)
+geomdim(geom::AbstractGeometry)::Integer = GDAL.ogr_g_getdimension(geom)
 
 """
     getcoorddim(geom::AbstractGeometry)
@@ -236,7 +236,7 @@ Get the dimension of the coordinates in this geometry.
 This will return 2 or 3.
 """
 getcoorddim(geom::AbstractGeometry)::Integer =
-    GDAL.ogr_g_getcoordinatedimension(geom.ptr)
+    GDAL.ogr_g_getcoordinatedimension(geom)
 
 """
     setcoorddim!(geom::AbstractGeometry, dim::Integer)
@@ -251,7 +251,7 @@ before this call.
 """
 function setcoorddim!(geom::G, dim::Integer)::G where {G<:AbstractGeometry}
     # TODO change the geometry type here
-    GDAL.ogr_g_setcoordinatedimension(geom.ptr, dim)
+    GDAL.ogr_g_setcoordinatedimension(geom, dim)
     return geom
 end
 
@@ -262,7 +262,7 @@ Computes and returns the bounding envelope for this geometry.
 """
 function envelope(geom::AbstractGeometry)::GDAL.OGREnvelope
     envelope = Ref{GDAL.OGREnvelope}(GDAL.OGREnvelope(0, 0, 0, 0))
-    GDAL.ogr_g_getenvelope(geom.ptr, envelope)
+    GDAL.ogr_g_getenvelope(geom, envelope)
     return envelope[]
 end
 
@@ -273,7 +273,7 @@ Computes and returns the bounding envelope (3D) for this geometry
 """
 function envelope3d(geom::AbstractGeometry)::GDAL.OGREnvelope3D
     envelope = Ref{GDAL.OGREnvelope3D}(GDAL.OGREnvelope3D(0, 0, 0, 0, 0, 0))
-    GDAL.ogr_g_getenvelope3d(geom.ptr, envelope)
+    GDAL.ogr_g_getenvelope3d(geom, envelope)
     return envelope[]
 end
 
@@ -310,7 +310,7 @@ function toWKB(
     order::OGRwkbByteOrder = wkbNDR,
 )::Vector{Cuchar}
     buffer = Vector{Cuchar}(undef, wkbsize(geom))
-    result = GDAL.ogr_g_exporttowkb(geom.ptr, order, buffer)
+    result = GDAL.ogr_g_exporttowkb(geom, order, buffer)
     @ogrerr result "Failed to export geometry to WKB"
     return buffer
 end
@@ -329,7 +329,7 @@ function toISOWKB(
     order::OGRwkbByteOrder = wkbNDR,
 )::Vector{Cuchar}
     buffer = Array{Cuchar}(undef, wkbsize(geom))
-    result = GDAL.ogr_g_exporttoisowkb(geom.ptr, order, buffer)
+    result = GDAL.ogr_g_exporttoisowkb(geom, order, buffer)
     @ogrerr result "Failed to export geometry to ISO WKB"
     return buffer
 end
@@ -339,7 +339,7 @@ end
 
 Returns size (in bytes) of related binary representation.
 """
-wkbsize(geom::AbstractGeometry)::Integer = GDAL.ogr_g_wkbsize(geom.ptr)
+wkbsize(geom::AbstractGeometry)::Integer = GDAL.ogr_g_wkbsize(geom)
 
 """
     toWKT(geom::AbstractGeometry)
@@ -348,7 +348,7 @@ Convert a geometry into well known text format.
 """
 function toWKT(geom::AbstractGeometry)::String
     wkt_ptr = Ref(Cstring(C_NULL))
-    result = GDAL.ogr_g_exporttowkt(geom.ptr, wkt_ptr)
+    result = GDAL.ogr_g_exporttowkt(geom, wkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to WKT"
     wkt = unsafe_string(wkt_ptr[])
     GDAL.vsifree(pointer(wkt_ptr[]))
@@ -362,7 +362,7 @@ Convert a geometry into SFSQL 1.2 / ISO SQL/MM Part 3 well known text format.
 """
 function toISOWKT(geom::AbstractGeometry)::String
     isowkt_ptr = Ref(Cstring(C_NULL))
-    result = GDAL.ogr_g_exporttoisowkt(geom.ptr, isowkt_ptr)
+    result = GDAL.ogr_g_exporttoisowkt(geom, isowkt_ptr)
     @ogrerr result "OGRErr $result: failed to export geometry to ISOWKT"
     wkt = unsafe_string(isowkt_ptr[])
     GDAL.vsifree(pointer(isowkt_ptr[]))
@@ -385,7 +385,7 @@ function geomname(geom::AbstractGeometry)::Union{String,Missing}
     return if geom.ptr == C_NULL
         missing
     else
-        GDAL.ogr_g_getgeometryname(geom.ptr)
+        GDAL.ogr_g_getgeometryname(geom)
     end
 end
 
@@ -398,7 +398,7 @@ The return value will have a new type, do not continue using the original object
 """
 function flattento2d!(geom::G)::G where {G<:AbstractGeometry}
     # TODO change the geometry type here
-    GDAL.ogr_g_flattento2d(geom.ptr)
+    GDAL.ogr_g_flattento2d(geom)
     return geom
 end
 
@@ -411,7 +411,7 @@ If this geometry, or any contained geometries has polygon rings that are not
 closed, they will be closed by adding the starting point at the end.
 """
 function closerings!(geom::G)::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_closerings(geom.ptr)
+    GDAL.ogr_g_closerings(geom)
     return geom
 end
 
@@ -436,7 +436,7 @@ unsafe_fromGML(data)::Geometry = Geometry(GDAL.ogr_g_createfromgml(data))
 
 Convert a geometry into GML format.
 """
-toGML(geom::AbstractGeometry)::String = GDAL.ogr_g_exporttogml(geom.ptr)
+toGML(geom::AbstractGeometry)::String = GDAL.ogr_g_exporttogml(geom)
 
 """
     toKML(geom::AbstractGeometry, altitudemode = C_NULL)
@@ -444,7 +444,7 @@ toGML(geom::AbstractGeometry)::String = GDAL.ogr_g_exporttogml(geom.ptr)
 Convert a geometry into KML format.
 """
 toKML(geom::AbstractGeometry, altitudemode = C_NULL)::String =
-    GDAL.ogr_g_exporttokml(geom.ptr, altitudemode)
+    GDAL.ogr_g_exporttokml(geom, altitudemode)
 # ↑ * `altitudemode`: value to write in altitudeMode element, or NULL.
 
 """
@@ -468,10 +468,10 @@ Convert a geometry into GeoJSON format.
 A GeoJSON fragment or NULL in case of error.
 """
 toJSON(geom::AbstractGeometry; kwargs...)::String =
-    GDAL.ogr_g_exporttojsonex(geom.ptr, String["$k=$v" for (k, v) in kwargs])
+    GDAL.ogr_g_exporttojsonex(geom, String["$k=$v" for (k, v) in kwargs])
 
 toJSON(geom::AbstractGeometry, options::Vector{String})::String =
-    GDAL.ogr_g_exporttojsonex(geom.ptr, options)
+    GDAL.ogr_g_exporttojsonex(geom, options)
 
 """
     fromJSON(data::String)
@@ -499,7 +499,7 @@ unsafe_fromJSON(data::String)::Geometry =
 # their derived classes).
 # """
 # function setspatialref!(geom::Geometry, spatialref::AbstractSpatialRef)
-#     GDAL.assignspatialreference(geom.ptr, spatialref.ptr)
+#     GDAL.assignspatialreference(geom, spatialref)
 #     return geom
 # end
 
@@ -514,7 +514,7 @@ function getspatialref(geom::AbstractGeometry)::ISpatialRef
     if geom.ptr == C_NULL
         return ISpatialRef()
     end
-    result = GDAL.ogr_g_getspatialreference(geom.ptr)
+    result = GDAL.ogr_g_getspatialreference(geom)
     return if result == C_NULL
         ISpatialRef()
     else
@@ -526,7 +526,7 @@ function unsafe_getspatialref(geom::AbstractGeometry)::SpatialRef
     if geom.ptr == C_NULL
         return SpatialRef()
     end
-    result = GDAL.ogr_g_getspatialreference(geom.ptr)
+    result = GDAL.ogr_g_getspatialreference(geom)
     return if result == C_NULL
         SpatialRef()
     else
@@ -547,7 +547,7 @@ function transform!(
     geom::G,
     coordtransform::CoordTransform,
 )::G where {G<:AbstractGeometry}
-    result = GDAL.ogr_g_transform(geom.ptr, coordtransform.ptr)
+    result = GDAL.ogr_g_transform(geom, coordtransform)
     @ogrerr result "Failed to transform geometry"
     return geom
 end
@@ -576,7 +576,7 @@ end
 # * `spatialref`: Target spatial reference system.
 # """
 # function transform!(geom::AbstractGeometry, spatialref::AbstractSpatialRef)
-#     result = GDAL.ogr_g_transformto(geom.ptr, spatialref.ptr)
+#     result = GDAL.ogr_g_transformto(geom, spatialref)
 #     @ogrerr result "Failed to transform geometry to the new SRS"
 #     return geom
 # end
@@ -591,10 +591,10 @@ Compute a simplified geometry.
 * `tol`: the distance tolerance for the simplification.
 """
 simplify(geom::AbstractGeometry, tol::Real)::IGeometry =
-    IGeometry(GDAL.ogr_g_simplify(geom.ptr, tol))
+    IGeometry(GDAL.ogr_g_simplify(geom, tol))
 
 unsafe_simplify(geom::AbstractGeometry, tol::Real)::Geometry =
-    Geometry(GDAL.ogr_g_simplify(geom.ptr, tol))
+    Geometry(GDAL.ogr_g_simplify(geom, tol))
 
 """
     simplifypreservetopology(geom::AbstractGeometry, tol::Real)
@@ -606,10 +606,10 @@ Simplify the geometry while preserving topology.
 * `tol`: the distance tolerance for the simplification.
 """
 simplifypreservetopology(geom::AbstractGeometry, tol::Real)::IGeometry =
-    IGeometry(GDAL.ogr_g_simplifypreservetopology(geom.ptr, tol))
+    IGeometry(GDAL.ogr_g_simplifypreservetopology(geom, tol))
 
 unsafe_simplifypreservetopology(geom::AbstractGeometry, tol::Real)::Geometry =
-    Geometry(GDAL.ogr_g_simplifypreservetopology(geom.ptr, tol))
+    Geometry(GDAL.ogr_g_simplifypreservetopology(geom, tol))
 
 """
     delaunaytriangulation(geom::AbstractGeometry, tol::Real, onlyedges::Bool)
@@ -627,7 +627,7 @@ function delaunaytriangulation(
     tol::Real,
     onlyedges::Bool,
 )::IGeometry
-    return IGeometry(GDAL.ogr_g_delaunaytriangulation(geom.ptr, tol, onlyedges))
+    return IGeometry(GDAL.ogr_g_delaunaytriangulation(geom, tol, onlyedges))
 end
 
 function unsafe_delaunaytriangulation(
@@ -635,7 +635,7 @@ function unsafe_delaunaytriangulation(
     tol::Real,
     onlyedges::Bool,
 )::Geometry
-    return Geometry(GDAL.ogr_g_delaunaytriangulation(geom.ptr, tol, onlyedges))
+    return Geometry(GDAL.ogr_g_delaunaytriangulation(geom, tol, onlyedges))
 end
 
 """
@@ -651,7 +651,7 @@ computation is performed in 2d only
 * `maxlength`: the maximum distance between 2 points after segmentization
 """
 function segmentize!(geom::G, maxlength::Real)::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_segmentize(geom.ptr, maxlength)
+    GDAL.ogr_g_segmentize(geom, maxlength)
     return geom
 end
 
@@ -665,10 +665,10 @@ done in rigorous fashion otherwise `true` is returned if the envelopes (bounding
 boxes) of the two geometries overlap.
 """
 intersects(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_intersects(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_intersects(g1, g2))
 
 intersects(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogrpreparedgeometryintersects(g1.ptr, g2.ptr))
+    Bool(GDAL.ogrpreparedgeometryintersects(g1, g2))
 
 """
     equals(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -676,7 +676,7 @@ intersects(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if the geometries are equivalent.
 """
 equals(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_equals(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_equals(g1, g2))
 
 function Base.:(==)(g1::AbstractGeometry, g2::AbstractGeometry)
     return equals(g1, g2)
@@ -688,7 +688,7 @@ end
 Returns `true` if the geometries are disjoint.
 """
 disjoint(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_disjoint(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_disjoint(g1, g2))
 
 """
     touches(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -696,7 +696,7 @@ disjoint(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if the geometries are touching.
 """
 touches(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_touches(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_touches(g1, g2))
 
 """
     crosses(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -704,7 +704,7 @@ touches(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if the geometries are crossing.
 """
 crosses(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_crosses(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_crosses(g1, g2))
 
 """
     within(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -712,7 +712,7 @@ crosses(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if g1 is contained within g2.
 """
 within(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_within(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_within(g1, g2))
 
 """
     contains(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -720,10 +720,10 @@ within(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if g1 contains g2.
 """
 contains(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_contains(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_contains(g1, g2))
 
 contains(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogrpreparedgeometrycontains(g1.ptr, g2.ptr))
+    Bool(GDAL.ogrpreparedgeometrycontains(g1, g2))
 
 """
     overlaps(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -731,7 +731,7 @@ contains(g1::AbstractPreparedGeometry, g2::AbstractGeometry)::Bool =
 Returns `true` if the geometries overlap.
 """
 overlaps(g1::AbstractGeometry, g2::AbstractGeometry)::Bool =
-    Bool(GDAL.ogr_g_overlaps(g1.ptr, g2.ptr))
+    Bool(GDAL.ogr_g_overlaps(g1, g2))
 
 """
     boundary(geom::AbstractGeometry)
@@ -742,10 +742,10 @@ A new geometry object is created and returned containing the boundary of the
 geometry on which the method is invoked.
 """
 boundary(geom::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_boundary(geom.ptr))
+    IGeometry(GDAL.ogr_g_boundary(geom))
 
 unsafe_boundary(geom::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_boundary(geom.ptr))
+    Geometry(GDAL.ogr_g_boundary(geom))
 
 """
     convexhull(geom::AbstractGeometry)
@@ -756,10 +756,10 @@ A new geometry object is created and returned containing the convex hull of the
 geometry on which the method is invoked.
 """
 convexhull(geom::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_convexhull(geom.ptr))
+    IGeometry(GDAL.ogr_g_convexhull(geom))
 
 unsafe_convexhull(geom::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_convexhull(geom.ptr))
+    Geometry(GDAL.ogr_g_convexhull(geom))
 
 """
     buffer(geom::AbstractGeometry, dist::Real, quadsegs::Integer = 30)
@@ -785,14 +785,14 @@ accuracy of the result.
     (quadrant) of curvature.
 """
 buffer(geom::AbstractGeometry, dist::Real, quadsegs::Integer = 30)::IGeometry =
-    IGeometry(GDAL.ogr_g_buffer(geom.ptr, dist, quadsegs))
+    IGeometry(GDAL.ogr_g_buffer(geom, dist, quadsegs))
 
 function unsafe_buffer(
     geom::AbstractGeometry,
     dist::Real,
     quadsegs::Integer = 30,
 )::Geometry
-    return Geometry(GDAL.ogr_g_buffer(geom.ptr, dist, quadsegs))
+    return Geometry(GDAL.ogr_g_buffer(geom, dist, quadsegs))
 end
 
 """
@@ -806,10 +806,10 @@ geometries operated on. The OGR_G_Intersects() function can be used to test if
 two geometries intersect.
 """
 intersection(g1::AbstractGeometry, g2::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_intersection(g1.ptr, g2.ptr))
+    IGeometry(GDAL.ogr_g_intersection(g1, g2))
 
 unsafe_intersection(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_intersection(g1.ptr, g2.ptr))
+    Geometry(GDAL.ogr_g_intersection(g1, g2))
 
 """
     union(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -817,10 +817,10 @@ unsafe_intersection(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
 Returns a new geometry representing the union of the geometries.
 """
 union(g1::AbstractGeometry, g2::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_union(g1.ptr, g2.ptr))
+    IGeometry(GDAL.ogr_g_union(g1, g2))
 
 unsafe_union(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_union(g1.ptr, g2.ptr))
+    Geometry(GDAL.ogr_g_union(g1, g2))
 
 """
     pointonsurface(geom::AbstractGeometry)
@@ -833,10 +833,10 @@ than the types that are supported by SQL/MM-Part 3 : surfaces (polygons) and
 multisurfaces (multipolygons).
 """
 pointonsurface(geom::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_pointonsurface(geom.ptr))
+    IGeometry(GDAL.ogr_g_pointonsurface(geom))
 
 unsafe_pointonsurface(geom::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_pointonsurface(geom.ptr))
+    Geometry(GDAL.ogr_g_pointonsurface(geom))
 
 """
     difference(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -849,10 +849,10 @@ A new geometry representing the difference of the geometries, or NULL
 if the difference is empty.
 """
 difference(g1::AbstractGeometry, g2::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_difference(g1.ptr, g2.ptr))
+    IGeometry(GDAL.ogr_g_difference(g1, g2))
 
 unsafe_difference(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_difference(g1.ptr, g2.ptr))
+    Geometry(GDAL.ogr_g_difference(g1, g2))
 
 """
     symdifference(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -861,10 +861,10 @@ Returns a new geometry representing the symmetric difference of the geometries
 or NULL if the difference is empty or an error occurs.
 """
 symdifference(g1::AbstractGeometry, g2::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_symdifference(g1.ptr, g2.ptr))
+    IGeometry(GDAL.ogr_g_symdifference(g1, g2))
 
 unsafe_symdifference(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_symdifference(g1.ptr, g2.ptr))
+    Geometry(GDAL.ogr_g_symdifference(g1, g2))
 
 """
     distance(g1::AbstractGeometry, g2::AbstractGeometry)
@@ -872,21 +872,21 @@ unsafe_symdifference(g1::AbstractGeometry, g2::AbstractGeometry)::Geometry =
 Returns the distance between the geometries or -1 if an error occurs.
 """
 distance(g1::AbstractGeometry, g2::AbstractGeometry)::Float64 =
-    GDAL.ogr_g_distance(g1.ptr, g2.ptr)
+    GDAL.ogr_g_distance(g1, g2)
 
 """
     geomlength(geom::AbstractGeometry)
 
 Returns the length of the geometry, or 0.0 for unsupported geometry types.
 """
-geomlength(geom::AbstractGeometry)::Float64 = GDAL.ogr_g_length(geom.ptr)
+geomlength(geom::AbstractGeometry)::Float64 = GDAL.ogr_g_length(geom)
 
 """
     geomarea(geom::AbstractGeometry)
 
 Returns the area of the geometry or 0.0 for unsupported geometry types.
 """
-geomarea(geom::AbstractGeometry)::Float64 = GDAL.ogr_g_area(geom.ptr)
+geomarea(geom::AbstractGeometry)::Float64 = GDAL.ogr_g_area(geom)
 
 """
     centroid!(geom::AbstractGeometry, centroid::AbstractGeometry)
@@ -906,7 +906,7 @@ function centroid!(
     geom::AbstractGeometry,
     centroid::G,
 )::G where {G<:AbstractGeometry}
-    result = GDAL.ogr_g_centroid(geom.ptr, centroid.ptr)
+    result = GDAL.ogr_g_centroid(geom, centroid)
     @ogrerr result "Failed to compute the geometry centroid"
     return centroid
 end
@@ -951,10 +951,10 @@ Fetch point at given distance along curve.
 a point or NULL.
 """
 pointalongline(geom::AbstractGeometry, distance::Real)::IGeometry =
-    IGeometry(GDAL.ogr_g_value(geom.ptr, distance))
+    IGeometry(GDAL.ogr_g_value(geom, distance))
 
 unsafe_pointalongline(geom::AbstractGeometry, distance::Real)::Geometry =
-    Geometry(GDAL.ogr_g_value(geom.ptr, distance))
+    Geometry(GDAL.ogr_g_value(geom, distance))
 
 """
     empty!(geom::AbstractGeometry)
@@ -965,7 +965,7 @@ This restores the geometry to its initial state after construction, and before
 assignment of actual geometry.
 """
 function empty!(geom::G)::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_empty(geom.ptr)
+    GDAL.ogr_g_empty(geom)
     return geom
 end
 
@@ -1098,7 +1098,7 @@ Returns `true` if the geometry has a z coordinate, otherwise `false`.
 """
 is3d(geom::_AbstractGeometry2d) = false
 is3d(geom::_AbstractGeometry3d) = true
-# is3d(geom::AbstractGeometry)::Bool = GDAL.ogr_g_is3d(geom.ptr) != 0 # old GDAL method
+# is3d(geom::AbstractGeometry)::Bool = GDAL.ogr_g_is3d(geom) != 0 # old GDAL method
 
 """
     ismeasured(geom::AbstractGeometry)
@@ -1107,35 +1107,35 @@ Returns `true` if the geometry has a m coordinate, otherwise `false`.
 """
 ismeasured(geom::_AbstractGeometryHasM) = true
 ismeasured(geom::_AbstractGeometryNoM) = false
-# ismeasured(geom::AbstractGeometry)::Bool = GDAL.ogr_g_ismeasured(geom.ptr) != 0 # old GDAL method
+# ismeasured(geom::AbstractGeometry)::Bool = GDAL.ogr_g_ismeasured(geom) != 0 # old GDAL method
 
 """
     isempty(geom::AbstractGeometry)
 
 Returns `true` if the geometry has no points, otherwise `false`.
 """
-isempty(geom::AbstractGeometry)::Bool = GDAL.ogr_g_isempty(geom.ptr) != 0
+isempty(geom::AbstractGeometry)::Bool = GDAL.ogr_g_isempty(geom) != 0
 
 """
     isvalid(geom::AbstractGeometry)
 
 Returns `true` if the geometry is valid, otherwise `false`.
 """
-isvalid(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_isvalid(geom.ptr))
+isvalid(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_isvalid(geom))
 
 """
     issimple(geom::AbstractGeometry)
 
 Returns `true` if the geometry is simple, otherwise `false`.
 """
-issimple(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_issimple(geom.ptr))
+issimple(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_issimple(geom))
 
 """
     isring(geom::AbstractGeometry)
 
 Returns `true` if the geometry is a ring, otherwise `false`.
 """
-isring(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_isring(geom.ptr))
+isring(geom::AbstractGeometry)::Bool = Bool(GDAL.ogr_g_isring(geom))
 
 """
     polygonize(geom::AbstractGeometry)
@@ -1148,10 +1148,10 @@ correspond to a MultiLinestring, or when reassembling Edges into Polygons is
 impossible due to topological inconsistencies.
 """
 polygonize(geom::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_polygonize(geom.ptr))
+    IGeometry(GDAL.ogr_g_polygonize(geom))
 
 unsafe_polygonize(geom::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_polygonize(geom.ptr))
+    Geometry(GDAL.ogr_g_polygonize(geom))
 
 # """
 #     OGR_G_GetPoints(OGRGeometryH hGeom,
@@ -1188,28 +1188,28 @@ unsafe_polygonize(geom::AbstractGeometry)::Geometry =
 
 Fetch the x coordinate of a point from a geometry, at index i.
 """
-getx(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getx(geom.ptr, i)
+getx(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getx(geom, i)
 
 """
     gety(geom::AbstractGeometry, i::Integer)
 
 Fetch the y coordinate of a point from a geometry, at index i.
 """
-gety(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_gety(geom.ptr, i)
+gety(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_gety(geom, i)
 
 """
     getz(geom::AbstractGeometry, i::Integer)
 
 Fetch the z coordinate of a point from a geometry, at index i.
 """
-getz(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getz(geom.ptr, i)
+getz(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getz(geom, i)
 
 """
     getm(geom::AbstractGeometry, i::Integer)
 
 Fetch the m coordinate of a point from a geometry, at index i.
 """
-getm(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getm(geom.ptr, i)
+getm(geom::AbstractGeometry, i::Integer)::Float64 = GDAL.ogr_g_getm(geom, i)
 
 """
     getpoint(geom::AbstractGeometry, i::Integer)
@@ -1229,7 +1229,7 @@ function getpoint!(
     y,
     z,
 )::Tuple{Float64,Float64,Float64}
-    GDAL.ogr_g_getpoint(geom.ptr, i, x, y, z)
+    GDAL.ogr_g_getpoint(geom, i, x, y, z)
     return (x[], y[], z[])
 end
 
@@ -1243,7 +1243,7 @@ Set number of points in a geometry.
 * `n`: the new number of points for geometry.
 """
 function setpointcount!(geom::G, n::Integer)::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_setpointcount(geom.ptr, n)
+    GDAL.ogr_g_setpointcount(geom, n)
     return geom
 end
 
@@ -1269,7 +1269,7 @@ function setpoint!(
     y::Real,
     z::Real,
 )::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_setpoint(geom.ptr, i, x, y, z)
+    GDAL.ogr_g_setpoint(geom, i, x, y, z)
     return geom
 end
 
@@ -1279,7 +1279,7 @@ function setpoint!(
     x::Real,
     y::Real,
 )::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_setpoint_2d(geom.ptr, i, x, y)
+    GDAL.ogr_g_setpoint_2d(geom, i, x, y)
     return geom
 end
 
@@ -1303,12 +1303,12 @@ function addpoint!(
     y::Real,
     z::Real,
 )::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_addpoint(geom.ptr, x, y, z)
+    GDAL.ogr_g_addpoint(geom, x, y, z)
     return geom
 end
 
 function addpoint!(geom::G, x::Real, y::Real)::G where {G<:AbstractGeometry}
-    GDAL.ogr_g_addpoint_2d(geom.ptr, x, y)
+    GDAL.ogr_g_addpoint_2d(geom, x, y)
     return geom
 end
 
@@ -1354,8 +1354,8 @@ This corresponds to
 * `0` for other geometry types.
 """
 function ngeom(geom::AbstractGeometry)::Int32
-    n = GDAL.ogr_g_getpointcount(geom.ptr)::Int32
-    return n == 0 ? GDAL.ogr_g_getgeometrycount(geom.ptr) : n
+    n = GDAL.ogr_g_getpointcount(geom)::Int32
+    return n == 0 ? GDAL.ogr_g_getgeometrycount(geom) : n
 end
 
 """
@@ -1376,7 +1376,7 @@ function getgeom(geom::AbstractGeometry, i::Integer)::IGeometry
     # container, and should not be modified. The handle is only valid until the
     # next change to the geometry container. Use OGR_G_Clone() to make a copy.
     geom.ptr == C_NULL && return IGeometry{wkbUnknown}()
-    result = GDAL.ogr_g_getgeometryref(geom.ptr, i)
+    result = GDAL.ogr_g_getgeometryref(geom, i)
     result == C_NULL && return IGeometry{wkbUnknown}()
     return IGeometry(GDAL.ogr_g_clone(result))
 end
@@ -1396,7 +1396,7 @@ function unsafe_getgeom(geom::AbstractGeometry, i::Integer)::Geometry
     # container, and should not be modified. The handle is only valid until the
     # next change to the geometry container. Use OGR_G_Clone() to make a copy.
     geom.ptr == C_NULL && return Geometry{wkbUnknown}()
-    result = GDAL.ogr_g_getgeometryref(geom.ptr, i)
+    result = GDAL.ogr_g_getgeometryref(geom, i)
     result == C_NULL && return Geometry{wkbUnknown}()
     return Geometry(GDAL.ogr_g_clone(result))
 end
@@ -1429,7 +1429,7 @@ for (parent, child) in (
         i::Integer,
     )::Union{IGeometry{wkbUnknown},IGeometry{$child}}
         geom.ptr == C_NULL && return IGeometry{wkbUnknown}()
-        result = GDAL.ogr_g_getgeometryref(geom.ptr, i)
+        result = GDAL.ogr_g_getgeometryref(geom, i)
         result == C_NULL && return IGeometry{wkbUnknown}()
         return IGeometry{$child}(GDAL.ogr_g_clone(result))
     end
@@ -1438,7 +1438,7 @@ for (parent, child) in (
         i::Integer,
     )::Union{Geometry{wkbUnknown},Geometry{$child}}
         geom.ptr == C_NULL && return Geometry{wkbUnknown}()
-        result = GDAL.ogr_g_getgeometryref(geom.ptr, i)
+        result = GDAL.ogr_g_getgeometryref(geom, i)
         result == C_NULL && return Geometry{wkbUnknown}()
         return Geometry{$child}(GDAL.ogr_g_clone(result))
     end
@@ -1465,7 +1465,7 @@ function addgeom!(
     geomcontainer::G,
     subgeom::AbstractGeometry,
 )::G where {G<:AbstractGeometry}
-    result = GDAL.ogr_g_addgeometry(geomcontainer.ptr, subgeom.ptr)
+    result = GDAL.ogr_g_addgeometry(geomcontainer, subgeom)
     @ogrerr result "Failed to add geometry. The geometry type could be illegal"
     return geomcontainer
 end
@@ -1489,7 +1489,7 @@ end
 #         geomcontainer::AbstractGeometry,
 #         subgeom::AbstractGeometry
 #     )
-#     result = GDAL.ogr_g_addgeometrydirectly(geomcontainer.ptr, subgeom.ptr)
+#     result = GDAL.ogr_g_addgeometrydirectly(geomcontainer, subgeom)
 #     @ogrerr result "Failed to add geometry. The geometry type could be illegal"
 #     return geomcontainer
 # end
@@ -1512,7 +1512,7 @@ function removegeom!(
     i::Integer,
     todelete::Bool = true,
 )::G where {G<:AbstractGeometry}
-    result = GDAL.ogr_g_removegeometry(geom.ptr, i, todelete)
+    result = GDAL.ogr_g_removegeometry(geom, i, todelete)
     @ogrerr result "Failed to remove geometry. The index could be out of range."
     return geom
 end
@@ -1532,7 +1532,7 @@ function removeallgeoms!(
     geom::G,
     todelete::Bool = true,
 )::G where {G<:AbstractGeometry}
-    result = GDAL.ogr_g_removegeometry(geom.ptr, -1, todelete)
+    result = GDAL.ogr_g_removegeometry(geom, -1, todelete)
     @ogrerr result "Failed to remove all geometries."
     return geom
 end
@@ -1548,7 +1548,7 @@ Returns if this geometry is or has curve geometry.
     CIRCULARSTRING.
 """
 hascurvegeom(geom::AbstractGeometry, nonlinear::Bool)::Bool =
-    Bool(GDAL.ogr_g_hascurvegeometry(geom.ptr, nonlinear))
+    Bool(GDAL.ogr_g_hascurvegeometry(geom, nonlinear))
 
 """
     lineargeom(geom::AbstractGeometry, stepsize::Real = 0)
@@ -1591,7 +1591,7 @@ function lineargeom(
     options::Vector{String},
     stepsize::Real = 0,
 )::IGeometry
-    return IGeometry(GDAL.ogr_g_getlineargeometry(geom.ptr, stepsize, options))
+    return IGeometry(GDAL.ogr_g_getlineargeometry(geom, stepsize, options))
 end
 
 function unsafe_lineargeom(
@@ -1599,7 +1599,7 @@ function unsafe_lineargeom(
     options::Vector{String},
     stepsize::Real = 0,
 )::Geometry
-    return Geometry(GDAL.ogr_g_getlineargeometry(geom.ptr, stepsize, options))
+    return Geometry(GDAL.ogr_g_getlineargeometry(geom, stepsize, options))
 end
 
 """
@@ -1616,10 +1616,10 @@ If the geometry has no curve portion, the returned geometry will be a clone.
 The reverse function is OGR_G_GetLinearGeometry().
 """
 curvegeom(geom::AbstractGeometry)::IGeometry =
-    IGeometry(GDAL.ogr_g_getcurvegeometry(geom.ptr, C_NULL))
+    IGeometry(GDAL.ogr_g_getcurvegeometry(geom, C_NULL))
 
 unsafe_curvegeom(geom::AbstractGeometry)::Geometry =
-    Geometry(GDAL.ogr_g_getcurvegeometry(geom.ptr, C_NULL))
+    Geometry(GDAL.ogr_g_getcurvegeometry(geom, C_NULL))
 
 """
     polygonfromedges(lines::AbstractGeometry, tol::Real; besteffort = false,
@@ -1645,7 +1645,7 @@ function polygonfromedges(
 )::IGeometry
     perr = Ref{GDAL.OGRErr}()
     result = GDAL.ogrbuildpolygonfromedges(
-        lines.ptr,
+        lines,
         besteffort,
         autoclose,
         tol,
@@ -1663,7 +1663,7 @@ function unsafe_polygonfromedges(
 )::Geometry
     perr = Ref{GDAL.OGRErr}()
     result = GDAL.ogrbuildpolygonfromedges(
-        lines.ptr,
+        lines,
         besteffort,
         autoclose,
         tol,
@@ -1748,21 +1748,21 @@ for f in (:create, :unsafe_create)
             for pt in zip($(args...))
                 addpoint!(geom, pt...)
             end
-            return IGeometry{$T}(geom.ptr) # rewrap LinearRing as the corrent LineString/LineString25D
+            return IGeometry{$T}(geom) # rewrap LinearRing as the corrent LineString/LineString25D
         end
         @eval function unsafe_createlinearring($(typedargs...))
             geom = $f1(Val{wkbLinearRing}())
             for pt in zip($(args...))
                 addpoint!(geom, pt...)
             end
-            return Geometry{$T}(geom.ptr) # rewrap LinearRing as the corrent LineString/LineString25D
+            return Geometry{$T}(geom) # rewrap LinearRing as the corrent LineString/LineString25D
         end
         f1 = Symbol("$(f)polygon")
         T = Symbol("wkbPolygon" * typesuffix)
         @eval function $f1($(typedargs...))
             geom = $f1(Val{$T}())
             subgeom = unsafe_createlinearring($(args...))
-            result = GDAL.ogr_g_addgeometrydirectly(geom.ptr, subgeom.ptr)
+            result = GDAL.ogr_g_addgeometrydirectly(geom, subgeom)
             @ogrerr result "Failed to add linearring."
             return geom
         end
@@ -1772,7 +1772,7 @@ for f in (:create, :unsafe_create)
             geom = $f1(Val{$T}())
             for pt in zip($(args...))
                 subgeom = unsafe_createpoint(pt)
-                result = GDAL.ogr_g_addgeometrydirectly(geom.ptr, subgeom.ptr)
+                result = GDAL.ogr_g_addgeometrydirectly(geom, subgeom)
                 @ogrerr result "Failed to add point."
             end
             return geom
@@ -1804,7 +1804,7 @@ for f in (:create, :unsafe_create)
     # return geom
     # end
 
-    # Coordinates can be Vector of Real or 
+    # Coordinates can be Vector of Real or
     # TODO handle M and 25D
     coordtypes =
         (Vector{<:Real}, Tuple{<:Real,<:Real}, Tuple{<:Real,<:Real,<:Real})
@@ -1824,7 +1824,7 @@ for f in (:create, :unsafe_create)
         @eval function $f1(coords::$typeargs)
             geom = $f1()
             subgeom = unsafe_createlinearring(coords)
-            result = GDAL.ogr_g_addgeometrydirectly(geom.ptr, subgeom.ptr)
+            result = GDAL.ogr_g_addgeometrydirectly(geom, subgeom)
             @ogrerr result "Failed to add linearring."
             return geom
         end
@@ -1849,7 +1849,7 @@ for f in (:create, :unsafe_create)
             geom = $f1()
             for coord in coords
                 subgeom = $(Symbol("unsafe_create$component"))(coord)
-                result = GDAL.ogr_g_addgeometrydirectly(geom.ptr, subgeom.ptr)
+                result = GDAL.ogr_g_addgeometrydirectly(geom, subgeom)
                 @ogrerr result "Failed to add $component."
             end
             return geom

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1778,7 +1778,9 @@ for f in (:create, :unsafe_create)
             return geom
         end
     end
+end
 
+for f in (:create, :unsafe_create)
     f1 = Symbol("$(f)point")
     @eval $f1(cs::Real...) = $f1(cs)
     @eval $f1(coords::Vector) = $f1(Tuple(coords))

--- a/src/ogr/styletable.jl
+++ b/src/ogr/styletable.jl
@@ -12,7 +12,7 @@ an handle to the new style manager object.
 function unsafe_createstylemanager(
     styletable::StyleTable = StyleTable(),
 )::StyleManager
-    return StyleManager(GDAL.ogr_sm_create(styletable.ptr))
+    return StyleManager(GDAL.ogr_sm_create(styletable))
 end
 
 """
@@ -22,7 +22,7 @@ Destroy Style Manager.
 * `stylemanager`: handle to the style manager to destroy.
 """
 function destroy(sm::StyleManager)::Nothing
-    GDAL.ogr_sm_destroy(sm.ptr)
+    GDAL.ogr_sm_destroy(sm)
     sm.ptr = C_NULL
     return nothing
 end
@@ -39,10 +39,10 @@ Initialize style manager from the style string.
 `true` on success, `false` on error.
 """
 initialize!(stylemanager::StyleManager, stylestring::String)::Bool =
-    Bool(GDAL.ogr_sm_initstylestring(stylemanager.ptr, stylestring))
+    Bool(GDAL.ogr_sm_initstylestring(stylemanager, stylestring))
 
 initialize!(stylemanager::StyleManager)::Bool =
-    Bool(GDAL.ogr_sm_initstylestring(stylemanager.ptr, C_NULL))
+    Bool(GDAL.ogr_sm_initstylestring(stylemanager, C_NULL))
 
 """
     npart(stylemanager::StyleManager)
@@ -61,10 +61,10 @@ the number of parts (style tools) in the style.
 function npart end
 
 npart(stylemanager::StyleManager)::Integer =
-    GDAL.ogr_sm_getpartcount(stylemanager.ptr, C_NULL)
+    GDAL.ogr_sm_getpartcount(stylemanager, C_NULL)
 
 npart(stylemanager::StyleManager, stylestring::AbstractString)::Integer =
-    GDAL.ogr_sm_getpartcount(stylemanager.ptr, stylestring)
+    GDAL.ogr_sm_getpartcount(stylemanager, stylestring)
 
 """
     unsafe_getpart(stylemanager::StyleManager, id::Integer,
@@ -86,7 +86,7 @@ function unsafe_getpart(
     id::Integer,
     stylestring = C_NULL,
 )::StyleTool
-    return StyleTool(GDAL.ogr_sm_getpart(stylemanager.ptr, id, stylestring))
+    return StyleTool(GDAL.ogr_sm_getpart(stylemanager, id, stylestring))
 end
 
 """
@@ -102,7 +102,7 @@ Add a part (style tool) to the current style.
 `true` on success, `false` on error.
 """
 addpart!(stylemanager::StyleManager, styletool::StyleTool)::Bool =
-    Bool(GDAL.ogr_sm_addpart(stylemanager.ptr, styletool.ptr))
+    Bool(GDAL.ogr_sm_addpart(stylemanager, styletool))
 
 """
     addstyle!(stylemanager::StyleManager, stylename, stylestring)
@@ -123,11 +123,11 @@ function addstyle!(
     stylename::AbstractString,
     stylestring::AbstractString,
 )::Bool
-    return Bool(GDAL.ogr_sm_addstyle(stylemanager.ptr, stylename, stylestring))
+    return Bool(GDAL.ogr_sm_addstyle(stylemanager, stylename, stylestring))
 end
 
 addstyle!(stylemanager::StyleManager, stylename::AbstractString)::Bool =
-    Bool(GDAL.ogr_sm_addstyle(stylemanager.ptr, stylename, C_NULL))
+    Bool(GDAL.ogr_sm_addstyle(stylemanager, stylename, C_NULL))
 
 """
     unsafe_createstyletool(classid::OGRSTClassId)
@@ -151,7 +151,7 @@ Destroy Style Tool.
 * `styletool`: handle to the style tool to destroy.
 """
 function destroy(styletool::StyleTool)::Nothing
-    GDAL.ogr_st_destroy(styletool.ptr)
+    GDAL.ogr_st_destroy(styletool)
     styletool.ptr = C_NULL
     return nothing
 end
@@ -168,7 +168,7 @@ Determine type of Style Tool.
 the style tool type, one of OGRSTCPen (1), OGRSTCBrush (2), OGRSTCSymbol (3) or
 OGRSTCLabel (4). Returns OGRSTCNone (0) if the OGRStyleToolH is invalid.
 """
-gettype(styletool::StyleTool)::OGRSTClassId = GDAL.ogr_st_gettype(styletool.ptr)
+gettype(styletool::StyleTool)::OGRSTClassId = GDAL.ogr_st_gettype(styletool)
 
 """
     getunit(styletool::StyleTool)
@@ -181,7 +181,7 @@ Get Style Tool units.
 ### Returns
 the style tool units.
 """
-getunit(styletool::StyleTool)::OGRSTUnitId = GDAL.ogr_st_getunit(styletool.ptr)
+getunit(styletool::StyleTool)::OGRSTUnitId = GDAL.ogr_st_getunit(styletool)
 
 """
     setunit!(styletool::StyleTool, newunit::OGRSTUnitId, scale::Real)
@@ -198,7 +198,7 @@ function setunit!(
     newunit::OGRSTUnitId,
     scale::Real,
 )::StyleTool
-    GDAL.ogr_st_setunit(styletool.ptr, newunit, scale)
+    GDAL.ogr_st_setunit(styletool, newunit, scale)
     return styletool
 end
 
@@ -220,7 +220,7 @@ Get Style Tool parameter value as a string.
 the parameter value as a string and sets `nullflag`.
 """
 asstring(styletool::StyleTool, id::Integer, nullflag::Ref{Cint})::String =
-    GDAL.ogr_st_getparamstr(styletool.ptr, id, nullflag)
+    GDAL.ogr_st_getparamstr(styletool, id, nullflag)
 
 asstring(styletool::StyleTool, id::Integer)::String =
     asstring(styletool, id, Ref{Cint}(0))
@@ -246,7 +246,7 @@ function asint(
     id::Integer,
     nullflag::Ref{Cint} = Ref{Cint}(0),
 )::Int32
-    return GDAL.ogr_st_getparamnum(styletool.ptr, id, nullflag)
+    return GDAL.ogr_st_getparamnum(styletool, id, nullflag)
 end
 
 """
@@ -270,7 +270,7 @@ function asdouble(
     id::Integer,
     nullflag::Ref{Cint} = Ref{Cint}(0),
 )::Float64
-    return GDAL.ogr_st_getparamdbl(styletool.ptr, id, nullflag)
+    return GDAL.ogr_st_getparamdbl(styletool, id, nullflag)
 end
 
 """
@@ -292,17 +292,17 @@ function setparam!(
     id::Integer,
     value::AbstractString,
 )::StyleTool
-    GDAL.ogr_st_setparamstr(styletool.ptr, id, value)
+    GDAL.ogr_st_setparamstr(styletool, id, value)
     return styletool
 end
 
 function setparam!(styletool::StyleTool, id::Integer, value::Integer)::StyleTool
-    GDAL.ogr_st_setparamnum(styletool.ptr, id, value)
+    GDAL.ogr_st_setparamnum(styletool, id, value)
     return styletool
 end
 
 function setparam!(styletool::StyleTool, id::Integer, value::Float64)::StyleTool
-    GDAL.ogr_st_setparamdbl(styletool.ptr, id, value)
+    GDAL.ogr_st_setparamdbl(styletool, id, value)
     return styletool
 end
 
@@ -318,7 +318,7 @@ Get the style string for this Style Tool.
 the style string for this style tool or "" if the styletool is invalid.
 """
 getstylestring(styletool::StyleTool)::String =
-    GDAL.ogr_st_getstylestring(styletool.ptr)
+    GDAL.ogr_st_getstylestring(styletool)
 
 """
     toRGBA(styletool::StyleTool, color::AbstractString)
@@ -342,7 +342,7 @@ function toRGBA(
     alpha = Ref{Int32}(0)
     result = Bool(
         GDAL.ogr_st_getrgbfromstring(
-            styletool.ptr,
+            styletool,
             color,
             red,
             green,
@@ -371,7 +371,7 @@ Destroy Style Table.
 * `styletable`: handle to the style table to destroy.
 """
 function destroy(st::StyleTable)::Nothing
-    GDAL.ogr_stbl_destroy(st.ptr)
+    GDAL.ogr_stbl_destroy(st)
     st.ptr = C_NULL
     return nothing
 end
@@ -394,7 +394,7 @@ function addstyle!(
     stylename::AbstractString,
     stylestring::AbstractString,
 )::Bool
-    return Bool(GDAL.ogr_stbl_addstyle(styletable.ptr, stylename, stylestring))
+    return Bool(GDAL.ogr_stbl_addstyle(styletable, stylename, stylestring))
 end
 
 """
@@ -410,7 +410,7 @@ Save a style table to a file.
 `true` on success, `false` on error
 """
 savestyletable(styletable::StyleTable, filename::AbstractString)::Bool =
-    Bool(GDAL.ogr_stbl_savestyletable(styletable.ptr, filename))
+    Bool(GDAL.ogr_stbl_savestyletable(styletable, filename))
 
 """
     loadstyletable!(styletable::StyleTable, filename::AbstractString)
@@ -425,7 +425,7 @@ Load a style table from a file.
 `true` on success, `false` on error
 """
 loadstyletable!(styletable::StyleTable, filename::AbstractString)::Bool =
-    Bool(GDAL.ogr_stbl_loadstyletable(styletable.ptr, filename))
+    Bool(GDAL.ogr_stbl_loadstyletable(styletable, filename))
 
 """
     findstylestring(styletable::StyleTable, name::AbstractString)
@@ -440,7 +440,7 @@ Get a style string by name.
 the style string matching the name or NULL if not found or error.
 """
 findstylestring(styletable::StyleTable, name::AbstractString)::String =
-    GDAL.ogr_stbl_find(styletable.ptr, name)
+    GDAL.ogr_stbl_find(styletable, name)
 
 """
     resetreading!(styletable::StyleTable)
@@ -451,7 +451,7 @@ Reset the next style pointer to 0.
 * `styletable`: handle to the style table.
 """
 function resetreading!(styletable::StyleTable)::StyleTable
-    GDAL.ogr_stbl_resetstylestringreading(styletable.ptr)
+    GDAL.ogr_stbl_resetstylestringreading(styletable)
     return styletable
 end
 
@@ -467,7 +467,7 @@ Get the next style string from the table.
 the next style string or NULL on error.
 """
 nextstyle(styletable::StyleTable)::String =
-    GDAL.ogr_stbl_getnextstyle(styletable.ptr)
+    GDAL.ogr_stbl_getnextstyle(styletable)
 
 """
     laststyle(styletable::StyleTable)
@@ -481,4 +481,4 @@ Get the style name of the last style string fetched with OGR_STBL_GetNextStyle.
 the Name of the last style string or NULL on error.
 """
 laststyle(styletable::StyleTable)::String =
-    GDAL.ogr_stbl_getlaststylename(styletable.ptr)
+    GDAL.ogr_stbl_getlaststylename(styletable)

--- a/src/raster/colortable.jl
+++ b/src/raster/colortable.jl
@@ -8,7 +8,7 @@ unsafe_createcolortable(palette::GDALPaletteInterp)::ColorTable =
 
 "Destroys a color table."
 function destroy(ct::ColorTable)::Nothing
-    GDAL.gdaldestroycolortable(ct.ptr)
+    GDAL.gdaldestroycolortable(ct)
     ct.ptr = C_NULL
     return nothing
 end
@@ -22,7 +22,7 @@ function unsafe_clone(ct::ColorTable)::ColorTable
     return if ct.ptr == C_NULL
         ColorTable(C_NULL)
     else
-        ColorTable(GDAL.gdalclonecolortable(ct.ptr))
+        ColorTable(GDAL.gdalclonecolortable(ct))
     end
 end
 
@@ -35,7 +35,7 @@ Fetch palette interpretation.
 palette interpretation enumeration value, usually `GPI_RGB`.
 """
 paletteinterp(ct::ColorTable)::GDALPaletteInterp =
-    GDAL.gdalgetpaletteinterpretation(ct.ptr)
+    GDAL.gdalgetpaletteinterpretation(ct)
 
 """
     getcolorentryasrgb(ct::ColorTable, i::Integer)
@@ -54,7 +54,7 @@ tables.
 """
 function getcolorentryasrgb(ct::ColorTable, i::Integer)::GDAL.GDALColorEntry
     colorentry = Ref{GDAL.GDALColorEntry}(GDAL.GDALColorEntry(0, 0, 0, 0))
-    result = Bool(GDAL.gdalgetcolorentryasrgb(ct.ptr, i, colorentry))
+    result = Bool(GDAL.gdalgetcolorentryasrgb(ct, i, colorentry))
     result || @warn("The conversion to RGB isn't supported.")
     return colorentry[]
 end
@@ -75,6 +75,6 @@ The table is grown as needed to hold the supplied offset.
 * `entry` value to assign to table.
 """
 function setcolorentry!(ct::ColorTable, i::Integer, entry::GDAL.GDALColorEntry)
-    GDAL.gdalsetcolorentry(ct.ptr, i, Ref{GDAL.GDALColorEntry}(entry))
+    GDAL.gdalsetcolorentry(ct, i, Ref{GDAL.GDALColorEntry}(entry))
     return ct
 end

--- a/src/raster/images.jl
+++ b/src/raster/images.jl
@@ -46,7 +46,7 @@ function imview(
         elseif gpi == GPI_RGB
             colorentries = GDAL.GDALColorEntry[
                 getcolorentryasrgb(colortable, i - 1) for
-                i in 1:GDAL.gdalgetcolorentrycount(colortable.ptr)
+                i in 1:GDAL.gdalgetcolorentrycount(colortable)
             ]
             c1 = Matrix{UInt8}(undef, size(imgvalues)...)
             c2 = Matrix{UInt8}(undef, size(imgvalues)...)

--- a/src/raster/rasterattributetable.jl
+++ b/src/raster/rasterattributetable.jl
@@ -16,7 +16,7 @@ unsafe_createRAT(ct::ColorTable)::RasterAttrTable =
 
 "Destroys a RAT."
 function destroy(rat::RasterAttrTable)::Nothing
-    GDAL.gdaldestroyrasterattributetable(rat.ptr)
+    GDAL.gdaldestroyrasterattributetable(rat)
     rat.ptr = C_NULL
     return nothing
 end
@@ -26,7 +26,7 @@ end
 
 Fetch table column count.
 """
-ncolumn(rat::RasterAttrTable)::Integer = GDAL.gdalratgetcolumncount(rat.ptr)
+ncolumn(rat::RasterAttrTable)::Integer = GDAL.gdalratgetcolumncount(rat)
 
 """
     columnname(rat::RasterAttrTable, i::Integer)
@@ -40,7 +40,7 @@ Fetch name of indicated column.
 the column name or an empty string for invalid column numbers.
 """
 columnname(rat::RasterAttrTable, i::Integer)::String =
-    GDAL.gdalratgetnameofcol(rat.ptr, i)
+    GDAL.gdalratgetnameofcol(rat, i)
 
 """
     columnusage(rat::RasterAttrTable, i::Integer)
@@ -48,7 +48,7 @@ columnname(rat::RasterAttrTable, i::Integer)::String =
 Fetch column usage value.
 """
 columnusage(rat::RasterAttrTable, i::Integer)::GDALRATFieldUsage =
-    GDAL.gdalratgetusageofcol(rat.ptr, i)
+    GDAL.gdalratgetusageofcol(rat, i)
 
 """
     columntype(rat::RasterAttrTable, i::Integer)
@@ -62,7 +62,7 @@ Fetch column type.
 column type or `GFT_Integer` if the column index is illegal.
 """
 columntype(rat::RasterAttrTable, i::Integer)::GDALRATFieldType =
-    GDAL.gdalratgettypeofcol(rat.ptr, i)
+    GDAL.gdalratgettypeofcol(rat, i)
 
 """
     findcolumnindex(rat::RasterAttrTable, usage::GDALRATFieldUsage)
@@ -74,14 +74,14 @@ match is found.
 * `usage`  usage type to search for.
 """
 findcolumnindex(rat::RasterAttrTable, usage::GDALRATFieldUsage)::Integer =
-    GDAL.gdalratgetcolofusage(rat.ptr, usage)
+    GDAL.gdalratgetcolofusage(rat, usage)
 
 """
     nrow(rat::RasterAttrTable)
 
 Fetch row count.
 """
-nrow(rat::RasterAttrTable)::Integer = GDAL.gdalratgetrowcount(rat.ptr)
+nrow(rat::RasterAttrTable)::Integer = GDAL.gdalratgetrowcount(rat)
 
 """
     asstring(rat::RasterAttrTable, row::Integer, col::Integer)
@@ -97,7 +97,7 @@ some precision may be lost.
 * `col`  column to fetch (zero based).
 """
 asstring(rat::RasterAttrTable, row::Integer, col::Integer)::String =
-    GDAL.gdalratgetvalueasstring(rat.ptr, row, col)
+    GDAL.gdalratgetvalueasstring(rat, row, col)
 
 """
     asint(rat::RasterAttrTable, row::Integer, col::Integer)
@@ -112,7 +112,7 @@ Non-integer fields will be converted to int with the possibility of data loss.
 * `col`  column to fetch (zero based).
 """
 asint(rat::RasterAttrTable, row::Integer, col::Integer)::Integer =
-    GDAL.gdalratgetvalueasint(rat.ptr, row, col)
+    GDAL.gdalratgetvalueasint(rat, row, col)
 
 """
     asdouble(rat::RasterAttrTable, row::Integer, col::Integer)
@@ -127,7 +127,7 @@ Non double fields will be converted to double with the possibility of data loss.
 * `col`  column to fetch (zero based).
 """
 asdouble(rat::RasterAttrTable, row::Integer, col::Integer)::Float64 =
-    GDAL.gdalratgetvalueasdouble(rat.ptr, row, col)
+    GDAL.gdalratgetvalueasdouble(rat, row, col)
 
 """
     setvalue!(rat::RasterAttrTable, row, col, val)
@@ -151,7 +151,7 @@ function setvalue!(
     col::Integer,
     val::AbstractString,
 )::RasterAttrTable
-    GDAL.gdalratsetvalueasstring(rat.ptr, row, col, val)
+    GDAL.gdalratsetvalueasstring(rat, row, col, val)
     return rat
 end
 
@@ -161,7 +161,7 @@ function setvalue!(
     col::Integer,
     val::Integer,
 )::RasterAttrTable
-    GDAL.gdalratsetvalueasint(rat.ptr, row, col, val)
+    GDAL.gdalratsetvalueasint(rat, row, col, val)
     return rat
 end
 
@@ -171,7 +171,7 @@ function setvalue!(
     col::Integer,
     val::Float64,
 )::RasterAttrTable
-    GDAL.gdalratsetvalueasdouble(rat.ptr, row, col, val)
+    GDAL.gdalratsetvalueasdouble(rat, row, col, val)
     return rat
 end
 
@@ -185,7 +185,7 @@ Otherwise this is unnecessary since changes to this object are reflected in the
 dataset.
 """
 changesarewrittentofile(rat::RasterAttrTable)::Bool =
-    Bool(GDAL.gdalratchangesarewrittentofile(rat.ptr))
+    Bool(GDAL.gdalratchangesarewrittentofile(rat))
 
 """
     attributeio!(rat::RasterAttrTable, access::GDALRWFlag, col, startrow, nrows,
@@ -212,7 +212,7 @@ function attributeio!(
     data::Vector{Float64},
 )::Vector{Float64}
     result = GDAL.gdalratvaluesioasdouble(
-        rat.ptr,
+        rat,
         access,
         col,
         startrow,
@@ -232,7 +232,7 @@ function attributeio!(
     data::Vector{Cint},
 )::Vector{Cint}
     result = GDAL.gdalratvaluesioasinteger(
-        rat.ptr,
+        rat,
         access,
         col,
         startrow,
@@ -252,7 +252,7 @@ function attributeio!(
     data::Vector{T},
 )::Vector{T} where {T<:AbstractString}
     result = GDAL.gdalratvaluesioasstring(
-        rat.ptr,
+        rat,
         access,
         col,
         startrow,
@@ -273,7 +273,7 @@ will be initialized to their default values - \"\" for strings, and zero for
 numeric fields.
 """
 function setrowcount!(rat::RasterAttrTable, n::Integer)::RasterAttrTable
-    GDAL.gdalratsetrowcount(rat.ptr, n)
+    GDAL.gdalratsetrowcount(rat, n)
     return rat
 end
 
@@ -294,7 +294,7 @@ function createcolumn!(
     fieldtype::GDALRATFieldType,
     fieldusage::GDALRATFieldUsage,
 )::RasterAttrTable
-    result = GDAL.gdalratcreatecolumn(rat.ptr, name, fieldtype, fieldusage)
+    result = GDAL.gdalratcreatecolumn(rat, name, fieldtype, fieldusage)
     @cplerr result "Failed to create column $name"
     return rat
 end
@@ -317,7 +317,7 @@ function setlinearbinning!(
     row0min::Real,
     binsize::Real,
 )::RasterAttrTable
-    result = GDAL.gdalratsetlinearbinning(rat.ptr, row0min, binsize)
+    result = GDAL.gdalratsetlinearbinning(rat, row0min, binsize)
     @cplerr result "Fail to set linear binning: r0min=$row0min, width=$binsize"
     return rat
 end
@@ -334,7 +334,7 @@ Get linear binning information.
 function getlinearbinning(rat::RasterAttrTable)::Tuple{Cdouble,Cdouble}
     row0min = Ref{Cdouble}()
     binsize = Ref{Cdouble}()
-    result = GDAL.gdalratgetlinearbinning(rat.ptr, row0min, binsize)
+    result = GDAL.gdalratgetlinearbinning(rat, row0min, binsize)
     result == false || @warn("There is no linear binning information.")
     return (row0min[], binsize[])
 end
@@ -358,7 +358,7 @@ function initializeRAT!(
     rat::RasterAttrTable,
     colortable::ColorTable,
 )::RasterAttrTable
-    result = GDAL.gdalratinitializefromcolortable(rat.ptr, colortable.ptr)
+    result = GDAL.gdalratinitializefromcolortable(rat, colortable)
     @cplerr result "Failed to initialize RAT from color table"
     return rat
 end
@@ -375,7 +375,7 @@ Translate to a color table.
 the generated color table or `NULL` on failure.
 """
 toColorTable(rat::RasterAttrTable, n::Integer = -1)::ColorTable =
-    ColorTable(GDAL.gdalrattranslatetocolortable(rat.ptr, n))
+    ColorTable(GDAL.gdalrattranslatetocolortable(rat, n))
 
 # """
 #     GDALRATDumpReadable(GDALRasterAttributeTableH,
@@ -398,14 +398,14 @@ attribute table is too large to clone:
     `(nrow() * ncolumn() > RAT_MAX_ELEM_FOR_CLONE)`
 """
 unsafe_clone(rat::RasterAttrTable)::RasterAttrTable =
-    RasterAttrTable(GDAL.gdalratclone(rat.ptr))
+    RasterAttrTable(GDAL.gdalratclone(rat))
 
 # """
 #     serializeJSON(rat::RasterAttrTable)
-# 
+#
 # Serialize Raster Attribute Table in Json format.
 # """
-# serializeJSON(rat::RasterAttrTable) = GDAL.gdalratserializejson(rat.ptr)
+# serializeJSON(rat::RasterAttrTable) = GDAL.gdalratserializejson(rat)
 
 """
     findrowindex(rat::RasterAttrTable, pxvalue::Real)
@@ -422,4 +422,4 @@ which row in the table applies to the pixel value. The row index is returned.
 The row index or -1 if no row is appropriate.
 """
 findrowindex(rat::RasterAttrTable, pxvalue::Real)::Integer =
-    GDAL.gdalratgetrowofvalue(rat.ptr, pxvalue)
+    GDAL.gdalratgetrowofvalue(rat, pxvalue)

--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -441,7 +441,7 @@ function regenerateoverviews!(
     result = GDAL.gdalregenerateoverviews(
         band,
         length(overviewbands),
-        [band.ptr for band in overviewbands],
+        overviewbands,
         resampling,
         cfunc,
         progressdata,

--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -147,7 +147,7 @@ function rasterio!(
     bands = isa(bands, Vector{Cint}) ? bands : Cint.(collect(bands))
     @assert nband == zbsize
     result = GDAL.gdaldatasetrasterioex(
-        dataset.ptr,
+        dataset,
         access,
         xoffset,
         yoffset,
@@ -237,7 +237,7 @@ function rasterio!(
     (rasterband == C_NULL) && error("Can't read NULL rasterband")
     xbsize, ybsize = size(buffer)
     result = GDAL.gdalrasterioex(
-        rasterband.ptr,
+        rasterband,
         access,
         xoffset,
         yoffset,
@@ -562,7 +562,7 @@ function readblock!(
     yoffset::Integer,
     buffer::T,
 )::T where {T<:Any}
-    result = GDAL.gdalreadblock(rb.ptr, xoffset, yoffset, buffer)
+    result = GDAL.gdalreadblock(rb, xoffset, yoffset, buffer)
     @cplerr result "Failed to read block at ($xoffset,$yoffset)"
     return buffer
 end
@@ -592,7 +592,7 @@ function writeblock!(
     yoffset::Integer,
     buffer,
 )::T where {T<:AbstractRasterBand}
-    result = GDAL.gdalwriteblock(rb.ptr, xoffset, yoffset, buffer)
+    result = GDAL.gdalwriteblock(rb, xoffset, yoffset, buffer)
     @cplerr result "Failed to write block at ($xoffset, $yoffset)"
     return rb
 end

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -201,7 +201,7 @@ Construct a Spatial Reference System from its WKT.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 function newspatialref(wkt::AbstractString = ""; order::Symbol = :compliant)
@@ -227,7 +227,7 @@ function maybesetaxisorder!(
 )::T where {T<:AbstractSpatialRef}
     if order == :trad
         GDAL.osrsetaxismappingstrategy(
-            spref.ptr,
+            spref,
             GDAL.OAMS_TRADITIONAL_GIS_ORDER,
         )
     elseif order != :compliant
@@ -241,7 +241,7 @@ function maybesetaxisorder!(
 end
 
 function destroy(spref::AbstractSpatialRef)::Nothing
-    GDAL.osrdestroyspatialreference(spref.ptr)
+    GDAL.osrdestroyspatialreference(spref)
     spref.ptr = C_NULL
     return nothing
 end
@@ -255,7 +255,7 @@ function clone(spref::AbstractSpatialRef)::ISpatialRef
     return if spref.ptr == C_NULL
         ISpatialRef()
     else
-        ISpatialRef(GDAL.osrclone(spref.ptr))
+        ISpatialRef(GDAL.osrclone(spref))
     end
 end
 
@@ -263,7 +263,7 @@ function unsafe_clone(spref::AbstractSpatialRef)::SpatialRef
     return if spref.ptr == C_NULL
         SpatialRef()
     else
-        SpatialRef(GDAL.osrclone(spref.ptr))
+        SpatialRef(GDAL.osrclone(spref))
     end
 end
 
@@ -293,7 +293,7 @@ directory identified by the GDAL_DATA configuration option. See CPLFindFile()
 for details.
 """
 function importEPSG!(spref::T, code::Integer)::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromepsg(spref.ptr, code)
+    result = GDAL.osrimportfromepsg(spref, code)
     @ogrerr result "Failed to initialize SRS based on EPSG"
     return spref
 end
@@ -305,7 +305,7 @@ Construct a Spatial Reference System from its EPSG GCS or PCS code.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 importEPSG(code::Integer; kwargs...)::ISpatialRef =
@@ -327,7 +327,7 @@ contrary to typical GIS use). See `importFromEPSG()` for more
 details on operation of this method.
 """
 function importEPSGA!(spref::T, code::Integer)::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromepsga(spref.ptr, code)
+    result = GDAL.osrimportfromepsga(spref, code)
     @ogrerr result "Failed to initializ SRS based on EPSGA"
     return spref
 end
@@ -369,7 +369,7 @@ function importWKT!(
     spref::T,
     wktstr::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromwkt(spref.ptr, [wktstr])
+    result = GDAL.osrimportfromwkt(spref, [wktstr])
     @ogrerr result "Failed to initialize SRS based on WKT string"
     return spref
 end
@@ -381,7 +381,7 @@ Create SRS from its WKT string.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis  ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis  ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 importWKT(wktstr::AbstractString; kwargs...)::ISpatialRef =
@@ -416,7 +416,7 @@ function importPROJ4!(
     spref::T,
     projstr::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromproj4(spref.ptr, projstr)
+    result = GDAL.osrimportfromproj4(spref, projstr)
     @ogrerr result "Failed to initialize SRS based on PROJ4 string"
     return spref
 end
@@ -428,7 +428,7 @@ Create SRS from its PROJ.4 string.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 importPROJ4(projstr::AbstractString; kwargs...)::ISpatialRef =
@@ -463,7 +463,7 @@ function importESRI!(
     spref::T,
     esristr::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromesri(spref.ptr, [esristr])
+    result = GDAL.osrimportfromesri(spref, [esristr])
     @ogrerr result "Failed to initialize SRS based on ESRI string"
     return spref
 end
@@ -473,7 +473,7 @@ end
 
 Create SRS from its ESRI .prj format(s).
 
-Passing the keyword argument `order=:compliant` or `order=:trad` will set the 
+Passing the keyword argument `order=:compliant` or `order=:trad` will set the
 mapping strategy to return compliant axis order or traditional lon/lat order.
 """
 importESRI(esristr::AbstractString; kwargs...)::ISpatialRef =
@@ -491,7 +491,7 @@ function importXML!(
     spref::T,
     xmlstr::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromxml(spref.ptr, xmlstr)
+    result = GDAL.osrimportfromxml(spref, xmlstr)
     @ogrerr result "Failed to initialize SRS based on XML string"
     return spref
 end
@@ -501,12 +501,12 @@ end
 
 Construct SRS from XML format (GML only currently).
 
-Passing the keyword argument `order=:compliant` or `order=:trad` will set the 
+Passing the keyword argument `order=:compliant` or `order=:trad` will set the
 mapping strategy to return compliant axis order or traditional lon/lat order.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 importXML(xmlstr::AbstractString; kwargs...)::ISpatialRef =
@@ -527,7 +527,7 @@ function importURL!(
     spref::T,
     url::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrimportfromurl(spref.ptr, url)
+    result = GDAL.osrimportfromurl(spref, url)
     @ogrerr result "Failed to initialize SRS from URL"
     return spref
 end
@@ -542,7 +542,7 @@ SetFromUserInput for you.
 
 # Keyword Arguments
 - `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
-    axis ordering in any actions done with the crs. `:compliant`, will use axis 
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
 importURL(url::AbstractString; kwargs...)::ISpatialRef =
@@ -558,7 +558,7 @@ Convert this SRS into WKT format.
 """
 function toWKT(spref::AbstractSpatialRef)::String
     wktptr = Ref{Cstring}()
-    result = GDAL.osrexporttowkt(spref.ptr, wktptr)
+    result = GDAL.osrexporttowkt(spref, wktptr)
     @ogrerr result "Failed to convert this SRS into WKT format"
     return unsafe_string(wktptr[])
 end
@@ -575,7 +575,7 @@ Convert this SRS into a nicely formatted WKT string for display to a person.
 """
 function toWKT(spref::AbstractSpatialRef, simplify::Bool)::String
     wktptr = Ref{Cstring}()
-    result = GDAL.osrexporttoprettywkt(spref.ptr, wktptr, simplify)
+    result = GDAL.osrexporttoprettywkt(spref, wktptr, simplify)
     @ogrerr result "Failed to convert this SRS into pretty WKT"
     return unsafe_string(wktptr[])
 end
@@ -587,7 +587,7 @@ Export coordinate system in PROJ.4 format.
 """
 function toPROJ4(spref::AbstractSpatialRef)::String
     projptr = Ref{Cstring}()
-    result = GDAL.osrexporttoproj4(spref.ptr, projptr)
+    result = GDAL.osrexporttoproj4(spref, projptr)
     @ogrerr result "Failed to export this SRS to PROJ.4 format"
     return unsafe_string(projptr[])
 end
@@ -603,7 +603,7 @@ be returned along with OGRERR_NONE.
 """
 function toXML(spref::AbstractSpatialRef)::String
     xmlptr = Ref{Cstring}()
-    result = GDAL.osrexporttoxml(spref.ptr, xmlptr, C_NULL)
+    result = GDAL.osrexporttoxml(spref, xmlptr, C_NULL)
     @ogrerr result "Failed to convert this SRS into XML"
     return unsafe_string(xmlptr[])
 end
@@ -615,7 +615,7 @@ Export coordinate system in Mapinfo style CoordSys format.
 """
 function toMICoordSys(spref::AbstractSpatialRef)::String
     ptr = Ref{Cstring}()
-    result = GDAL.osrexporttomicoordsys(spref.ptr, ptr)
+    result = GDAL.osrexporttomicoordsys(spref, ptr)
     @ogrerr result "Failed to convert this SRS into XML"
     return unsafe_string(ptr[])
 end
@@ -631,7 +631,7 @@ variety of projections and arguments, and stripping out nodes note recognised by
 ESRI (like AUTHORITY and AXIS).
 """
 function morphtoESRI!(spref::T)::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrmorphtoesri(spref.ptr)
+    result = GDAL.osrmorphtoesri(spref)
     @ogrerr result "Failed to convert in place to ESRI WKT format"
     return spref
 end
@@ -665,7 +665,7 @@ of the following (`TOWGS84` recommended for proper datum shift calculations)
         `GEOGCS`. Does not impact `PROJCS` values.
 """
 function morphfromESRI!(spref::T)::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrmorphfromesri(spref.ptr)
+    result = GDAL.osrmorphfromesri(spref)
     @ogrerr result "Failed to convert in place from ESRI WKT format"
     return spref
 end
@@ -690,7 +690,7 @@ function setattrvalue!(
     path::AbstractString,
     value::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrsetattrvalue(spref.ptr, path, value)
+    result = GDAL.osrsetattrvalue(spref, path, value)
     @ogrerr result "Failed to set attribute path to value"
     return spref
 end
@@ -699,7 +699,7 @@ function setattrvalue!(
     spref::T,
     path::AbstractString,
 )::T where {T<:AbstractSpatialRef}
-    result = GDAL.osrsetattrvalue(spref.ptr, path, C_NULL)
+    result = GDAL.osrsetattrvalue(spref, path, C_NULL)
     @ogrerr result "Failed to set attribute path"
     return spref
 end
@@ -726,7 +726,7 @@ function getattrvalue(
     name::AbstractString,
     i::Integer,
 )::Union{String,Nothing}
-    return GDAL.osrgetattrvalue(spref.ptr, name, i)
+    return GDAL.osrgetattrvalue(spref, name, i)
 end
 
 """
@@ -747,13 +747,13 @@ function unsafe_createcoordtrans(
     target::AbstractSpatialRef,
 )::CoordTransform
     return CoordTransform(
-        GDAL.octnewcoordinatetransformation(source.ptr, target.ptr),
+        GDAL.octnewcoordinatetransformation(source, target),
     )
 end
 
 "OGRCoordinateTransformation destructor."
 function destroy(obj::CoordTransform)::Nothing
-    GDAL.octdestroycoordinatetransformation(obj.ptr)
+    GDAL.octdestroycoordinatetransformation(obj)
     obj.ptr = C_NULL
     return nothing
 end
@@ -784,7 +784,7 @@ function transform!(
     @assert length(zvertices) == n
     return Bool(
         GDAL.octtransform(
-            obj.ptr,
+            obj,
             n,
             pointer(xvertices),
             pointer(yvertices),

--- a/src/types.jl
+++ b/src/types.jl
@@ -725,3 +725,24 @@ Return if type and subtype are compatible.
 """
 arecompatible(dtype::OGRFieldType, subtype::OGRFieldSubType)::Bool =
     Bool(GDAL.ogr_aretypesubtypecompatible(dtype, subtype))
+
+# teach ccall how to get the pointer to pass to libgdal
+# this way the Julia compiler will track the lifetimes for us
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractGeometry) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractSpatialRef) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractDataset) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractFeature) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractFeatureDefn) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractFeatureLayer) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractFieldDefn) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractGeomFieldDefn) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::AbstractRasterBand) = x.ptr
+
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::CoordTransform) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::Driver) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::Field) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::RasterAttrTable) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::StyleManager) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::StyleTable) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::StyleTool) = x.ptr
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::ColorTable) = x.ptr

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -14,7 +14,7 @@ String corresponding to the information about the raster dataset.
 function gdalinfo(dataset::AbstractDataset, options = String[])::String
     gdal_info_options = GDAL.gdalinfooptionsnew(options, C_NULL)
     return try
-        GDAL.gdalinfo(dataset.ptr, gdal_info_options)
+        GDAL.gdalinfo(dataset, gdal_info_options)
     finally
         GDAL.gdalinfooptionsfree(gdal_info_options)
     end
@@ -43,7 +43,7 @@ function unsafe_gdaltranslate(
 )::Dataset
     options = GDAL.gdaltranslateoptionsnew(options, C_NULL)
     usage_error = Ref{Cint}()
-    result = GDAL.gdaltranslate(dest, dataset.ptr, options, usage_error)
+    result = GDAL.gdaltranslate(dest, dataset, options, usage_error)
     GDAL.gdaltranslateoptionsfree(options)
     return Dataset(result)
 end
@@ -156,7 +156,7 @@ function unsafe_gdaldem(
     usage_error = Ref{Cint}()
     result = GDAL.gdaldemprocessing(
         dest,
-        dataset.ptr,
+        dataset,
         processing,
         colorfile,
         options,
@@ -189,7 +189,7 @@ function unsafe_gdalnearblack(
 )::Dataset
     options = GDAL.gdalnearblackoptionsnew(options, C_NULL)
     usage_error = Ref{Cint}()
-    result = GDAL.gdalnearblack(dest, C_NULL, dataset.ptr, options, usage_error)
+    result = GDAL.gdalnearblack(dest, C_NULL, dataset, options, usage_error)
     GDAL.gdalnearblackoptionsfree(options)
     return Dataset(result)
 end
@@ -217,7 +217,7 @@ function unsafe_gdalgrid(
 )::Dataset
     options = GDAL.gdalgridoptionsnew(options, C_NULL)
     usage_error = Ref{Cint}()
-    result = GDAL.gdalgrid(dest, dataset.ptr, options, usage_error)
+    result = GDAL.gdalgrid(dest, dataset, options, usage_error)
     GDAL.gdalgridoptionsfree(options)
     return Dataset(result)
 end
@@ -245,7 +245,7 @@ function unsafe_gdalrasterize(
 )::Dataset
     options = GDAL.gdalrasterizeoptionsnew(options, C_NULL)
     usage_error = Ref{Cint}()
-    result = GDAL.gdalrasterize(dest, C_NULL, dataset.ptr, options, usage_error)
+    result = GDAL.gdalrasterize(dest, C_NULL, dataset, options, usage_error)
     GDAL.gdalrasterizeoptionsfree(options)
     return Dataset(result)
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -75,7 +75,7 @@ function unsafe_gdalwarp(
         dest,
         C_NULL,
         length(datasets),
-        [ds.ptr for ds in datasets],
+        datasets,
         options,
         usage_error,
     )
@@ -110,7 +110,7 @@ function unsafe_gdalvectortranslate(
         dest,
         C_NULL,
         length(datasets),
-        [ds.ptr for ds in datasets],
+        datasets,
         options,
         usage_error,
     )
@@ -276,7 +276,7 @@ function unsafe_gdalbuildvrt(
     result = GDAL.gdalbuildvrt(
         dest,
         length(datasets),
-        [ds.ptr for ds in datasets],
+        datasets,
         C_NULL,
         options,
         usage_error,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -270,7 +270,7 @@ end
 Fetch list of (non-empty) metadata domains.
 """
 metadatadomainlist(obj)::Vector{String} =
-    GDAL.gdalgetmetadatadomainlist(obj.ptr)
+    GDAL.gdalgetmetadatadomainlist(obj)
 
 """
     metadata(obj; domain::AbstractString = "")
@@ -278,7 +278,7 @@ metadatadomainlist(obj)::Vector{String} =
 Fetch metadata. Note that relatively few formats return any metadata.
 """
 metadata(obj; domain::AbstractString = "")::Vector{String} =
-    GDAL.gdalgetmetadata(obj.ptr, domain)
+    GDAL.gdalgetmetadata(obj, domain)
 
 """
     metadataitem(obj, name::AbstractString, domain::AbstractString)
@@ -297,7 +297,7 @@ function metadataitem(
     name::AbstractString;
     domain::AbstractString = "",
 )::String
-    item = GDAL.gdalgetmetadataitem(obj.ptr, name, domain)
+    item = GDAL.gdalgetmetadataitem(obj, name, domain)
     # Use `=== nothing` instead of isnothing() for performance.
     # See https://github.com/JuliaLang/julia/pull/36444 for context.
     return item === nothing ? "" : item

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -344,10 +344,10 @@ import GeoFormatTypes as GFT
             AG.createlinearring([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]) do geom
                 @test GI.geomtrait(geom) == GI.LineStringTrait()
                 @test GI.testgeometry(geom)
-                @test typeof(geom) == AG.Geometry{AG.wkbLineString} # GDAL only uses the LinearRing enum during construction  
-                @test AG._infergeomtype(geom.ptr) == AG.wkbLineString
+                @test typeof(geom) == AG.Geometry{AG.wkbLineString} # GDAL only uses the LinearRing enum during construction
+                @test AG._infergeomtype(geom) == AG.wkbLineString
                 @test !AG.is3d(geom)
-                @test GDAL.ogr_g_is3d(geom.ptr) == 0
+                @test GDAL.ogr_g_is3d(geom) == 0
                 @test typeof(AG.getgeom(geom, 0)) == AG.IGeometry{AG.wkbPoint}
                 @test isapprox(
                     GI.coordinates(geom),
@@ -363,9 +363,9 @@ import GeoFormatTypes as GFT
             points = [1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]
             AG.createlinearring(points...) do geom
                 @test GI.testgeometry(geom)
-                @test AG._infergeomtype(geom.ptr) == AG.wkbLineString25D
+                @test AG._infergeomtype(geom) == AG.wkbLineString25D
                 @test AG.is3d(geom)
-                @test GDAL.ogr_g_is3d(geom.ptr) == 1
+                @test GDAL.ogr_g_is3d(geom) == 1
                 @test typeof(geom) == AG.Geometry{AG.wkbLineString25D}
                 @test typeof(AG.getgeom(geom, 0)) ==
                       AG.IGeometry{AG.wkbPoint25D}
@@ -518,7 +518,7 @@ import GeoFormatTypes as GFT
             ) do geom
                 @test GI.geomtrait(geom) == GI.MultiPolygonTrait()
                 @test GI.testgeometry(geom)
-                @test GDAL.ogr_g_is3d(geom.ptr) == 0
+                @test GDAL.ogr_g_is3d(geom) == 0
                 @test !GI.is3d(geom)
                 @test typeof(geom) == AG.Geometry{AG.wkbMultiPolygon}
                 @test typeof(AG.getgeom(geom, 0)) == AG.IGeometry{AG.wkbPolygon}

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -345,7 +345,6 @@ import GeoFormatTypes as GFT
                 @test GI.geomtrait(geom) == GI.LineStringTrait()
                 @test GI.testgeometry(geom)
                 @test typeof(geom) == AG.Geometry{AG.wkbLineString} # GDAL only uses the LinearRing enum during construction
-                @test AG._infergeomtype(geom) == AG.wkbLineString
                 @test !AG.is3d(geom)
                 @test GDAL.ogr_g_is3d(geom) == 0
                 @test typeof(AG.getgeom(geom, 0)) == AG.IGeometry{AG.wkbPoint}
@@ -363,7 +362,6 @@ import GeoFormatTypes as GFT
             points = [1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]
             AG.createlinearring(points...) do geom
                 @test GI.testgeometry(geom)
-                @test AG._infergeomtype(geom) == AG.wkbLineString25D
                 @test AG.is3d(geom)
                 @test GDAL.ogr_g_is3d(geom) == 1
                 @test typeof(geom) == AG.Geometry{AG.wkbLineString25D}

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -117,7 +117,7 @@ import ArchGDAL as AG
                 AG.getoverview(destband, 0) do overview
                     return AG.regenerateoverviews!(
                         destband,
-                        ArchGDAL.AbstractRasterBand{UInt8}[
+                        AG.AbstractRasterBand{UInt8}[
                             overview,
                             AG.getoverview(destband, 2),
                         ],

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -29,8 +29,8 @@ import ImageCore
 
             # Manual defined convert for Enums
             @enum TestEnum::Bool EnumValue = false
-            @test convert(ArchGDAL.OGRFieldType, TestEnum) == AG.OFTInteger
-            @test convert(ArchGDAL.OGRFieldSubType, TestEnum) == AG.OFSTBoolean
+            @test convert(AG.OGRFieldType, TestEnum) == AG.OFTInteger
+            @test convert(AG.OGRFieldSubType, TestEnum) == AG.OFSTBoolean
         end
     end
 


### PR DESCRIPTION
Adress #347, alternative approach to #348, based on discussion in #347.

Still has a few errors, like this:

```
Expression: AG.toWKT(AG.createlinearring([1, 2, 3], [4, 5, 6])) == AG.toWKT(AG.createlinearring([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])) == "LINEARRING (1 4,2 5,3 6)"
  MethodError: no method matching ArchGDAL.IGeometry{ArchGDAL.wkbLineString}(::ArchGDAL.Geometry{ArchGDAL.wkbLineString})

  Closest candidates are:
    ArchGDAL.IGeometry{T}(::Ptr{Nothing}) where T
     @ ArchGDAL D:\visser_mn\.julia\dev\ArchGDAL\src\types.jl:251

  Stacktrace:
   [1] createlinearring(xs::Vector{Int64}, ys::Vector{Int64})
     @ ArchGDAL D:\visser_mn\.julia\dev\ArchGDAL\src\ogr\geometry.jl:1751
   [2] macro expansion
     @ D:\visser_mn\.julia\juliaup\julia-1.10.0-latest+0.x64\share\julia\stdlib\v1.10\Test\src\Test.jl:477 [inlined]
   [3] macro expansion
     @ D:\visser_mn\.julia\dev\ArchGDAL\test\test_geometry.jl:339 [inlined]
```

So probably we need to add some constructors to handle this case. Not sure how to best do that safely, i.e. should we clone here? If not, how do we track lifetimes?