### PR TITLE
Fix macro callback.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -231,17 +231,21 @@ end
 macro cplprogress(progressfunc)
     @static if Sys.ARCH == :aarch64
         @warn "User provided progress functions are unsupported on this architecture."
-        return @cfunction(
-            GDAL.gdaldummyprogress,
-            Cint,
-            (Cdouble, Cstring, Ptr{Cvoid})
-        )
+        quote
+            @cfunction(
+                $(Expr(:$, esc(GDAL.gdaldummyprogress))),
+                Cint,
+                (Cdouble, Cstring, Ptr{Cvoid})
+            )
+        end
     else
-        return @cfunction(
-            $(esc(progressfunc)),
-            Cint,
-            (Cdouble, Cstring, Ptr{Cvoid})
-        )
+        quote
+            @cfunction(
+                $(Expr(:$, esc(progressfunc))),
+                Cint,
+                (Cdouble, Cstring, Ptr{Cvoid})
+            )
+        end
     end
 end
 


### PR DESCRIPTION
We never created the cfunction correctly in the macro, but because it became C_NULL, this was never noticed. (Also it seems no-one uses progress callbacks.). 

Oddly enough, on 1.8.2 the undefined behaviour changed, which started crashing M1 macs.
Probably fixes https://github.com/JuliaLang/julia/issues/47193.
