### PR TITLE
[breaking] switch from Base.convert to GeoInterface.convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - breaking: Updated compat for GDAL.jl 1.5 and fixed tests for GDAL 3.6. These include changes to `gdalnearblack`, `fillunsetwithdefault!` and `gdalgetgeotransform`.
+- breaking: Use `GeoInterface.convert` instead of `convert` to convert geometries from other
+  packages to ArchGDAL via the GeoInterface. Example: `GeoInterface.convert(AG.IGeometry, geom)`
 
 ## [0.9.4] - 2022-12-30
 

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -278,20 +278,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         return toWKT(geom)
     end
 
-    function Base.convert(::Type{T}, geom::X) where {T<:IGeometry,X}
-        return Base.convert(T, GeoInterface.geomtrait(geom), geom)
-    end
-    function Base.convert(
-        ::Type{T},
-        ::GeometryTraits,
-        geom::T,
-    ) where {T<:IGeometry}
-        return geom
-    end  # fast fallthrough without conversion
-    function Base.convert(::Type{T}, ::Nothing, geom::T) where {T<:IGeometry}
-        return geom
-    end  # fast fallthrough without conversion
-    function Base.convert(
+    function GeoInterface.convert(
         ::Type{T},
         type::GeometryTraits,
         geom,

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1005,7 +1005,7 @@ import GeoFormatTypes as GFT
         GI.getgeom(::GI.LineStringTrait, geom::MyLine, i) = MyPoint()
 
         geom = MyLine()
-        ag_geom = convert(AG.IGeometry, geom)
+        ag_geom = GI.convert(AG.IGeometry, geom)
         GI.coordinates(ag_geom) == [[1, 2], [1, 2]]
     end
 end


### PR DESCRIPTION
This is a breaking change.

For background see https://github.com/JuliaGeo/GeoInterface.jl/pull/66. Brought up in https://github.com/yeesian/ArchGDAL.jl/issues/189#issuecomment-1368537576.

Soon https://github.com/JuliaGeo/GeoInterface.jl/pull/85 will provide extra options for conversion, though this doesn't help ArchGDAL as much, since you always convert to `IGeometry` anyway. And it is not breaking so no need to wait for that.

After this is in, shall we tag v0.10?