### PR TITLE
implement module convert for geometries

### DIFF
--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -1,5 +1,7 @@
 using Extents
 
+geointerface_geomtype(::GeoInterface.AbstractGeometryTrait) = IGeometry
+
 const lookup_method = Dict{DataType,Function}(
     GeoInterface.PointTrait => createpoint,
     GeoInterface.MultiPointTrait => createmultipoint,

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1006,6 +1006,10 @@ import GeoFormatTypes as GFT
 
         geom = MyLine()
         ag_geom = GI.convert(AG.IGeometry, geom)
-        GI.coordinates(ag_geom) == [[1, 2], [1, 2]]
+        @test ag_geom isa AG.IGeometry{AG.wkbLineString}
+        @test GI.coordinates(ag_geom) == GI.coordinates(ag_geom) == [[1, 2], [1, 2]]
+        ag_geom1 = GI.convert(AG, geom)
+        @test ag_geom1 isa AG.IGeometry{AG.wkbLineString}
+        @test GI.coordinates(ag_geom1) == GI.coordinates(ag_geom) == [[1, 2], [1, 2]]
     end
 end


### PR DESCRIPTION
This allows us to do `GeoInterface.convert(ArchGDAL, geom)` with any GeoInterface.jl compatible geometry.