### PR TITLE
relax type constraint in unsafe_executesql

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -800,7 +800,7 @@ function unsafe_executesql(
     dataset::AbstractDataset,
     query::AbstractString;
     dialect::AbstractString = "",
-    spatialfilter::Geometry = Geometry(C_NULL),
+    spatialfilter::AbstractGeometry = Geometry(C_NULL),
 )::FeatureLayer
     return FeatureLayer(
         GDAL.gdaldatasetexecutesql(dataset, query, spatialfilter, dialect),


### PR DESCRIPTION
Hi! I just switched the spatialfilter type constraint to `AbstractGeometry`, so that one can use `IGeometry{wkbPolygon}` as filter. I hope this is valid; at least it seems to work.