### PR TITLE
faster getpoint

### DIFF
--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -133,6 +133,30 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     )
         return getgeom(geom, i - 1)
     end
+    # Return a tuple point rather than a GDAL point
+    function GeoInterface.getpoint(
+        ::GeoInterface.AbstractLineStringTrait,
+        geom::AbstractGeometry,
+        i::Integer,
+    )
+        if is3d(geom)
+            return (p[1], p[2], p[3])
+        else
+            return (p[1], p[2])
+        end
+    end
+    # Preallocate `Ref`s to reduce allocations.
+    function GeoInterface.getpoint(
+        ::GeoInterface.AbstractLineStringTrait,
+        geom::AbstractGeometry,
+    )
+        refs = Ref{Float64}(), Ref{Float64}(), Ref{Float64}()
+        if is3d(geom)
+            return ((p = getpoint!(geom, i - 1, refs...); (p[1], p[2], p[3])) for i in 1:GeoInterface.npoint(geom))
+        else
+            return ((p = getpoint!(geom, i - 1, refs...); (p[1], p[2])) for i in 1:GeoInterface.npoint(geom))
+        end
+    end
 
     # Operations
     function GeoInterface.intersects(

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -134,8 +134,8 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         return getgeom(geom, i - 1)
     end
     # Return a tuple point rather than a GDAL point
-    function GeoInterface.getpoint(
-        ::GeoInterface.AbstractLineStringTrait,
+    function GeoInterface.getgeom(
+        ::GeoInterface.LineStringTrait,
         geom::AbstractGeometry,
         i::Integer,
     )
@@ -148,8 +148,8 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         end
     end
     # Preallocate `Ref`s to reduce allocations.
-    function GeoInterface.getpoint(
-        ::GeoInterface.AbstractLineStringTrait,
+    function GeoInterface.getgeom(
+        ::GeoInterface.LineStringTrait,
         geom::AbstractGeometry,
     )
         # We need three refs, even for 2d points

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -139,6 +139,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         geom::AbstractGeometry,
         i::Integer,
     )
+        # This allocates 3 refs, best to use the iterator method instead
         p = getpoint(geom, i - 1)
         if is3d(geom)
             return (p[1], p[2], p[3])
@@ -151,6 +152,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         ::GeoInterface.AbstractLineStringTrait,
         geom::AbstractGeometry,
     )
+        # We need three refs, even for 2d points
         refs = Ref{Float64}(), Ref{Float64}(), Ref{Float64}()
         if is3d(geom)
             return ((p = getpoint!(geom, i - 1, refs...); (p[1], p[2], p[3])) for i in 1:GeoInterface.npoint(geom))

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -139,6 +139,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         geom::AbstractGeometry,
         i::Integer,
     )
+        p = getpoint(geom, i - 1)
         if is3d(geom)
             return (p[1], p[2], p[3])
         else

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -435,7 +435,6 @@ import GeoFormatTypes as GFT
                     [[1, 4], [2, 5], [3, 6]],
                     atol = 1e-6,
                 )
-                @test GI.getpoint(geom, 3) == (3, 6)
                 @test AG.toWKT(geom) == "MULTIPOINT (1 4,2 5,3 6)"
             end
             AG.createmultipoint(

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -289,7 +289,6 @@ import GeoFormatTypes as GFT
                     atol = 1e-6,
                 )
                 @test GI.getgeom(geom, 1) == (1, 4)
-                @test ArchGDAL.createpoint(GI.getgeom(geom, 1)) == (1, 4)
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
                 AG.closerings!(geom)
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -289,6 +289,8 @@ import GeoFormatTypes as GFT
                     atol = 1e-6,
                 )
                 @test GI.getgeom(geom, 1) == (1, 4)
+                # Round-trip via geointeface
+                @test AG.toWKT(AG.createlinestring(collect(GI.getgeom(geom)))) == "LINESTRING (1 4,2 5,3 6)"
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
                 AG.closerings!(geom)
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
@@ -354,6 +356,9 @@ import GeoFormatTypes as GFT
                     [[1, 4], [2, 5], [3, 6]],
                     atol = 1e-6,
                 )
+                @test GI.getgeom(geom, 1) == (1, 4)
+                # Round-trip via geointeface
+                @test AG.toWKT(AG.createlinearring(collect(GI.getgeom(geom)))) == "LINEARRING (1 4,2 5,3 6)"
                 @test AG.toWKT(geom) == "LINEARRING (1 4,2 5,3 6)"
                 AG.setpointcount!(geom, 5)
                 @test AG.toWKT(geom) == "LINEARRING (1 4,2 5,3 6,0 0,0 0)"
@@ -447,7 +452,6 @@ import GeoFormatTypes as GFT
                 @test typeof(geom) == AG.Geometry{AG.wkbMultiPoint25D}
                 @test typeof(AG.getgeom(geom, 0)) ==
                       AG.IGeometry{AG.wkbPoint25D}
-                @test GI.getpoint(geom, 1) == (1.0, 2.0, 3.0)
                 @test AG.toWKT(geom) == "MULTIPOINT (1 4 7,2 5 8,3 6 9)"
             end
         end

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -288,6 +288,8 @@ import GeoFormatTypes as GFT
                     [[1, 4], [2, 5], [3, 6]],
                     atol = 1e-6,
                 )
+                @test GI.getgeom(geom, 1) == (1, 4)
+                @test ArchGDAL.createpoint(GI.getgeom(geom, 1)) == (1, 4)
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
                 AG.closerings!(geom)
                 @test AG.toWKT(geom) == "LINESTRING (1 4,2 5,3 6)"
@@ -434,6 +436,7 @@ import GeoFormatTypes as GFT
                     [[1, 4], [2, 5], [3, 6]],
                     atol = 1e-6,
                 )
+                @test GI.getpoint(geom, 3) == (3, 6)
                 @test AG.toWKT(geom) == "MULTIPOINT (1 4,2 5,3 6)"
             end
             AG.createmultipoint(
@@ -446,6 +449,7 @@ import GeoFormatTypes as GFT
                 @test typeof(geom) == AG.Geometry{AG.wkbMultiPoint25D}
                 @test typeof(AG.getgeom(geom, 0)) ==
                       AG.IGeometry{AG.wkbPoint25D}
+                @test GI.getpoint(geom, 1) == (1.0, 2.0, 3.0)
                 @test AG.toWKT(geom) == "MULTIPOINT (1 4 7,2 5 8,3 6 9)"
             end
         end


### PR DESCRIPTION
`getpoint` is pretty slow currently, to the point rasterizing a shapefile from ArchGDAL.jl is 20x slower than one from Shapefile.jl. Mostly because getting points allocates every time.

This PR greatly (but not completely) reduces the gap by:
1. Not returning GDAL points. They are pretty inefficient when we have thousands of points. A `Tuple` is better.
2. Preallocating `Ref` for `getpoint!` in the iterator for `Geointerfce.getpoint(linestring)`, and reusing them for each point. 

This is implemented for line string but that means polygon will also work. It's probably not worth the effort of passing the Ref through from polygons, but I haven't checked. There may be more objects that need this treatment.

Edit: I assumed this would have a test already, but seems not.