### PR TITLE
Introduce `importUSER` for setting SRS from custom strings.

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -243,7 +243,7 @@ for gdalfunc in (
     :importPROJ4,
     :importWKT,
     :importXML,
-    :importUSER,
+    :importUserInput,
     :importURL,
     :lineargeom,
     :newspatialref,

--- a/src/context.jl
+++ b/src/context.jl
@@ -243,6 +243,7 @@ for gdalfunc in (
     :importPROJ4,
     :importWKT,
     :importXML,
+    :importUSER,
     :importURL,
     :lineargeom,
     :newspatialref,

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -312,7 +312,7 @@ unsafe_importEPSG(code::Integer; kwargs...)::SpatialRef =
     importEPSG!(unsafe_newspatialref(; kwargs...), code)
 
 """
-    importUSER(code::AbstractString; [order=:compliant])
+    importUserInput(code::AbstractString; [order=:compliant])
 
 Construct a Spatial Reference System from a user provided code that is parsed by GDAL.
 This is useful when the input code is in an unknown format or a shortcut not covered by more constrained methods.
@@ -323,13 +323,13 @@ An example is the code "EPSG:4326+3855", the shortest way to describe a combinat
     axis ordering in any actions done with the crs. `:compliant`, will use axis
     ordering compliant with the relevant CRS authority.
 """
-importUSER(code::AbstractString; kwargs...)::ISpatialRef =
-    importUSER!(newspatialref(; kwargs...), code)
+importUserInput(code::AbstractString; kwargs...)::ISpatialRef =
+    importUserInput!(newspatialref(; kwargs...), code)
 
-unsafe_importUSER(code::AbstractString; kwargs...)::SpatialRef =
-    importUSER!(unsafe_newspatialref(; kwargs...), code)
+unsafe_importUserInput(code::AbstractString; kwargs...)::SpatialRef =
+    importUserInput!(unsafe_newspatialref(; kwargs...), code)
 
-function importUSER!(
+function importUserInput!(
     spref::T,
     code::AbstractString,
 )::T where {T<:AbstractSpatialRef}

--- a/src/spatialref.jl
+++ b/src/spatialref.jl
@@ -312,6 +312,33 @@ unsafe_importEPSG(code::Integer; kwargs...)::SpatialRef =
     importEPSG!(unsafe_newspatialref(; kwargs...), code)
 
 """
+    importUSER(code::AbstractString; [order=:compliant])
+
+Construct a Spatial Reference System from a user provided code that is parsed by GDAL.
+This is useful when the input code is in an unknown format or a shortcut not covered by more constrained methods.
+An example is the code "EPSG:4326+3855", the shortest way to describe a combination of a horizontal and vertical crs.
+
+# Keyword Arguments
+- `order`: Sets the axis mapping strategy. `:trad` will use traditional lon/lat
+    axis ordering in any actions done with the crs. `:compliant`, will use axis
+    ordering compliant with the relevant CRS authority.
+"""
+importUSER(code::AbstractString; kwargs...)::ISpatialRef =
+    importUSER!(newspatialref(; kwargs...), code)
+
+unsafe_importUSER(code::AbstractString; kwargs...)::SpatialRef =
+    importUSER!(unsafe_newspatialref(; kwargs...), code)
+
+function importUSER!(
+    spref::T,
+    code::AbstractString,
+)::T where {T<:AbstractSpatialRef}
+    result = GDAL.osrsetfromuserinput(spref, code)
+    @ogrerr result "Failed to initialize SRS based on user input"
+    return spref
+end
+
+"""
     importEPSGA!(spref::AbstractSpatialRef, code::Integer)
 
 Initialize SRS based on EPSG CRS code.

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -177,6 +177,7 @@ import GeoFormatTypes as GFT
           </gml:usesCartesianCS>
         </gml:ProjectedCRS>
         """
+        cepsg = "EPSG:4326+3855"
 
         @testset "PROJ4 Format" begin
             AG.importPROJ4(proj4326) do spatialref
@@ -211,6 +212,15 @@ import GeoFormatTypes as GFT
                 @test startswith(AG.toXML(spatialref2), "<gml:ProjectedCRS")
                 AG.importXML!(spatialref2, xml4326)
                 @test startswith(AG.toXML(spatialref2), "<gml:GeographicCRS")
+            end
+        end
+
+        @testset "User provided Format" begin
+            AG.importUSER(cepsg) do spatialref
+                spatialref2 = AG.importUSER(cepsg)
+                @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
+                AG.importUSER!(spatialref2, cepsg)
+                @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
             end
         end
 

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -216,10 +216,10 @@ import GeoFormatTypes as GFT
         end
 
         @testset "User provided Format" begin
-            AG.importUSER(cepsg) do spatialref
-                spatialref2 = AG.importUSER(cepsg)
+            AG.importUserInput(cepsg) do spatialref
+                spatialref2 = AG.importUserInput(cepsg)
                 @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
-                AG.importUSER!(spatialref2, cepsg)
+                AG.importUserInput!(spatialref2, cepsg)
                 @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
             end
         end


### PR DESCRIPTION
Now we can do:

```julia
julia> p = ArchGDAL.importUSER("EPSG:4326+3855")
Spatial Reference System: +proj=longlat +datum=WGS84 +geoidgr ... _defs
```

Note how there's now `+geoidgrid` present, which represents the vertical transform of EPSG:3855.
