### PR TITLE
fix inference on GI.getcoord

### DIFF
--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -87,21 +87,23 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     end
     function GeoInterface.z(
         ::GeoInterface.AbstractPointTrait,
-        geom::_AbstractGeometryZ,
+        geom::AbstractGeometry,
     )
+        geom isa _AbstractGeometry3d || throw(ArgumentError("Geometry does not have `Z` values")) 
         return getz(geom, 0)
     end
     function GeoInterface.m(
         ::GeoInterface.AbstractPointTrait,
-        geom::_AbstractGeometryM,
+        geom::AbstractGeometry,
     )
+        geom isa _AbstractGeometryHasM || throw(ArgumentError("Geometry does not have `M` values")) 
         return getm(geom, 0)
     end
 
     function GeoInterface.getcoord(
         ::GeoInterface.AbstractPointTrait,
         geom::AbstractGeometry,
-        i,
+        i::Int,
     )
         if i == 1
             getx(geom, 0)

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -114,9 +114,12 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         elseif i == 4 && ismeasured(geom) && is3d(geom)
             getm(geom, 0)
         else
-            return nothing
+            _getcoord_error(i)
         end
     end
+
+    @noinline _getcoord_error(i) = 
+        throw(ArgumentError("Getcoord index must be between 1 and 4. Got $i"))
 
     function GeoInterface.isempty(::GeometryTraits, geom::AbstractGeometry)
         return isempty(geom)

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -118,8 +118,9 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         end
     end
 
-    @noinline _getcoord_error(i) = 
-        throw(ArgumentError("Getcoord index must be between 1 and 4. Got $i"))
+    @noinline function _getcoord_error(i)
+        throw(ArgumentError("Invalid getcoord index $i, must be between 1 and 2/3/4."))
+    end
 
     function GeoInterface.isempty(::GeometryTraits, geom::AbstractGeometry)
         return isempty(geom)

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -103,7 +103,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     function GeoInterface.getcoord(
         ::GeoInterface.AbstractPointTrait,
         geom::AbstractGeometry,
-        i::Int,
+        i::Integer,
     )
         if i == 1
             getx(geom, 0)

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -15,8 +15,8 @@ import GeoFormatTypes as GFT
             @test GI.m(point) == nothing
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 3)
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
+            @test_throws ErrorException GI.getcoord(point, 3)
+            @test_throws ErrorException GI.getcoord(point, 4)
         end
         AG.createpoint(100, 70, 1) do point
             @test GI.geomtrait(point) == GI.PointTrait()
@@ -29,7 +29,7 @@ import GeoFormatTypes as GFT
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
             @test GI.getcoord(point, 3) == 1
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
+            @test_throws ErrorException GI.getcoord(point, 4)
         end
         @test GI.isgeometry(AG.IGeometry)
     end
@@ -971,14 +971,14 @@ import GeoFormatTypes as GFT
     @testset "Test coordinate dimensions" begin
         AG.createpoint(1, 2, 3) do point
             @test GI.getcoord(point, 3) == 3
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
+            @test_throws ErrorException GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test GI.is3d(point)
         end
         AG.createpoint(1, 2) do point
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 3)
-            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
+            @test_throws ErrorException GI.getcoord(point, 3)
+            @test_throws ErrorException GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test !GI.is3d(point)

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -15,8 +15,8 @@ import GeoFormatTypes as GFT
             @test GI.m(point) == nothing
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
-            @test GI.getcoord(point, 3) == nothing
-            @test GI.getcoord(point, 4) == nothing
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 3)
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
         end
         AG.createpoint(100, 70, 1) do point
             @test GI.geomtrait(point) == GI.PointTrait()
@@ -29,7 +29,7 @@ import GeoFormatTypes as GFT
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
             @test GI.getcoord(point, 3) == 1
-            @test GI.getcoord(point, 4) == nothing
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
         end
         @test GI.isgeometry(AG.IGeometry)
     end
@@ -971,14 +971,14 @@ import GeoFormatTypes as GFT
     @testset "Test coordinate dimensions" begin
         AG.createpoint(1, 2, 3) do point
             @test GI.getcoord(point, 3) == 3
-            @test isnothing(GI.getcoord(point, 4))
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test GI.is3d(point)
         end
         AG.createpoint(1, 2) do point
-            @test isnothing(GI.getcoord(point, 3))
-            @test isnothing(GI.getcoord(point, 4))
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 3)
+            @test_throws "Invalid getcoord index" GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test !GI.is3d(point)

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -9,27 +9,29 @@ import GeoFormatTypes as GFT
             @test GI.geomtrait(point) == GI.PointTrait()
             @test GI.testgeometry(point)
             @test GI.bbox(point).X[1] == 100
+            @test !GI.is3d(point)
             @test GI.x(point) == 100
             @test GI.y(point) == 70
-            @test GI.z(point) == nothing
-            @test GI.m(point) == nothing
+            @test_throws ArgumentError GI.z(point)
+            @test_throws ArgumentError GI.m(point)
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
-            @test_throws ErrorException GI.getcoord(point, 3)
-            @test_throws ErrorException GI.getcoord(point, 4)
+            @test_throws ArgumentError GI.getcoord(point, 3)
+            @test_throws ArgumentError GI.getcoord(point, 4)
         end
         AG.createpoint(100, 70, 1) do point
             @test GI.geomtrait(point) == GI.PointTrait()
             @test GI.testgeometry(point)
             @test GI.bbox(point).Z[1] == 1
+            @test GI.is3d(point)
             @test GI.x(point) == 100
             @test GI.y(point) == 70
             @test GI.z(point) == 1
-            @test GI.m(point) == nothing
+            @test_throws ArgumentError GI.m(point)
             @test GI.getcoord(point, 1) == 100
             @test GI.getcoord(point, 2) == 70
             @test GI.getcoord(point, 3) == 1
-            @test_throws ErrorException GI.getcoord(point, 4)
+            @test_throws ArgumentError GI.getcoord(point, 4)
         end
         @test GI.isgeometry(AG.IGeometry)
     end
@@ -971,14 +973,14 @@ import GeoFormatTypes as GFT
     @testset "Test coordinate dimensions" begin
         AG.createpoint(1, 2, 3) do point
             @test GI.getcoord(point, 3) == 3
-            @test_throws ErrorException GI.getcoord(point, 4)
+            @test_throws ArgumentError GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test GI.is3d(point)
         end
         AG.createpoint(1, 2) do point
-            @test_throws ErrorException GI.getcoord(point, 3)
-            @test_throws ErrorException GI.getcoord(point, 4)
+            @test_throws ArgumentError GI.getcoord(point, 3)
+            @test_throws ArgumentError GI.getcoord(point, 4)
             @test !GI.isempty(point)
             @test !GI.ismeasured(point)
             @test !GI.is3d(point)


### PR DESCRIPTION
Throw an error on wrong index to `getcoord` instead of returning `nothing`. This was pretty bad for inference and ran into bugs in base and other poorly inferenced functions in Meshes.jl to cause hangs.

@ErickChacon this should fix the other half of your inference bug. Thanks for persevering to find problems in both packages and Base!

 