### PR TITLE
GeoPackage test no longer errors

### DIFF
--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -107,12 +107,13 @@ end
                 for dsname in ("point", "metropole")
                     AG.read("data/$dsname.geojson") do input_ds
                         try
-                            # the GPKG driver can handle field ids of type real, which is the case for point.geojson
+                            # the GPKG driver can't handle field ids of type real, which is the case for point.geojson
                             if driver == "GPKG" && dsname == "point"
                                 @test_throws GDAL.GDALError AG.write(
                                     input_ds,
                                     fname;
                                     driver = AG.getdriver(driver),
+                                    use_gdal_copy = false,
                                 )
                             else
                                 AG.write(


### PR DESCRIPTION
This is all that is required to fix tests after https://github.com/JuliaGeo/GDAL.jl/pull/153

Don't really understand, but it now only errors on `use_gdal_copy = false`, whereas the default, true, does not fail.