### PR TITLE
factor out layer copying into its own function

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -307,7 +307,7 @@ Dict{<:Integer, Vector{String}} to set individual options per layer.",
         sourcelayer = getlayer(source_dataset, layeridx)
         sourcelayerdef = layerdefn(sourcelayer)
 
-        if shortname(getdriver(source_dataset)) == "GPKG"
+        if shortname(getdriver(target_dataset)) == "GPKG"
             if !any(Base.contains.(current_layer_options, "GEOMETRY_NAME"))
                 if ngeom(sourcelayer) > 0  # for GPKG there can be only one geometry column per layer
                     geometry_column_name =

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -180,20 +180,21 @@ Writes the dataset to the designated filename.
 * `filename`: The filename, UTF-8 encoded.
 
 ### Keyword Arguments
-* `driver` (ArchGDAL.Driver): The driver to use, you have to manually select the right driver via `getdriver(drivername)` matching the file extension you wish.
-Otherwise the driver of the source dataset will be used.
+* `driver` (ArchGDAL.Driver): The driver to use, you have to manually select the right driver via `getdriver(drivername)`
+                              matching the file extension you wish. Otherwise the driver of the source dataset will be used.
 * `options` (Vector{String}): A vector of strings containing KEY=VALUE pairs for driver-specific creation options.
+* `layers`:        Specifies which layers should be written. Can be e.g. a range, Vector{Int} or tuple.
 * `layer_options`: Driver specific options for layer creation. The options can either be a Vector{String} to provide the
-same options for each layer, or a Vector{Vector{String}} to provide individual options per layer, in the order of their
-appearance in the dataset. The strings have to be KEY=VALUE pairs. If you give less individual options than there are layers,
-the remaining layers use the default creation options. An example for two layers:
-`[["FORMAT=WKT", "LAUNDER=NO"], ["STRICT=NO"]]`
-* `use_gdal_copy` (Bool): Set this to false (default is true) to achieve higher write speeds at the cost of possible errors.
-Note that when set to true, no coordinate transformations are possible while writing the features.
+                   same options for each layer, or a Vector{Vector{String}} to provide individual options per layer, 
+                   in the order of their appearance in the dataset. The strings have to be KEY=VALUE pairs. 
+                   If you give less individual options than there are layers, the remaining layers use the default creation 
+                   options. An example for two layers: `Dict(0 => ["FORMAT=WKT", "LAUNDER=NO"], 1 => ["STRICT=NO"])`
+* `use_gdal_copy` (Bool): Set this to false (default is true) to achieve higher write speeds at the cost of possible errors. 
+                          Note that when set to true, no coordinate transformations are possible while writing the features.
 * `chunksize` (Integer): Number of features to write in one database transaction. Neglected when `use_gdal_copy` is true.
-Default is 20000.
+                         Default is 20000.
 * `strict` (Bool): Set this to `true` if the written dataset should be a 1:1 copy of the source data, default is `false`,
-which allows the driver to adapt if necessary.
+                   which allows the driver to adapt if necessary.
 
 ### Returns
     `nothing`
@@ -240,10 +241,11 @@ Currently working drivers: FlatGeobuf, GeoJSON, GeoJSONSeq, GML, GPKG, JML, KML,
 ### Keyword arguments
 * `driver`:           The driver to use, you have to manually select the right driver for the file extension you wish
 * `options`:          A vector of strings containing KEY=VALUE pairs for driver-specific creation options
+* `layers`:           Specifies which layers should be written. Can be e.g. a range, Vector{Int} or tuple.
 * `layer_options`:    Driver specific options for layer creation. The options can either be a Vector{String} to provide the
-same options for each layer, or a Dict(layer_index => Vector{String}) to provide individual options per layer.
-Note that layer indexing in GDAL starts with 0. The strings have to be KEY=VALUE pairs. An example for two layers:
-`[["FORMAT=WKT", "LAUNDER=NO"], ["STRICT=NO"]]`
+                      same options for each layer, or a Dict(layer_index => Vector{String}) to provide individual options per layer.
+                      Note that layer indexing in GDAL starts with 0. The strings have to be KEY=VALUE pairs.
+                      An example for two layers: `Dict(0 => ["FORMAT=WKT", "LAUNDER=NO"], 1 => ["STRICT=NO"])`
 * `chunksize`:        Number of features to write in one database transaction. Neglected when `use_gdal_copy` is true.
 * `use_gdal_copy`:    Set this to false (default is true) to achieve higher write speeds at the cost of possible errors.
 Note that when set to true, no coordinate transformations are possible while writing the features.
@@ -256,6 +258,34 @@ function writelayers(
     filename::AbstractString;
     driver::Driver = getdriver(dataset),
     options = [""],
+    layers = 0:(nlayer(dataset)-1),
+    layer_options = [""],
+    chunksize::Integer = 20000,
+    use_gdal_copy::Bool = true,
+)
+    create(filename; driver = driver, options = options) do target
+        return copylayers!(
+            dataset,
+            target;
+            layers = layers,
+            layer_options = layer_options,
+            chunksize = chunksize,
+            use_gdal_copy = use_gdal_copy,
+        )
+    end
+    return nothing
+end
+
+"""
+    copylayers(source_dataset, target_dataset; kwargs...)
+
+Copies a (sub)set of layers from source to target dataset. The keyword arguments are the same as for `writelayers`.
+Note that eventual layer options have to conform with the target dataset driver.
+"""
+function copylayers!(
+    source_dataset::AbstractDataset,
+    target_dataset::AbstractDataset;
+    layers = 0:(nlayer(source_dataset)-1),
     layer_options = [""],
     chunksize::Integer = 20000,
     use_gdal_copy::Bool = true,
@@ -271,61 +301,59 @@ Dict{<:Integer, Vector{String}} to set individual options per layer.",
             ),
         )
     end
-    create(filename; driver = driver, options = options) do target
-        for layeridx in 0:nlayer(dataset)-1  # GDAL indexing starts with 0
-            current_layer_options = _getlayeroptions(layer_options, layeridx)
+    for layeridx in layers
+        current_layer_options = _getlayeroptions(layer_options, layeridx)
 
-            sourcelayer = getlayer(dataset, layeridx)
-            sourcelayerdef = layerdefn(sourcelayer)
+        sourcelayer = getlayer(source_dataset, layeridx)
+        sourcelayerdef = layerdefn(sourcelayer)
 
-            if shortname(driver) == "GPKG"
-                if !any(Base.contains.(current_layer_options, "GEOMETRY_NAME"))
-                    if ngeom(sourcelayer) > 0  # for GPKG there can be only one geometry column per layer
-                        geometry_column_name =
-                            getname(getgeomdefn(sourcelayerdef, 0))
-                        push!(
-                            current_layer_options,
-                            "GEOMETRY_NAME=$geometry_column_name",
-                        )
-                    end
+        if shortname(getdriver(source_dataset)) == "GPKG"
+            if !any(Base.contains.(current_layer_options, "GEOMETRY_NAME"))
+                if ngeom(sourcelayer) > 0  # for GPKG there can be only one geometry column per layer
+                    geometry_column_name =
+                        getname(getgeomdefn(sourcelayerdef, 0))
+                    push!(
+                        current_layer_options,
+                        "GEOMETRY_NAME=$geometry_column_name",
+                    )
                 end
             end
+        end
 
-            if use_gdal_copy
-                copy(
-                    sourcelayer;
-                    dataset = target,
-                    name = getname(sourcelayer),
-                    options = current_layer_options,
-                )
-            else
-                createlayer(
-                    name = getname(sourcelayer),
-                    dataset = target,
-                    geom = getgeomtype(sourcelayer),
-                    spatialref = getspatialref(sourcelayer),
-                    options = current_layer_options,
-                ) do targetlayer
-                    # add field definitions
-                    for fieldidx in 0:nfield(sourcelayer)-1
-                        addfielddefn!(
-                            targetlayer,
-                            getfielddefn(sourcelayerdef, fieldidx),
-                        )
-                    end
+        if use_gdal_copy
+            copy(
+                sourcelayer;
+                dataset = target_dataset,
+                name = getname(sourcelayer),
+                options = current_layer_options,
+            )
+        else
+            createlayer(;
+                name = getname(sourcelayer),
+                dataset = target_dataset,
+                geom = getgeomtype(sourcelayer),
+                spatialref = getspatialref(sourcelayer),
+                options = current_layer_options,
+            ) do targetlayer
+                # add field definitions
+                for fieldidx in 0:(nfield(sourcelayer)-1)
+                    addfielddefn!(
+                        targetlayer,
+                        getfielddefn(sourcelayerdef, fieldidx),
+                    )
+                end
 
-                    # iterate over features in chunks to get better speed than gdaldatasetcopylayer
-                    for chunk in Iterators.partition(sourcelayer, chunksize)
-                        GDAL.ogr_l_starttransaction(targetlayer)
-                        for feature in chunk
-                            addfeature!(targetlayer, feature)
-                        end
-                        GDAL.ogr_l_committransaction(targetlayer)
+                # iterate over features in chunks to get better speed than gdaldatasetcopylayer
+                for chunk in Iterators.partition(sourcelayer, chunksize)
+                    GDAL.ogr_l_starttransaction(targetlayer)
+                    for feature in chunk
+                        addfeature!(targetlayer, feature)
                     end
-                end # createlayer
-            end # if
-        end # for layeridx
-    end # create
+                    GDAL.ogr_l_committransaction(targetlayer)
+                end
+            end # createlayer
+        end # if use_gdal_copy
+    end # for layeridx
     return nothing
 end
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -221,7 +221,7 @@ end
 
 # utility functions for writelayers
 function _getlayeroptions(options::Dict{<:Integer,Vector{String}}, i::Integer)
-    return get(options, i, [""])
+    return get(options, i, String[])
 end
 _getlayeroptions(options::Union{Ptr{Cstring},Vector{String}}, i) = options
 
@@ -257,9 +257,9 @@ function writelayers(
     dataset::AbstractDataset,
     filename::AbstractString;
     driver::Driver = getdriver(dataset),
-    options = [""],
+    options = String[],
     layers = 0:(nlayer(dataset)-1),
-    layer_options = [""],
+    layer_options = String[],
     chunksize::Integer = 20000,
     use_gdal_copy::Bool = true,
 )
@@ -286,7 +286,7 @@ function copylayers!(
     source_dataset::AbstractDataset,
     target_dataset::AbstractDataset;
     layers = 0:(nlayer(source_dataset)-1),
-    layer_options = [""],
+    layer_options = String[],
     chunksize::Integer = 20000,
     use_gdal_copy::Bool = true,
 )

--- a/test/test_dataset.jl
+++ b/test/test_dataset.jl
@@ -145,10 +145,10 @@ end
                         end
                     end
                     rm("test.xsd", force = true, recursive = true)  # some driver creates this file, delete it manually
-                end
-            end
+                end # datasets
+            end # drivers
 
-            # test setting individual layer options
+            # test setting individual layer options and layer counts
             AG.create(AG.getdriver("Memory")) do point_dataset
                 # first layer
                 AG.createlayer(
@@ -207,11 +207,27 @@ end
                     @test AG.getname(gd0) == "WKT_GEOMETRY"
                     @test AG.getname(gd1) == "GEOMETRY"
                 end
+                AG.write(
+                    point_dataset,
+                    "deleteme.sqlite";
+                    driver = AG.getdriver("SQLite"),
+                    layers = [1],
+                    layer_options = Dict(
+                        1 => ["FORMAT=WKT", "LAUNDER=YES"],
+                    ),
+                    use_gdal_copy = true,
+                )
+                AG.read("deleteme.sqlite") do read_ds
+                    @test AG.nlayer(read_ds) == 1
+                    l0 = AG.getlayer(read_ds, 0)
+                    gd0 = AG.getgeomdefn(AG.layerdefn(l0))
+                    @test AG.getname(gd0) == "WKT_GEOMETRY"
+                end
                 sleep(0.05)
                 GC.gc()
                 return rm("deleteme.sqlite", force = true)
-            end
-        end
+            end # individual layer options
+        end # write functionality
 
         dataset1 = AG.read("data/point.geojson")
         @test AG.nlayer(dataset1) == 1


### PR DESCRIPTION
Hi! I have factored out the layer copying from writelayers into its own function. So basically I changed (pseudocode):

```julia
function writelayers()
  create() do
    copystuff
  end
end
```

to 
```julia
function writelayers()
  create() do
    copylayers(src, dst)
  end
end

function copylayers(src, dst, ...)
  copystuff
end
```
That should now allow to copy data from and to arbitrary datasets, whether on disk or not. You can also give the layer indices you want to be copied. I added a tiny test for that. Furthermore I adjusted the docstrings for nicer rendering in the REPL. I'm not sure with the naming `copylayers`, is it ok? What do you think in general? Lastly, this supersedes https://github.com/yeesian/ArchGDAL.jl/pull/381, but I can take that part out if you want to merge this before the change to GDAL.
