### PR TITLE
Implement GeoInterface.crs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -106,6 +106,10 @@ function Base.convert(
     return unsafe_convertcrs(target, importCRS(source))
 end
 
+function Base.convert(target::Type{<:GFT.GeoFormat}, source::AbstractSpatialRef)
+    return unsafe_convertcrs(target, source)
+end
+
 function unsafe_convertcrs(::Type{<:GFT.CoordSys}, crsref)
     return GFT.CoordSys(toMICoordSys(crsref))
 end

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -55,8 +55,23 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         GeoInterface.TriangleTrait,
     }
 
+    # Raster
+    function GeoInterface.crs(ds::AbstractDataset)
+        sr = getproj(ds)
+        return Base.isempty(sr) ? nothing : GFT.WellKnownText(GFT.CRS(), sr)
+    end
+
     # Feature
     GeoInterface.isfeature(feat::AbstractFeature) = true
+    function GeoInterface.crs(layer::AbstractFeatureLayer)
+        sr = getspatialref(layer)
+        return sr.ptr == C_NULL ? nothing : convert(GFT.WellKnownText, sr)
+    end
+    function GeoInterface.crs(geom::AbstractGeometry)
+        sr = getspatialref(geom)
+        return sr.ptr == C_NULL ? nothing : convert(GFT.WellKnownText, sr)
+    end
+
     function GeoInterface.properties(feat::AbstractFeature)
         return (; (zip(Symbol.(keys(feat)), values(feat)))...)
     end

--- a/test/test_cookbook_projection.jl
+++ b/test/test_cookbook_projection.jl
@@ -10,11 +10,14 @@ import GeoFormatTypes as GFT
                 AG.importEPSG(4326) do target
                     AG.createcoordtrans(source, target) do transform
                         AG.fromWKT("POINT (1120351.57 741921.42)") do point
+                            @test GeoInterface.crs(point) === nothing
                             @test AG.toWKT(point) ==
                                   "POINT (1120351.57 741921.42)"
                             AG.transform!(point, transform)
                             @test GeoInterface.coordinates(point) ≈
                                   [47.3488070138318, -122.5981499431438]
+                            @test GeoInterface.crs(point) isa
+                                  GFT.WellKnownText{GFT.CRS}
                         end
                     end
                 end
@@ -116,6 +119,7 @@ import GeoFormatTypes as GFT
             @test AG.toXML(spatialref)[1:17] == "<gml:ProjectedCRS"
             @test AG.toMICoordSys(spatialref) ==
                   "Earth Projection 8, 104, \"m\", -111, 0, 0.9996, 500000, 0"
+            @test GeoInterface.crs(layer) isa GFT.WellKnownText{GFT.CRS}
             AG.nextfeature(layer) do feature
                 @test AG.toPROJ4(AG.getspatialref(AG.getgeom(feature))) ==
                       "+proj=utm +zone=12 +datum=WGS84 +units=m +no_defs"

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -1,6 +1,8 @@
 using Test
 import GDAL
 import ArchGDAL as AG
+import GeoInterface
+import GeoFormatTypes as GFT
 
 @testset "test_rasterband.jl" begin
     @testset "Test methods for rasterband" begin
@@ -15,6 +17,9 @@ import ArchGDAL as AG
               [GA_ReadOnly] Band 1 (Gray): 100 x 100 (UInt8)
             """
             @test sprint(print, dataset) == ds_result
+
+            @test GeoInterface.crs(dataset) isa GFT.WellKnownText{GFT.CRS}
+
             rb = AG.getband(dataset, 1)
             sprint(print, rb) == """
             [GA_ReadOnly] Band 1 (Gray): 100 x 100 (UInt8)

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -287,6 +287,7 @@ end
         nbands = 1,
         dtype = ComplexF32,
     ) do ds
+        @test isnothing(GeoInterface.crs(ds))
         return AG.write!(ds, a, 1)
     end
 

--- a/test/test_spatialref.jl
+++ b/test/test_spatialref.jl
@@ -1,6 +1,7 @@
 using Test
 import ArchGDAL as AG
 import GeoFormatTypes as GFT
+import GeoInterface
 
 @testset "test_spatialref.jl" begin
     @testset "Test Formats for Spatial Reference Systems" begin
@@ -185,6 +186,8 @@ import GeoFormatTypes as GFT
                 @test AG.toPROJ4(spatialref2) == proj26912
                 AG.importPROJ4!(spatialref2, AG.toPROJ4(spatialref))
                 @test AG.toPROJ4(spatialref2) == proj4326
+                @test convert(GFT.WellKnownText, spatialref) isa
+                      GFT.WellKnownText{GFT.CRS}
             end
         end
 
@@ -194,6 +197,8 @@ import GeoFormatTypes as GFT
                 @test AG.toWKT(spatialref2) == wkt26912
                 AG.importWKT!(spatialref2, AG.toWKT(spatialref))
                 @test AG.toWKT(spatialref2) == wkt4326
+                @test convert(GFT.WellKnownText, spatialref) isa
+                      GFT.WellKnownText{GFT.CRS}
             end
         end
 
@@ -203,6 +208,8 @@ import GeoFormatTypes as GFT
                 @test AG.toWKT(spatialref2) == esri26912
                 AG.importESRI!(spatialref2, AG.toWKT(spatialref))
                 @test AG.toWKT(spatialref2) == esri4326
+                @test convert(GFT.WellKnownText, spatialref) isa
+                      GFT.WellKnownText{GFT.CRS}
             end
         end
 
@@ -212,6 +219,8 @@ import GeoFormatTypes as GFT
                 @test startswith(AG.toXML(spatialref2), "<gml:ProjectedCRS")
                 AG.importXML!(spatialref2, xml4326)
                 @test startswith(AG.toXML(spatialref2), "<gml:GeographicCRS")
+                @test convert(GFT.WellKnownText, spatialref) isa
+                      GFT.WellKnownText{GFT.CRS}
             end
         end
 
@@ -221,6 +230,8 @@ import GeoFormatTypes as GFT
                 @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
                 AG.importUserInput!(spatialref2, cepsg)
                 @test contains(AG.toPROJ4(spatialref2), "+geoidgrids=")
+                @test convert(GFT.WellKnownText, spatialref) isa
+                      GFT.WellKnownText{GFT.CRS}
             end
         end
 


### PR DESCRIPTION
As found here https://discourse.julialang.org/t/retrieving-crs-from-vector-and-raster-data/107903/4
One can now do `GeoInterface.crs` on a geometry, layer and dataset.

Also implements a convert method to GFT from an AbstractSpatialRef.
