### PR TITLE
Make buffer for `read!` an AbstractArray

### DIFF
--- a/src/raster/rasterio.jl
+++ b/src/raster/rasterio.jl
@@ -1,12 +1,12 @@
 
 """
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Any, 3},
+    rasterio!(dataset::AbstractDataset, buffer::AbstractArray{<:Any, 3},
         bands; <keyword arguments>)
-    rasterio!(dataset::AbstractDataset, buffer::Array{<:Any, 3}, bands, rows,
+    rasterio!(dataset::AbstractDataset, buffer::AbstractArray{<:Any, 3}, bands, rows,
         cols; <keyword arguments>)
-    rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Any};
+    rasterio!(rasterband::AbstractRasterBand, buffer::AbstractMatrix{<:Any};
         <keyword arguments>)
-    rasterio!(rasterband::AbstractRasterBand, buffer::Matrix{<:Any}, rows,
+    rasterio!(rasterband::AbstractRasterBand, buffer::AbstractMatrix{<:Any}, rows,
         cols; <keyword arguments>)
 
 
@@ -73,7 +73,7 @@ function rasterio!(
     pxspace::Integer = 0,
     linespace::Integer = 0,
     bandspace::Integer = 0,
-)::T where {T<:Array{<:Any,3}}
+)::T where {T<:AbstractArray{<:Any,3}}
     rasterio!(
         dataset,
         buffer,
@@ -92,7 +92,7 @@ end
 
 function rasterio!(
     dataset::AbstractDataset,
-    buffer::Array{T,3},
+    buffer::AbstractArray{T,3},
     bands,
     rows::UnitRange{<:Integer},
     cols::UnitRange{<:Integer},
@@ -123,7 +123,7 @@ end
 
 function rasterio!(
     dataset::AbstractDataset,
-    buffer::Array{T,3},
+    buffer::AbstractArray{T,3},
     bands,
     xoffset::Integer,
     yoffset::Integer,
@@ -174,7 +174,7 @@ function rasterio!(
     access::GDALRWFlag = GF_Read,
     pxspace::Integer = 0,
     linespace::Integer = 0,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(
         rasterband,
         buffer,
@@ -197,7 +197,7 @@ function rasterio!(
     access::GDALRWFlag = GF_Read,
     pxspace::Integer = 0,
     linespace::Integer = 0,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     xsize = length(cols)
     xsize < 1 && error("invalid window width")
     ysize = length(rows)
@@ -218,7 +218,7 @@ end
 
 function rasterio!(
     rasterband::AbstractRasterBand,
-    buffer::Matrix{T},
+    buffer::AbstractMatrix{T},
     xoffset::Integer,
     yoffset::Integer,
     xsize::Integer,
@@ -255,7 +255,7 @@ function rasterio!(
     return buffer
 end
 
-function read!(rb::AbstractRasterBand, buffer::T)::T where {T<:Matrix{<:Any}}
+function read!(rb::AbstractRasterBand, buffer::T)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(rb, buffer, GF_Read)
     return buffer
 end
@@ -267,7 +267,7 @@ function read!(
     yoffset::Integer,
     xsize::Integer,
     ysize::Integer,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize)
     return buffer
 end
@@ -277,7 +277,7 @@ function read!(
     buffer::T,
     rows::UnitRange{<:Integer},
     cols::UnitRange{<:Integer},
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(rb, buffer, rows, cols)
     return buffer
 end
@@ -315,7 +315,7 @@ function write!(
     yoffset::Integer,
     xsize::Integer,
     ysize::Integer,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(rb, buffer, xoffset, yoffset, xsize, ysize, GF_Write)
     return buffer
 end
@@ -325,7 +325,7 @@ function write!(
     buffer::T,
     rows::UnitRange{<:Integer} = 1:height(rb),
     cols::UnitRange{<:Integer} = 1:width(rb),
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     rasterio!(rb, buffer, rows, cols, GF_Write)
     return buffer
 end
@@ -334,7 +334,7 @@ function read!(
     dataset::AbstractDataset,
     buffer::T,
     i::Integer,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     read!(getband(dataset, i), buffer)
     return buffer
 end
@@ -343,12 +343,12 @@ function read!(
     dataset::AbstractDataset,
     buffer::T,
     indices,
-)::T where {T<:Array{<:Any,3}}
+)::T where {T<:AbstractArray{<:Any,3}}
     rasterio!(dataset, buffer, indices, GF_Read)
     return buffer
 end
 
-function read!(dataset::AbstractDataset, buffer::T)::T where {T<:Array{<:Any,3}}
+function read!(dataset::AbstractDataset, buffer::T)::T where {T<:AbstractArray{<:Any,3}}
     nband = nraster(dataset)
     @assert size(buffer, 3) == nband
     rasterio!(dataset, buffer, collect(Cint, 1:nband), GF_Read)
@@ -363,7 +363,7 @@ function read!(
     yoffset::Integer,
     xsize::Integer,
     ysize::Integer,
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     read!(getband(dataset, i), buffer, xoffset, yoffset, xsize, ysize)
     return buffer
 end
@@ -376,7 +376,7 @@ function read!(
     yoffset::Integer,
     xsize::Integer,
     ysize::Integer,
-)::T where {T<:Array{<:Any,3}}
+)::T where {T<:AbstractArray{<:Any,3}}
     rasterio!(dataset, buffer, indices, xoffset, yoffset, xsize, ysize)
     return buffer
 end
@@ -387,7 +387,7 @@ function read!(
     i::Integer,
     rows::UnitRange{<:Integer},
     cols::UnitRange{<:Integer},
-)::T where {T<:Matrix{<:Any}}
+)::T where {T<:AbstractMatrix{<:Any}}
     read!(getband(dataset, i), buffer, rows, cols)
     return buffer
 end
@@ -398,7 +398,7 @@ function read!(
     indices,
     rows::UnitRange{<:Integer},
     cols::UnitRange{<:Integer},
-)::T where {T<:Array{<:Any,3}}
+)::T where {T<:AbstractArray{<:Any,3}}
     rasterio!(dataset, buffer, indices, rows, cols)
     return buffer
 end

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -290,6 +290,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -307,6 +308,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -324,6 +326,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -341,6 +344,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -361,6 +365,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -373,6 +378,7 @@ end
             AG.rasterio!(ds, buffer, [1])
             count = sum(buffer .> 0)
             total = sum(buffer)
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -386,6 +392,7 @@ end
             AG.read!(band, buffer)
             count = sum(buffer .> 0)
             total = sum(buffer)
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -399,6 +406,7 @@ end
                 AG.read!(ds, buffer, 1)
             count = sum(buffer .> 0)
             total = sum(buffer)
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -412,6 +420,7 @@ end
             AG.read!(ds, buffer, [1])
             count = sum(buffer .> 0)
             total = sum(buffer)
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -425,6 +434,7 @@ end
             AG.read!(ds, buffer)
             count = sum(buffer[:, :, 1] .> 0)
             total = sum(buffer[:, :, 1])
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end
@@ -443,6 +453,7 @@ end
                 count += sum(data .> 0)
                 total += sum(data)
             end
+            @test buffer isa SubArray
             @test total / count ≈ 76.33891347095299
             @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
         end

--- a/test/test_rasterio.jl
+++ b/test/test_rasterio.jl
@@ -275,6 +275,180 @@ import ArchGDAL as AG
     end
 end
 
+
+@testset "Non standard buffer rasterio " begin
+    AG.read("ospy/data4/aster.img") do ds
+        @testset "version 1" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            abuffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
+            buffer = view(abuffer, :,:,:)
+            for (cols, rows) in AG.windows(band)
+                AG.rasterio!(ds, buffer, [1], rows, cols)
+                data = buffer[1:length(cols), 1:length(rows)]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 2" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            abuffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
+            buffer = view(abuffer, :,:,:)
+
+            for (cols, rows) in AG.windows(band)
+                AG.read!(ds, buffer, [1], rows, cols)
+                data = buffer[1:length(cols), 1:length(rows)]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 3" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            abuffer = Matrix{AG.pixeltype(band)}(undef, AG.blocksize(band)...)
+            buffer = view(abuffer, :,:)
+
+            for (cols, rows) in AG.windows(band)
+                AG.read!(ds, buffer, 1, rows, cols)
+                data = buffer[1:length(cols), 1:length(rows)]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 4" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            abuffer = Matrix{AG.pixeltype(band)}(undef, AG.blocksize(band)...)
+            buffer = view(abuffer, :,:)
+
+            for (cols, rows) in AG.windows(band)
+                AG.read!(band, buffer, rows, cols)
+                data = buffer[1:length(cols), 1:length(rows)]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 5" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            xbsize, ybsize = AG.blocksize(band)
+            abuffer = Matrix{AG.pixeltype(band)}(undef, ybsize, xbsize)
+            buffer = view(abuffer, :,:)
+
+            for ((i, j), (nrows, ncols)) in AG.blocks(band)
+                # AG.rasterio!(ds,buffer,[1],i,j,nrows,ncols)
+                # AG.read!(band, buffer, j, i, ncols, nrows)
+                AG.readblock!(band, j, i, buffer)
+                data = buffer[1:nrows, 1:ncols]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 6" begin
+            band = AG.getband(ds, 1)
+            abuffer = Array{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds), 1)
+            buffer = view(abuffer, :,:,:)
+
+            AG.rasterio!(ds, buffer, [1])
+            count = sum(buffer .> 0)
+            total = sum(buffer)
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 7" begin
+            band = AG.getband(ds, 1)
+            abuffer =
+                Matrix{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds))
+            buffer = view(abuffer, :,:)
+
+            AG.read!(band, buffer)
+            count = sum(buffer .> 0)
+            total = sum(buffer)
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 8" begin
+            band = AG.getband(ds, 1)
+            abuffer =
+                Matrix{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds))
+            buffer = view(abuffer, :,:)
+
+                AG.read!(ds, buffer, 1)
+            count = sum(buffer .> 0)
+            total = sum(buffer)
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 9" begin
+            band = AG.getband(ds, 1)
+            abuffer =
+                Array{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds), 1)
+            buffer = view(abuffer, :,:,:)
+
+            AG.read!(ds, buffer, [1])
+            count = sum(buffer .> 0)
+            total = sum(buffer)
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        @testset "version 10" begin
+            band = AG.getband(ds, 1)
+            abuffer =
+                Array{AG.pixeltype(band)}(undef, AG.width(ds), AG.height(ds), 3)
+            buffer = view(abuffer, :,:, :)
+
+            AG.read!(ds, buffer)
+            count = sum(buffer[:, :, 1] .> 0)
+            total = sum(buffer[:, :, 1])
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+
+        # check for calling with Tuple
+        @testset "version 11" begin
+            band = AG.getband(ds, 1)
+            count = 0
+            total = 0
+            abuffer = Array{AG.pixeltype(band)}(undef, AG.blocksize(band)..., 1)
+            buffer = view(abuffer, :,:,:)
+
+            for (cols, rows) in AG.windows(band)
+                AG.rasterio!(ds, buffer, (1,), rows, cols)
+                data = buffer[1:length(cols), 1:length(rows)]
+                count += sum(data .> 0)
+                total += sum(data)
+            end
+            @test total / count ≈ 76.33891347095299
+            @test total / (AG.height(ds) * AG.width(ds)) ≈ 47.55674749653172
+        end
+    end
+end
+
 @testset "Complex IO" begin
     a = rand(ComplexF32, 10, 10)
 


### PR DESCRIPTION
This widens the dispatch of the `read!` and `rasterio!` functions so that the buffer can be an AbstractArray instead of a normal Array. This will allow to also read into for example views or other array wrapper types like PermuteDimsArrays. 

This would close #410. 
It will also close https://github.com/rafaqz/Rasters.jl/issues/596

Should we also widen the buffer type for the write! functions? 

