### PR TITLE
Forward gdalinfo for RasterDataset

### DIFF
--- a/src/raster/array.jl
+++ b/src/raster/array.jl
@@ -60,6 +60,7 @@ for f in (
     :metadata,
     :metadatadomainlist,
     :imread,
+    :gdalinfo,
 )
     eval(:(function $(f)(x::RasterDataset, args...; kwargs...)
         return $(f)(x.ds, args...; kwargs...)

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -23,6 +23,7 @@ import ArchGDAL as AG
                 @test AG.ngcp(ds) == 0
                 @test AG.write(ds, tempname()) == nothing
                 @test AG.testcapability(ds, "ODsCCreateLayer") == false
+                @test startswith(AG.gdalinfo(ds), "Driver:")
             end
             @testset "DiskArray chunk interface" begin
                 b = AG.getband(ds, 1)


### PR DESCRIPTION
This allows to use AG.gdalinfo on  a RasterDataset.
