### PR TITLE
Add Proj as a dependency and constrain its version to <1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -17,6 +17,7 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 GeoInterfaceMakie = "0edc0954-3250-4c18-859d-ec71c1660c08"
 GeoInterfaceRecipes = "0329782f-3d07-4b52-b9f6-d3137cf03c7a"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+Proj = "c94c279d-25a6-4763-9509-64d165bea63e" # to ensure no invalidations with GeoFormatTypes.jl blessed piracy
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
@@ -32,6 +33,7 @@ GeoInterfaceMakie = "0.1"
 GeoInterfaceRecipes = "1.0"
 ImageCore = "0.8, 0.9, 0.10"
 Makie = "0.20, 0.21"
+Proj = "<1.9" # to ensure no invalidations with GeoFormatTypes.jl blessed piracy
 Tables = "1"
 julia = "1.6"
 


### PR DESCRIPTION
A theoretical Proj v1.9 release will be the new blessed pirate for GeoFormatTypes, see https://github.com/JuliaGeo/GeoFormatTypes.jl/issues/21

This comes with some benefits for users but it's a bit breaking.  Maybe ArchGDAL should also load Proj, to minimize breakage, since loading Proj means GFT converts work as usual.

Something to think about.