### PR TITLE
Add coordtype implementation

### DIFF
--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -415,7 +415,7 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     end
 
     # coordtype implementations - guarded against old GeoInterface versions
-    if :coordtype in names(GeoInterface; all = true)
+    if isdefined(GeoInterface, :coordtype)
         # ArchGDAL always uses Float64 for coordinates
         function GeoInterface.coordtype(::GeoInterface.AbstractGeometryTrait, ::AbstractGeometry)
             return Float64

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -413,4 +413,21 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     function GeoInterface.geomtrait(geom::AbstractGeometry{wkbTriangle})
         return GeoInterface.TriangleTrait()
     end
+
+    # coordtype implementations - guarded against old GeoInterface versions
+    if :coordtype in names(GeoInterface; all = true)
+        # ArchGDAL always uses Float64 for coordinates
+        function GeoInterface.coordtype(::GeoInterface.AbstractGeometryTrait, ::AbstractGeometry)
+            return Float64
+        end
+
+        function GeoInterface.coordtype(::GeoInterface.FeatureTrait, ::AbstractFeature)
+            return Float64
+        end
+
+        # AbstractFeatureLayer acts like a FeatureCollection in ArchGDAL
+        function GeoInterface.coordtype(::GeoInterface.FeatureCollectionTrait, ::AbstractFeatureLayer)
+            return Float64
+        end
+    end
 end


### PR DESCRIPTION
Implements GeoInterface.coordtype for ArchGDAL types. Returns Float64.

🤖 Generated with [Claude Code](https://claude.ai/code)