### PR TITLE
Bump version to 0.10.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 keywords = ["GDAL", "IO"]
 license = "MIT"
 desc = "A high level API for GDAL - Geospatial Data Abstraction Library"
-version = "0.10.10"
+version = "0.10.11"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"


### PR DESCRIPTION
~To get a release that removes GeoInterfaceRecipes!  This is causing downstream tests to fail on nightly, because GeoInterfaceRecipes just doesn't load there.~

Seems that was already released, not sure why my installation was held back then :D - but GeoMakie CI also had the same issue.