### PR TITLE
Add `subdatasets` function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -325,13 +325,13 @@ end
 """
     subdatasets(obj)
 
-Return list of subdatasets (if any).
+Return list of subdatasets filenames (if any).
 """
 function subdatasets(obj)::Vector{String}
     metadata_ = metadata(obj, domain="SUBDATASETS")
     subdatasets_ = Vector{String}()
     for (key, val) in [split(e, "="; limit = 2) for e in metadata_]
-        if endswith(lowercase(key), "name")
+        if endswith(lowercase(key), "_name")
             push!(subdatasets_, val)
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -330,7 +330,7 @@ Return list of subdatasets (if any).
 function subdatasets(obj)::Vector{String}
     metadata_ = metadata(obj, domain="SUBDATASETS")
     subdatasets_ = Vector{String}()
-    for (key, val) in [split(e, "=") for e in metadata_]
+    for (key, val) in [split(e, "="; limit = 2) for e in metadata_]
         if endswith(lowercase(key), "name")
             push!(subdatasets_, val)
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -323,6 +323,22 @@ function metadataitem(
 end
 
 """
+    subdatasets(obj)
+
+Return list of subdatasets (if any).
+"""
+function subdatasets(obj)::Vector{String}
+    metadata_ = metadata(obj, domain="SUBDATASETS")
+    subdatasets_ = Vector{String}()
+    for (key, val) in [split(e, "=") for e in metadata_]
+        if endswith(lowercase(key), "name")
+            push!(subdatasets_, val)
+        end
+    end
+    return subdatasets_
+end
+
+"""
     setconfigoption(option::AbstractString, value)
 
 Set a configuration option for GDAL/OGR use.

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -16,6 +16,34 @@ end
         @test AG.metadataitem(driver, "DMD_EXTENSIONS") == "tif tiff"
     end
 
+    @testset "subdatasets" begin
+        AG.create(AG.getdriver("MEM"), width = 1, height = 1) do dataset
+            @test isempty(AG.subdatasets(dataset))
+
+            GDAL.gdalsetmetadataitem(
+                dataset,
+                "SUBDATASET_1_NAME",
+                "subdataset-1?token=a=b",
+                "SUBDATASETS",
+            )
+            GDAL.gdalsetmetadataitem(
+                dataset,
+                "SUBDATASET_1_DESC",
+                "first subdataset",
+                "SUBDATASETS",
+            )
+            GDAL.gdalsetmetadataitem(
+                dataset,
+                "SUBDATASET_2_NAME",
+                "subdataset-2",
+                "SUBDATASETS",
+            )
+
+            @test AG.subdatasets(dataset) ==
+                  ["subdataset-1?token=a=b", "subdataset-2"]
+        end
+    end
+
     @testset "OGR Errors" begin
         @test isnothing(AG.@ogrerr GDAL.OGRERR_NONE "not an error")
         eval_ogrerr(GDAL.OGRERR_NOT_ENOUGH_DATA, "Not enough data.", "foo")


### PR DESCRIPTION
Add a way to easily access subdatasets (see #463):

```Julia
julia> dataset = ArchGDAL.read("path/to/S2A_MSIL1C_xxx.SAFE/MTD_MSIL1C.xml")
GDAL Dataset (Driver: SENTINEL2/Sentinel 2)
File(s):
  path/to/S2A_MSIL1C_xxx.SAFE/MTD_MSIL1C.xml

julia> ArchGDAL.subdatasets(dataset)
4-element Vector{String}:
 "SENTINEL2_L1C:path/to" ⋯ n bytes ⋯ "E/MTD_MSIL1C.xml:10m:EPSG_xxx"
 "SENTINEL2_L1C:path/to" ⋯ n bytes ⋯ "E/MTD_MSIL1C.xml:20m:EPSG_xxx"
 "SENTINEL2_L1C:path/to" ⋯ n bytes ⋯ "E/MTD_MSIL1C.xml:60m:EPSG_xxx"
 "SENTINEL2_L1C:path/to" ⋯ n bytes ⋯ "E/MTD_MSIL1C.xml:TCI:EPSG_xxx"

julia> ArchGDAL.subdatasets(dataset)[1]
"SENTINEL2_L1C:path/to/S2A_MSIL1C_xxx.SAFE/MTD_MSIL1C.xml:10m:EPSG_xxx"

julia> subdataset = ArchGDAL.read(ArchGDAL.subdatasets(dataset)[1])
GDAL Dataset (Driver: SENTINEL2/Sentinel 2)
File(s):
  path/to/S2A_MSIL1C_xxx.SAFE/MTD_MSIL1C.xml
  path/to/S2A_MSIL1C_xxx.SAFE/GRANULE/L1C_xxx/MTD_TL.xml
  path/to/S2A_MSIL1C_xxx.SAFE/GRANULE/L1C_xxx/IMG_DATA/xxx_B04.jp2
  path/to/S2A_MSIL1C_xxx.SAFE/GRANULE/L1C_xxx/IMG_DATA/xxx_B03.jp2
  path/to/S2A_MSIL1C_xxx.SAFE/GRANULE/L1C_xxx/IMG_DATA/xxx_B02.jp2
  path/to/S2A_MSIL1C_xxx.SAFE/GRANULE/L1C_xxx/IMG_DATA/xxx_B08.jp2
  ...

Dataset (width x height): 10980 x 10980 (pixels)
Number of raster bands: 4
  [GA_ReadOnly] Band 1 (Red): 10980 x 10980 (UInt16)
  [GA_ReadOnly] Band 2 (Green): 10980 x 10980 (UInt16)
  [GA_ReadOnly] Band 3 (Blue): 10980 x 10980 (UInt16)
  ...
```
If there is no subdataset, `ArchGDAL.subdatasets` function returns `Vector{String}()`.