### PR TITLE
CI: run macOS tests natively on aarch64 instead of x64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,22 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          # macOS-latest runners are Apple Silicon (arm64); requesting x64 runs
+          # Julia and the GDAL_jll binaries under Rosetta emulation. Test the
+          # architecture macOS users actually run on instead.
+          - os: macOS-latest
+            arch: x64
+        include:
+          - os: macOS-latest
+            arch: aarch64
+            version: 'lts'
+          - os: macOS-latest
+            arch: aarch64
+            version: '1'
+          - os: macOS-latest
+            arch: aarch64
+            version: 'nightly'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,16 +22,9 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
-        exclude:
-          # macOS-latest runners are Apple Silicon (arm64); requesting x64 runs
-          # Julia and the GDAL_jll binaries under Rosetta emulation. Test the
-          # architecture macOS users actually run on instead.
-          - os: macOS-latest
-            arch: x64
         include:
           - os: macOS-latest
             arch: aarch64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,36 +11,24 @@ permissions:
   contents: read
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - 'lts'  # lts
+          - 'lts'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest
-        arch:
-          - x64
-        include:
-          - os: macOS-latest
-            arch: aarch64
-            version: 'lts'
-          - os: macOS-latest
-            arch: aarch64
-            version: '1'
-          - os: macOS-latest
-            arch: aarch64
-            version: 'nightly'
+          - macOS-latest
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
Fix macos by manually adding the aarch64 testing matrix entries.

There's still an sqlite3 linking issue or something, probably needs a fix in the jll