### PR TITLE
Expose the FID as a column in the tables interface

### DIFF
--- a/docs/src/tables.md
+++ b/docs/src/tables.md
@@ -26,3 +26,37 @@ dataset1 = ArchGDAL.read("data/multi_geom.csv", options = ["GEOM_POSSIBLE_NAMES=
 
 DataFrames.DataFrame(ArchGDAL.getlayer(dataset1, 0))
 ```
+
+## Feature IDs
+
+Database-like formats (GeoPackage, PostGIS, SQLite, ...) give every feature a
+persistent primary key, the *FID*. GDAL models it separately from the ordinary
+fields, so it does not appear among the field definitions. Where a driver
+reports such a column, via
+[`ArchGDAL.fidcolumnname`](@ref), it is included as the leading column of the
+table, under the name the driver gives it:
+
+```julia
+julia> dataset2 = ArchGDAL.read("data/rivers.gpkg")
+
+julia> ArchGDAL.fidcolumnname(ArchGDAL.getlayer(dataset2, 0))
+"fid"
+
+julia> DataFrames.DataFrame(ArchGDAL.getlayer(dataset2, 0))
+357×5 DataFrame
+ Row │ fid    geom                     property_0  property_1      property_2
+     │ Int64  IGeometry                String      String          String
+─────┼──────────────────────────────────────────────────────────────────────────
+   1 │     1  Geometry: wkbLineString  6           Sutlej          null
+   2 │     2  Geometry: wkbLineString  4           Svernaya Dvina  null
+  ⋮  │   ⋮               ⋮                 ⋮             ⋮              ⋮
+```
+
+This matches what QGIS and R's `sf` show for the same data, and the values agree
+with [`ArchGDAL.getfid`](@ref) on the individual features.
+
+Formats that carry no such column — ESRI Shapefile, FlatGeobuf and the like —
+report `""` and are unaffected, gaining no extra column. A driver that reports a
+FID column which is *also* an ordinary field (the GeoJSON driver does this for
+`id`, where both hold the same value) keeps just the field, so the column is
+never duplicated.

--- a/docs/src/tables.md
+++ b/docs/src/tables.md
@@ -29,34 +29,29 @@ DataFrames.DataFrame(ArchGDAL.getlayer(dataset1, 0))
 
 ## Feature IDs
 
-Database-like formats (GeoPackage, PostGIS, SQLite, ...) give every feature a
-persistent primary key, the *FID*. GDAL models it separately from the ordinary
-fields, so it does not appear among the field definitions. Where a driver
-reports such a column, via
-[`ArchGDAL.fidcolumnname`](@ref), it is included as the leading column of the
-table, under the name the driver gives it:
+Database-like formats (GeoPackage, PostGIS, SQLite, ...) give each feature a
+persistent primary key, the *FID*, which GDAL keeps out of the field
+definitions. Where a driver reports one through
+[`ArchGDAL.fidcolumnname`](@ref), it leads the table under that name, and its
+values match [`ArchGDAL.getfid`](@ref):
 
 ```julia
-julia> dataset2 = ArchGDAL.read("data/rivers.gpkg")
+julia> layer = ArchGDAL.getlayer(ArchGDAL.read("rivers.gpkg"), 0);
 
-julia> ArchGDAL.fidcolumnname(ArchGDAL.getlayer(dataset2, 0))
-"fid"
+julia> ArchGDAL.fidcolumnname(layer)
+"id"
 
-julia> DataFrames.DataFrame(ArchGDAL.getlayer(dataset2, 0))
+julia> DataFrames.DataFrame(layer)
 357×5 DataFrame
- Row │ fid    geom                     property_0  property_1      property_2
+ Row │ id     geom                     property_0  property_1      property_2
      │ Int64  IGeometry                String      String          String
-─────┼──────────────────────────────────────────────────────────────────────────
+─────┼────────────────────────────────────────────────────────────────────────
    1 │     1  Geometry: wkbLineString  6           Sutlej          null
    2 │     2  Geometry: wkbLineString  4           Svernaya Dvina  null
   ⋮  │   ⋮               ⋮                 ⋮             ⋮              ⋮
 ```
 
-This matches what QGIS and R's `sf` show for the same data, and the values agree
-with [`ArchGDAL.getfid`](@ref) on the individual features.
-
-Formats that carry no such column — ESRI Shapefile, FlatGeobuf and the like —
-report `""` and are unaffected, gaining no extra column. A driver that reports a
-FID column which is *also* an ordinary field (the GeoJSON driver does this for
-`id`, where both hold the same value) keeps just the field, so the column is
-never duplicated.
+Formats without one, such as ESRI Shapefile and FlatGeobuf, report `""` and
+gain no column. Where a driver reports a FID column that is also an ordinary
+field — GeoJSON does this for `id`, both holding the same value — the field
+wins, so the column is never duplicated.

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -1,7 +1,5 @@
-# The FID column name is a property of the layer, not of the individual
-# feature, so it is looked up once when iteration starts and carried along in
-# the iteration state. Re-querying it per feature would roughly double the cost
-# of iterating a layer.
+# The FID column name rides along in the iteration state; looking it up per
+# feature instead roughly doubles the cost of iterating a layer.
 const FeatureIteratorState = Tuple{Int64,Symbol}
 
 function _nextfeature(
@@ -34,8 +32,7 @@ function Base.iterate(
     return _nextfeature(layer, state[1], state[2])
 end
 
-# Retained for callers that drive `iterate` by hand with an integer state, as
-# the iteration state used to be a bare counter.
+# The iteration state used to be a bare counter.
 function Base.iterate(
     layer::AbstractFeatureLayer,
     state::Integer,

--- a/src/base/iterators.jl
+++ b/src/base/iterators.jl
@@ -1,16 +1,48 @@
-function Base.iterate(
+# The FID column name is a property of the layer, not of the individual
+# feature, so it is looked up once when iteration starts and carried along in
+# the iteration state. Re-querying it per feature would roughly double the cost
+# of iterating a layer.
+const FeatureIteratorState = Tuple{Int64,Symbol}
+
+function _nextfeature(
     layer::AbstractFeatureLayer,
-    state::Integer = 0,
-)::Union{Nothing,Tuple{IFeature,Int64}}
-    layer.ptr == C_NULL && return nothing
-    state == 0 && resetreading!(layer)
+    count::Int64,
+    fidcolumn::Symbol,
+)::Union{Nothing,Tuple{IFeature,FeatureIteratorState}}
     ptr = GDAL.ogr_l_getnextfeature(layer)
     return if ptr == C_NULL
         resetreading!(layer)
         nothing
     else
-        (IFeature(ptr), state + 1)
+        (IFeature(ptr, fidcolumn), (count + 1, fidcolumn))
     end
+end
+
+function Base.iterate(
+    layer::AbstractFeatureLayer,
+)::Union{Nothing,Tuple{IFeature,FeatureIteratorState}}
+    layer.ptr == C_NULL && return nothing
+    resetreading!(layer)
+    return _nextfeature(layer, 0, _fidcolumn(layer))
+end
+
+function Base.iterate(
+    layer::AbstractFeatureLayer,
+    state::FeatureIteratorState,
+)::Union{Nothing,Tuple{IFeature,FeatureIteratorState}}
+    layer.ptr == C_NULL && return nothing
+    return _nextfeature(layer, state[1], state[2])
+end
+
+# Retained for callers that drive `iterate` by hand with an integer state, as
+# the iteration state used to be a bare counter.
+function Base.iterate(
+    layer::AbstractFeatureLayer,
+    state::Integer,
+)::Union{Nothing,Tuple{IFeature,FeatureIteratorState}}
+    layer.ptr == C_NULL && return nothing
+    state == 0 && resetreading!(layer)
+    return _nextfeature(layer, Int64(state), _fidcolumn(layer))
 end
 
 Base.eltype(layer::AbstractFeatureLayer)::DataType = IFeature

--- a/src/ogr/feature.jl
+++ b/src/ogr/feature.jl
@@ -7,7 +7,7 @@ The newly created feature is owned by the caller, and will have its own
 reference to the OGRFeatureDefn.
 """
 unsafe_clone(feature::AbstractFeature)::AbstractFeature =
-    Feature(GDAL.ogr_f_clone(feature))
+    Feature(GDAL.ogr_f_clone(feature), feature.fidcolumn)
 
 """
     destroy(feature::AbstractFeature)

--- a/src/ogr/featurelayer.jl
+++ b/src/ogr/featurelayer.jl
@@ -376,7 +376,7 @@ reading may or may not be valid after that operation and a call to
 `resetreading!()` might be needed.
 """
 function unsafe_nextfeature(layer::AbstractFeatureLayer)::Feature
-    return Feature(GDAL.ogr_l_getnextfeature(layer))
+    return Feature(GDAL.ogr_l_getnextfeature(layer), _fidcolumn(layer))
 end
 
 """
@@ -441,7 +441,7 @@ The returned feature is now owned by the caller, and should be freed with
 `destroy()`.
 """
 unsafe_getfeature(layer::AbstractFeatureLayer, i::Integer)::Feature =
-    Feature(GDAL.ogr_l_getfeature(layer, i))
+    Feature(GDAL.ogr_l_getfeature(layer, i), _fidcolumn(layer))
 
 """
     setfeature!(layer::AbstractFeatureLayer, feature::AbstractFeature)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,3 +1,39 @@
+# The FID is a `GIntBig` on the GDAL side.
+const FIDTYPE = Int64
+
+"""
+    _fidcolumn(layer::AbstractFeatureLayer)
+
+The name to expose the FID of `layer`'s features under, or `Symbol("")` if it
+should not be exposed as a column at all.
+
+Database-like drivers (GPKG, PostGIS, SQLite, ...) back the FID with a real
+primary key column that OGR models separately from the fields, leaving it
+absent from the field definitions and so invisible to the rest of the tables
+interface. Those get a leading column named after the driver's FID column,
+matching what QGIS and R's `sf` show for the same data. Drivers without such a
+column (ESRI Shapefile, FlatGeobuf, ...) report `""` and gain no extra column.
+
+Some drivers report a FID column that *is* also a field: the GeoJSON driver
+promotes an `id` field to the FID while still listing `id` among the fields,
+with both carrying the same value. The field wins there, so that the column is
+not duplicated and the values stay reachable under the name they already had.
+
+This resolves to a fixed answer for the whole layer, so it is queried once when
+features start being read rather than per feature or per column.
+"""
+function _fidcolumn(layer::AbstractFeatureLayer)::Symbol
+    fidcolumn = Symbol(fidcolumnname(layer))
+    fidcolumn === Symbol("") && return fidcolumn
+    featuredefn = layerdefn(layer)
+    for i in 0:(nfield(featuredefn)-1)
+        if Symbol(getname(getfielddefn(featuredefn, i))) === fidcolumn
+            return Symbol("")
+        end
+    end
+    return fidcolumn
+end
+
 function Tables.schema(
     layer::AbstractFeatureLayer,
 )::Union{Nothing,Tables.Schema}
@@ -11,6 +47,11 @@ function Tables.schema(
     names = (geom_names..., field_names...)
     types = Type[_datatype(getgeomdefn(ld, i - 1)) for i in 1:ngeom(ld)]
     append!(types, map(_datatype, fielddefns))
+    fidcolumn = _fidcolumn(layer)
+    if fidcolumn !== Symbol("")
+        names = (fidcolumn, names...)
+        pushfirst!(types, FIDTYPE)
+    end
     return Tables.Schema(names, types)
 end
 
@@ -30,6 +71,11 @@ function Tables.rows(layer::T)::T where {T<:AbstractFeatureLayer}
 end
 
 function Tables.getcolumn(row::AbstractFeature, i::Int)
+    # The FID leads the columns, so shift the remaining indices past it.
+    if row.fidcolumn !== Symbol("")
+        i == 1 && return getfid(row)
+        i -= 1
+    end
     if i > nfield(row)
         return getgeom(row, i - nfield(row) - 1)
     elseif i > 0
@@ -40,6 +86,11 @@ function Tables.getcolumn(row::AbstractFeature, i::Int)
 end
 
 function Tables.getcolumn(row::AbstractFeature, name::Symbol)
+    # `Symbol("")` doubles as "no FID column" and as the name of an unnamed
+    # geometry column, so an empty name must never resolve to the FID.
+    if name !== Symbol("") && name === row.fidcolumn
+        return getfid(row)
+    end
     field = getfield(row, name)
     if !ismissing(field)
         return field
@@ -51,11 +102,14 @@ function Tables.getcolumn(row::AbstractFeature, name::Symbol)
     return missing
 end
 
-function Tables.columnnames(
-    row::AbstractFeature,
-)::NTuple{Int64(nfield(row) + ngeom(row)),Symbol}
+function Tables.columnnames(row::AbstractFeature)::Tuple{Vararg{Symbol}}
     geom_names, field_names = schema_names(getfeaturedefn(row))
-    return (geom_names..., field_names...)
+    fidcolumn = row.fidcolumn
+    return if fidcolumn === Symbol("")
+        (geom_names..., field_names...)
+    else
+        (fidcolumn, geom_names..., field_names...)
+    end
 end
 
 function schema_names(featuredefn::IFeatureDefnView)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -4,23 +4,14 @@ const FIDTYPE = Int64
 """
     _fidcolumn(layer::AbstractFeatureLayer)
 
-The name to expose the FID of `layer`'s features under, or `Symbol("")` if it
-should not be exposed as a column at all.
+The name to expose `layer`'s FID under, or `Symbol("")` for none.
 
-Database-like drivers (GPKG, PostGIS, SQLite, ...) back the FID with a real
-primary key column that OGR models separately from the fields, leaving it
-absent from the field definitions and so invisible to the rest of the tables
-interface. Those get a leading column named after the driver's FID column,
-matching what QGIS and R's `sf` show for the same data. Drivers without such a
-column (ESRI Shapefile, FlatGeobuf, ...) report `""` and gain no extra column.
+Database-like drivers (GPKG, PostGIS, SQLite, ...) back the FID with a primary
+key that OGR keeps out of the field definitions; others report `""`.
 
-Some drivers report a FID column that *is* also a field: the GeoJSON driver
-promotes an `id` field to the FID while still listing `id` among the fields,
-with both carrying the same value. The field wins there, so that the column is
-not duplicated and the values stay reachable under the name they already had.
-
-This resolves to a fixed answer for the whole layer, so it is queried once when
-features start being read rather than per feature or per column.
+Also `Symbol("")` when a field already claims the name: the GeoJSON driver
+promotes an `id` field to the FID yet still lists `id` as a field, both holding
+the same value. The field wins, so the column is not duplicated.
 """
 function _fidcolumn(layer::AbstractFeatureLayer)::Symbol
     fidcolumn = Symbol(fidcolumnname(layer))
@@ -86,8 +77,8 @@ function Tables.getcolumn(row::AbstractFeature, i::Int)
 end
 
 function Tables.getcolumn(row::AbstractFeature, name::Symbol)
-    # `Symbol("")` doubles as "no FID column" and as the name of an unnamed
-    # geometry column, so an empty name must never resolve to the FID.
+    # `Symbol("")` is both "no FID column" and the name of an unnamed geometry
+    # column, so it must never resolve to the FID.
     if name !== Symbol("") && name === row.fidcolumn
         return getfid(row)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,15 +145,33 @@ mutable struct IFeatureLayer <: AbstractFeatureLayer
     end
 end
 
+# `fidcolumn` records the name of the FID column of the layer the feature was
+# read from, mirroring GDAL's own convention for `OGR_L_GetFIDColumn`: it is
+# `Symbol("")` when the driver exposes no FID column, and for features that do
+# not originate from a layer at all (e.g. `createfeature(featuredefn)`), which
+# have no FID assigned yet. It is fixed for the lifetime of the feature, so it
+# is captured once at construction rather than re-queried from the layer.
 mutable struct Feature <: AbstractFeature
     ptr::GDAL.OGRFeatureH
+    fidcolumn::Symbol
+
+    function Feature(
+        ptr::GDAL.OGRFeatureH = C_NULL,
+        fidcolumn::Symbol = Symbol(""),
+    )
+        return new(ptr, fidcolumn)
+    end
 end
 
 mutable struct IFeature <: AbstractFeature
     ptr::GDAL.OGRFeatureH
+    fidcolumn::Symbol
 
-    function IFeature(ptr::GDAL.OGRFeatureH = C_NULL)
-        feature = new(ptr)
+    function IFeature(
+        ptr::GDAL.OGRFeatureH = C_NULL,
+        fidcolumn::Symbol = Symbol(""),
+    )
+        feature = new(ptr, fidcolumn)
         finalizer(destroy, feature)
         return feature
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -145,12 +145,8 @@ mutable struct IFeatureLayer <: AbstractFeatureLayer
     end
 end
 
-# `fidcolumn` records the name of the FID column of the layer the feature was
-# read from, mirroring GDAL's own convention for `OGR_L_GetFIDColumn`: it is
-# `Symbol("")` when the driver exposes no FID column, and for features that do
-# not originate from a layer at all (e.g. `createfeature(featuredefn)`), which
-# have no FID assigned yet. It is fixed for the lifetime of the feature, so it
-# is captured once at construction rather than re-queried from the layer.
+# `fidcolumn` names the FID column of the layer the feature was read from, and
+# is `Symbol("")` for features not read from a layer, which have no FID yet.
 mutable struct Feature <: AbstractFeature
     ptr::GDAL.OGRFeatureH
     fidcolumn::Symbol

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -676,9 +676,8 @@ using Tables
             end
 
             @testset "Conversion to table for GPKG driver" begin
-                # GPKG is a database-like driver, so it exposes a FID column
-                # ("fid") ahead of the geometry and field columns. Note this is
-                # distinct from the regular integer field also named `id`.
+                # The leading `fid` is the FID column, distinct from the
+                # ordinary integer field named `id`.
                 GPKG_test_reference_geotable = (
                     names = (:fid, :geom, :id, :name),
                     types = (
@@ -876,21 +875,16 @@ using Tables
                     @test AG.fidcolumnname(layer) == "fid"
 
                     rows = collect(Tables.rows(layer))
-                    # The FID leads the columns, as QGIS and R's `sf` show it
                     @test Tables.columnnames(rows[1]) == (:fid, :geom, :name)
-
-                    # ...by name
                     @test Tables.getcolumn(rows[1], :fid) == 1
                     @test Tables.getcolumn(rows[2], :fid) == 2
-                    # ...and by index, which the other columns shift past
+                    @test [Tables.getcolumn(r, :fid) for r in rows] == [AG.getfid(r) for r in rows]
+
+                    # The FID takes index 1, shifting the other columns past it
                     @test Tables.getcolumn(rows[1], 1) == 1
-                    @test Tables.getcolumn(rows[2], 1) == 2
                     @test Tables.getcolumn(rows[1], 2) == "a"
                     @test AG.toWKT(Tables.getcolumn(rows[1], 3)) ==
                           "POINT (1 1)"
-
-                    # The FID agrees with the feature-level accessor
-                    @test [Tables.getcolumn(r, :fid) for r in rows] == [AG.getfid(r) for r in rows]
 
                     table = Tables.columntable(layer)
                     @test Tables.columnnames(table) == (:fid, :geom, :name)
@@ -900,8 +894,6 @@ using Tables
             end
 
             @testset "The FID column is named after the driver's" begin
-                # GPKG lets the FID column be renamed; the exposed column
-                # follows it rather than being hardcoded to `fid`.
                 gpkg_with(dir, options = ["FID=my_id"]) do layer
                     @test AG.fidcolumnname(layer) == "my_id"
                     rows = collect(Tables.rows(layer))
@@ -912,40 +904,31 @@ using Tables
             end
 
             @testset "Empty layers carry the FID in their schema" begin
-                gpkg_with(dir) do layer
-                    copied = AG.copy(layer)
-                    for i in 1:AG.nfeature(copied)
-                        AG.deletefeature!(copied, i)
+                # Only a featureless layer reports a schema; otherwise it is
+                # built from the rows.
+                empty_gpkg = joinpath(dir, "empty.gpkg")
+                AG.create(empty_gpkg, driver = AG.getdriver("GPKG")) do ds
+                    AG.createlayer(
+                        name = "pts",
+                        dataset = ds,
+                        geom = AG.wkbPoint,
+                    ) do layer
+                        AG.addfielddefn!(layer, "name", AG.OFTString)
                     end
-                    # The in-memory copy is no longer a GPKG, so drive the
-                    # layer-level schema through the original instead.
-                    @test AG.nfeature(copied) == 0
-
-                    empty_gpkg = joinpath(dir, "empty.gpkg")
-                    AG.create(empty_gpkg, driver = AG.getdriver("GPKG")) do ds
-                        AG.createlayer(
-                            name = "pts",
-                            dataset = ds,
-                            geom = AG.wkbPoint,
-                        ) do lyr
-                            AG.addfielddefn!(lyr, "name", AG.OFTString)
-                        end
-                    end
-                    AG.read(empty_gpkg) do ds
-                        lyr = AG.getlayer(ds, 0)
-                        @test AG.nfeature(lyr) == 0
-                        @test Tables.schema(lyr) == Tables.Schema(
-                            (:fid, :geom, :name),
-                            (Int64, AG.IGeometry{AG.wkbPoint}, String),
-                        )
-                    end
+                end
+                AG.read(empty_gpkg) do ds
+                    layer = AG.getlayer(ds, 0)
+                    @test AG.nfeature(layer) == 0
+                    @test Tables.schema(layer) == Tables.Schema(
+                        (:fid, :geom, :name),
+                        (Int64, AG.IGeometry{AG.wkbPoint}, String),
+                    )
                 end
             end
 
             @testset "A field of the same name hides the FID column" begin
                 # The GeoJSON driver promotes an `id` field to the FID while
-                # still listing `id` among the fields, both carrying the same
-                # value. Exposing the FID too would produce a duplicate column.
+                # still listing `id` as a field, both holding the same value.
                 path = joinpath(dir, "id_field.geojson")
                 isfile(path) && rm(path)
                 AG.create(path, driver = AG.getdriver("GeoJSON")) do ds
@@ -967,15 +950,15 @@ using Tables
                     layer = AG.getlayer(ds, 0)
                     @test AG.fidcolumnname(layer) == "id"
                     row = first(Tables.rows(layer))
-                    # The FID and the field really do collide...
                     @test AG.getfid(row) == 42
                     @test AG.getfield(row, :id) == 42
-                    # ...so `id` appears exactly once, as the field
+
+                    # `id` appears once, as the field; duplicating it would
+                    # make `columntable` throw
                     names = Tables.columnnames(row)
                     @test names == (Symbol(""), :id, :name)
                     @test count(==(:id), names) == 1
                     @test Tables.getcolumn(row, :id) == 42
-                    # and building a column table does not throw on duplicates
                     @test keys(Tables.columntable(layer)) ==
                           (Symbol(""), :id, :name)
                 end
@@ -1002,8 +985,8 @@ using Tables
                         layer = AG.getlayer(ds, 0)
                         @test AG.fidcolumnname(layer) == ""
                         row = first(Tables.rows(layer))
-                        # No FID column, and the unnamed geometry column keeps
-                        # its `Symbol("")` name rather than resolving to a FID
+                        # The unnamed geometry column keeps its `Symbol("")`
+                        # name rather than resolving to the FID
                         @test Tables.columnnames(row) == (Symbol(""), :name)
                         @test Tables.getcolumn(row, 1) == "a"
                         @test ismissing(Tables.getcolumn(row, :fid))
@@ -1024,8 +1007,7 @@ using Tables
                         AG.addfielddefn!(layer, "name", AG.OFTString)
                         AG.addfeature(layer) do feature
                             # Being written rather than read, this feature has
-                            # no FID assigned yet (`OGRNullFID`), so it reports
-                            # no FID column instead of a placeholder one.
+                            # no FID yet (`OGRNullFID`)
                             @test AG.getfid(feature) == -1
                             @test :fid ∉ Tables.columnnames(feature)
                             @test ismissing(Tables.getcolumn(feature, :fid))
@@ -1035,8 +1017,7 @@ using Tables
                     end
                 end
 
-                # Read back out of the layer, the FID is there, and cloning
-                # preserves it
+                # Read back out of the layer it is there, and cloning keeps it
                 AG.read(path) do ds
                     layer = AG.getlayer(ds, 0)
                     feature = AG.unsafe_nextfeature(layer)
@@ -1060,8 +1041,6 @@ using Tables
 
             @testset "Iteration state carries the FID column name" begin
                 gpkg_with(dir) do layer
-                    # The name is looked up once per iteration rather than per
-                    # feature, so the state is no longer a bare counter.
                     next = iterate(layer)
                     @test next !== nothing
                     feature, state = next
@@ -1069,7 +1048,7 @@ using Tables
                     @test state == (1, :fid)
                     @test Tables.getcolumn(feature, :fid) == 1
 
-                    # Driving iteration with an integer state still works
+                    # An integer state still drives iteration
                     next2 = iterate(layer, 1)
                     @test next2 !== nothing
                     @test Tables.getcolumn(next2[1], :fid) == 2

--- a/test/test_tables.jl
+++ b/test/test_tables.jl
@@ -676,14 +676,19 @@ using Tables
             end
 
             @testset "Conversion to table for GPKG driver" begin
+                # GPKG is a database-like driver, so it exposes a FID column
+                # ("fid") ahead of the geometry and field columns. Note this is
+                # distinct from the regular integer field also named `id`.
                 GPKG_test_reference_geotable = (
-                    names = (:geom, :id, :name),
+                    names = (:fid, :geom, :id, :name),
                     types = (
+                        Int64,
                         Union{Missing,AG.IGeometry},
                         Union{Missing,Int64},
                         String,
                     ),
                     values = (
+                        Int64[1, 2, 3, 4],
                         Union{Missing,String}[
                             "LINESTRING (1 2,2 3,3 4)",
                             "MULTILINESTRING ((1 2,2 3,3 4,4 5),(6 7,7 8,8 9,9 10))",
@@ -828,6 +833,248 @@ using Tables
             end
 
             clean_test_dataset_files()
+        end
+    end
+
+    @testset "FID column" begin
+        """
+            gpkg_with(f, dir; options)
+
+        Writes a two-feature point layer to a GPKG in `dir` and reopens it,
+        applying `f` to the resulting layer.
+        """
+        function gpkg_with(f, dir; options = String[])
+            path = joinpath(dir, "fid_test.gpkg")
+            isfile(path) && rm(path)
+            AG.create(path, driver = AG.getdriver("GPKG")) do ds
+                AG.createlayer(
+                    name = "pts",
+                    dataset = ds,
+                    geom = AG.wkbPoint,
+                    options = options,
+                ) do layer
+                    AG.addfielddefn!(layer, "name", AG.OFTString)
+                    for (i, nm) in enumerate(["a", "b"])
+                        AG.addfeature(layer) do feature
+                            AG.setgeom!(
+                                feature,
+                                AG.createpoint(Float64(i), Float64(i)),
+                            )
+                            AG.setfield!(feature, 0, nm)
+                        end
+                    end
+                end
+            end
+            return AG.read(path) do ds
+                f(AG.getlayer(ds, 0))
+            end
+        end
+
+        mktempdir() do dir
+            @testset "Database-like drivers expose the FID" begin
+                gpkg_with(dir) do layer
+                    @test AG.fidcolumnname(layer) == "fid"
+
+                    rows = collect(Tables.rows(layer))
+                    # The FID leads the columns, as QGIS and R's `sf` show it
+                    @test Tables.columnnames(rows[1]) == (:fid, :geom, :name)
+
+                    # ...by name
+                    @test Tables.getcolumn(rows[1], :fid) == 1
+                    @test Tables.getcolumn(rows[2], :fid) == 2
+                    # ...and by index, which the other columns shift past
+                    @test Tables.getcolumn(rows[1], 1) == 1
+                    @test Tables.getcolumn(rows[2], 1) == 2
+                    @test Tables.getcolumn(rows[1], 2) == "a"
+                    @test AG.toWKT(Tables.getcolumn(rows[1], 3)) ==
+                          "POINT (1 1)"
+
+                    # The FID agrees with the feature-level accessor
+                    @test [Tables.getcolumn(r, :fid) for r in rows] == [AG.getfid(r) for r in rows]
+
+                    table = Tables.columntable(layer)
+                    @test Tables.columnnames(table) == (:fid, :geom, :name)
+                    @test table.fid == [1, 2]
+                    @test eltype(table.fid) == Int64
+                end
+            end
+
+            @testset "The FID column is named after the driver's" begin
+                # GPKG lets the FID column be renamed; the exposed column
+                # follows it rather than being hardcoded to `fid`.
+                gpkg_with(dir, options = ["FID=my_id"]) do layer
+                    @test AG.fidcolumnname(layer) == "my_id"
+                    rows = collect(Tables.rows(layer))
+                    @test Tables.columnnames(rows[1]) == (:my_id, :geom, :name)
+                    @test Tables.getcolumn(rows[1], :my_id) == 1
+                    @test ismissing(Tables.getcolumn(rows[1], :fid))
+                end
+            end
+
+            @testset "Empty layers carry the FID in their schema" begin
+                gpkg_with(dir) do layer
+                    copied = AG.copy(layer)
+                    for i in 1:AG.nfeature(copied)
+                        AG.deletefeature!(copied, i)
+                    end
+                    # The in-memory copy is no longer a GPKG, so drive the
+                    # layer-level schema through the original instead.
+                    @test AG.nfeature(copied) == 0
+
+                    empty_gpkg = joinpath(dir, "empty.gpkg")
+                    AG.create(empty_gpkg, driver = AG.getdriver("GPKG")) do ds
+                        AG.createlayer(
+                            name = "pts",
+                            dataset = ds,
+                            geom = AG.wkbPoint,
+                        ) do lyr
+                            AG.addfielddefn!(lyr, "name", AG.OFTString)
+                        end
+                    end
+                    AG.read(empty_gpkg) do ds
+                        lyr = AG.getlayer(ds, 0)
+                        @test AG.nfeature(lyr) == 0
+                        @test Tables.schema(lyr) == Tables.Schema(
+                            (:fid, :geom, :name),
+                            (Int64, AG.IGeometry{AG.wkbPoint}, String),
+                        )
+                    end
+                end
+            end
+
+            @testset "A field of the same name hides the FID column" begin
+                # The GeoJSON driver promotes an `id` field to the FID while
+                # still listing `id` among the fields, both carrying the same
+                # value. Exposing the FID too would produce a duplicate column.
+                path = joinpath(dir, "id_field.geojson")
+                isfile(path) && rm(path)
+                AG.create(path, driver = AG.getdriver("GeoJSON")) do ds
+                    AG.createlayer(
+                        name = "l",
+                        dataset = ds,
+                        geom = AG.wkbPoint,
+                    ) do layer
+                        AG.addfielddefn!(layer, "id", AG.OFTInteger)
+                        AG.addfielddefn!(layer, "name", AG.OFTString)
+                        AG.addfeature(layer) do feature
+                            AG.setgeom!(feature, AG.createpoint(1.0, 2.0))
+                            AG.setfield!(feature, 0, 42)
+                            AG.setfield!(feature, 1, "a")
+                        end
+                    end
+                end
+                AG.read(path) do ds
+                    layer = AG.getlayer(ds, 0)
+                    @test AG.fidcolumnname(layer) == "id"
+                    row = first(Tables.rows(layer))
+                    # The FID and the field really do collide...
+                    @test AG.getfid(row) == 42
+                    @test AG.getfield(row, :id) == 42
+                    # ...so `id` appears exactly once, as the field
+                    names = Tables.columnnames(row)
+                    @test names == (Symbol(""), :id, :name)
+                    @test count(==(:id), names) == 1
+                    @test Tables.getcolumn(row, :id) == 42
+                    # and building a column table does not throw on duplicates
+                    @test keys(Tables.columntable(layer)) ==
+                          (Symbol(""), :id, :name)
+                end
+            end
+
+            @testset "Drivers without a FID column are unchanged" begin
+                for (drv, ext) in
+                    [("GeoJSON", ".geojson"), ("ESRI Shapefile", ".shp")]
+                    path = joinpath(dir, "nofid$ext")
+                    AG.create(path, driver = AG.getdriver(drv)) do ds
+                        AG.createlayer(
+                            name = "l",
+                            dataset = ds,
+                            geom = AG.wkbPoint,
+                        ) do layer
+                            AG.addfielddefn!(layer, "name", AG.OFTString)
+                            AG.addfeature(layer) do feature
+                                AG.setgeom!(feature, AG.createpoint(1.0, 2.0))
+                                AG.setfield!(feature, 0, "a")
+                            end
+                        end
+                    end
+                    AG.read(path) do ds
+                        layer = AG.getlayer(ds, 0)
+                        @test AG.fidcolumnname(layer) == ""
+                        row = first(Tables.rows(layer))
+                        # No FID column, and the unnamed geometry column keeps
+                        # its `Symbol("")` name rather than resolving to a FID
+                        @test Tables.columnnames(row) == (Symbol(""), :name)
+                        @test Tables.getcolumn(row, 1) == "a"
+                        @test ismissing(Tables.getcolumn(row, :fid))
+                        @test !ismissing(Tables.getcolumn(row, Symbol("")))
+                    end
+                end
+            end
+
+            @testset "Features not read from a layer have no FID column" begin
+                path = joinpath(dir, "detached.gpkg")
+                isfile(path) && rm(path)
+                AG.create(path, driver = AG.getdriver("GPKG")) do ds
+                    AG.createlayer(
+                        name = "pts",
+                        dataset = ds,
+                        geom = AG.wkbPoint,
+                    ) do layer
+                        AG.addfielddefn!(layer, "name", AG.OFTString)
+                        AG.addfeature(layer) do feature
+                            # Being written rather than read, this feature has
+                            # no FID assigned yet (`OGRNullFID`), so it reports
+                            # no FID column instead of a placeholder one.
+                            @test AG.getfid(feature) == -1
+                            @test :fid ∉ Tables.columnnames(feature)
+                            @test ismissing(Tables.getcolumn(feature, :fid))
+                            AG.setgeom!(feature, AG.createpoint(1.0, 2.0))
+                            AG.setfield!(feature, 0, "a")
+                        end
+                    end
+                end
+
+                # Read back out of the layer, the FID is there, and cloning
+                # preserves it
+                AG.read(path) do ds
+                    layer = AG.getlayer(ds, 0)
+                    feature = AG.unsafe_nextfeature(layer)
+                    try
+                        @test Tables.columnnames(feature) ==
+                              (:fid, :geom, :name)
+                        @test Tables.getcolumn(feature, :fid) == 1
+                        cloned = AG.unsafe_clone(feature)
+                        try
+                            @test Tables.columnnames(cloned) ==
+                                  (:fid, :geom, :name)
+                            @test Tables.getcolumn(cloned, :fid) == 1
+                        finally
+                            AG.destroy(cloned)
+                        end
+                    finally
+                        AG.destroy(feature)
+                    end
+                end
+            end
+
+            @testset "Iteration state carries the FID column name" begin
+                gpkg_with(dir) do layer
+                    # The name is looked up once per iteration rather than per
+                    # feature, so the state is no longer a bare counter.
+                    next = iterate(layer)
+                    @test next !== nothing
+                    feature, state = next
+                    @test state isa Tuple{Int64,Symbol}
+                    @test state == (1, :fid)
+                    @test Tables.getcolumn(feature, :fid) == 1
+
+                    # Driving iteration with an integer state still works
+                    next2 = iterate(layer, 1)
+                    @test next2 !== nothing
+                    @test Tables.getcolumn(next2[1], :fid) == 2
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Fixes evetion/GeoDataFrames.jl#142 — reading a GeoPackage dropped the id column that QGIS and R's `sf` both show.

Database-like drivers (GPKG, PostGIS, SQLite, …) give each feature a persistent primary key, which GDAL keeps out of the field definitions, so it never reached the tables interface. Where a driver reports one via `OGR_L_GetFIDColumn` it now leads the table, under that driver's name for it. Drivers reporting `""` (Shapefile, FlatGeobuf, …) are unchanged.

```julia
julia> DataFrame(ArchGDAL.getlayer(ArchGDAL.read("rivers.gpkg"), 0))
357×5 DataFrame
 Row │ id     geom                     property_0  property_1      property_2
   1 │     1  Geometry: wkbLineString  6           Sutlej          null
```

Worth a look:

- **Features carry the column name.** It's a layer property, but schemas are built from rows, so features capture it at construction — also the only point it's knowable. A feature built from a featuredefn has no layer and no FID, and reports no FID column.
- **The GeoJSON driver promotes an `id` field to the FID *and* keeps `id` as a field.** The field wins; otherwise `columntable` throws `duplicate field name`.
- **Iteration state** is now `Tuple{Int64,Symbol}` rather than `Int64`, so the name is resolved per layer, not per feature (which measured ~+96% on iteration). An `Integer`-state method is kept for hand-driven callers. Iteration is unchanged vs master (161 vs 166 ns/feature, min of 7).
- **The FID takes index 1**, shifting the rest. Note `getcolumn(row, i)` and `columnnames` already disagree on master — index 1 is the first *field*, name 1 the first *geometry*. Left alone; happy to fix separately.

Suite: 1955 passed, 3 errored — the same 3 as master here (SQLite driver, network).
