### PR TITLE
Add dimensional geometry constructors and GeoInterface convert fast paths

### DIFF
--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -83,6 +83,8 @@ The following methods are commonly used for modifying or adding to a geometry.
 * [`ArchGDAL.setpoint!(geom, i, x, y, z)`](@ref)
 * [`ArchGDAL.addpoint!(geom, x, y)`](@ref)
 * [`ArchGDAL.addpoint!(geom, x, y, z)`](@ref)
+* [`ArchGDAL.addpoint!(geom, x, y, z, m)`](@ref)
+* [`ArchGDAL.addpointm!(geom, x, y, m)`](@ref)
 * [`ArchGDAL.addgeom!(geom1, geom2)`](@ref)
 * [`ArchGDAL.removegeom!(geom, i)`](@ref)
 * [`ArchGDAL.removeallgeoms!(geom)`](@ref)

--- a/src/context.jl
+++ b/src/context.jl
@@ -260,6 +260,7 @@ for gdalfunc in (
     :union,
     :update,
     :readraster,
+    DIMENSIONED_CONSTRUCTORS...,
 )
     eval(quote
         function $(gdalfunc)(f::Function, args...; kwargs...)

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -440,3 +440,33 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
         end
     end
 end
+
+# Streams points straight into the polygon's rings, which skips the nested
+# coordinate vectors the generic `GeoInterface.coordinates` path materializes.
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.PolygonTrait,
+    geom,
+) where {T<:IGeometry}
+    is3d = GeoInterface.is3d(geom)
+    poly =
+        is3d ? creategeom(Val{wkbPolygon25D}()) : creategeom(Val{wkbPolygon}())
+    for ring in GeoInterface.getring(geom)
+        lr = unsafe_createlinearring()
+        for p in GeoInterface.getpoint(ring)
+            if is3d
+                addpoint!(
+                    lr,
+                    GeoInterface.x(p),
+                    GeoInterface.y(p),
+                    GeoInterface.z(p),
+                )
+            else
+                addpoint!(lr, GeoInterface.x(p), GeoInterface.y(p))
+            end
+        end
+        result = GDAL.ogr_g_addgeometrydirectly(poly, lr)
+        @ogrerr result "Failed to add linearring."
+    end
+    return poly
+end

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -441,32 +441,147 @@ let pointtypes = (wkbPoint, wkbPoint25D, wkbPointM, wkbPointZM),
     end
 end
 
-# Streams points straight into the polygon's rings, which skips the nested
-# coordinate vectors the generic `GeoInterface.coordinates` path materializes.
+# Fast paths for `GeoInterface.convert`. These stream points straight into the
+# OGR geometry, which skips the nested coordinate vectors that the generic
+# `GeoInterface.coordinates` fallback materializes for every ring and
+# sub-geometry.
+
+# The Z coordinate lives on the points, so the first one settles whether the
+# geometry is 3D. GeoInterface leaves `ncoord` optional on container geometries.
+function _is3d(geom)
+    for p in GeoInterface.getpoint(geom)
+        return GeoInterface.is3d(p)
+    end
+    return false
+end
+
+# Appends every point of `geom` to `curve`, an OGR line string or linear ring.
+function _addpoints!(curve, geom, is3d::Bool)
+    for p in GeoInterface.getpoint(geom)
+        if is3d
+            addpoint!(
+                curve,
+                GeoInterface.x(p),
+                GeoInterface.y(p),
+                GeoInterface.z(p),
+            )
+        else
+            addpoint!(curve, GeoInterface.x(p), GeoInterface.y(p))
+        end
+    end
+    return curve
+end
+
+# Hands `subgeom` to `parent`. GDAL owns it from here, so `subgeom` must come
+# from an `unsafe_create*` constructor.
+function _addsubgeom!(parent, subgeom, what::AbstractString)
+    result = GDAL.ogr_g_addgeometrydirectly(parent, subgeom)
+    @ogrerr result "Failed to add $what."
+    return parent
+end
+
+# Appends every ring of `geom` to `polygon`.
+function _addrings!(polygon, geom, is3d::Bool)
+    for ring in GeoInterface.getring(geom)
+        lr = unsafe_createlinearring()
+        _addpoints!(lr, ring, is3d)
+        _addsubgeom!(polygon, lr, "linearring")
+    end
+    return polygon
+end
+
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.PointTrait,
+    geom,
+) where {T<:IGeometry}
+    return if GeoInterface.is3d(geom)
+        createpoint(
+            GeoInterface.x(geom),
+            GeoInterface.y(geom),
+            GeoInterface.z(geom),
+        )
+    else
+        createpoint(GeoInterface.x(geom), GeoInterface.y(geom))
+    end
+end
+
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.LineStringTrait,
+    geom,
+) where {T<:IGeometry}
+    is3d = _is3d(geom)
+    line = is3d ? createlinestring25D() : createlinestring()
+    return _addpoints!(line, geom, is3d)
+end
+
+# `wkbLinearRing` carries no dimensional variants, so the ring starts flat and
+# `addpoint!` lifts it to 3D on the first point.
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.LinearRingTrait,
+    geom,
+) where {T<:IGeometry}
+    return _addpoints!(createlinearring(), geom, _is3d(geom))
+end
+
 function GeoInterface.convert(
     ::Type{T},
     ::GeoInterface.PolygonTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = GeoInterface.is3d(geom)
-    poly =
-        is3d ? creategeom(Val{wkbPolygon25D}()) : creategeom(Val{wkbPolygon}())
-    for ring in GeoInterface.getring(geom)
-        lr = unsafe_createlinearring()
-        for p in GeoInterface.getpoint(ring)
-            if is3d
-                addpoint!(
-                    lr,
-                    GeoInterface.x(p),
-                    GeoInterface.y(p),
-                    GeoInterface.z(p),
-                )
-            else
-                addpoint!(lr, GeoInterface.x(p), GeoInterface.y(p))
-            end
-        end
-        result = GDAL.ogr_g_addgeometrydirectly(poly, lr)
-        @ogrerr result "Failed to add linearring."
+    is3d = _is3d(geom)
+    poly = is3d ? createpolygon25D() : createpolygon()
+    return _addrings!(poly, geom, is3d)
+end
+
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.MultiPointTrait,
+    geom,
+) where {T<:IGeometry}
+    is3d = _is3d(geom)
+    multipoint = is3d ? createmultipoint25D() : createmultipoint()
+    for p in GeoInterface.getgeom(geom)
+        pt =
+            is3d ?
+            unsafe_createpoint(
+                GeoInterface.x(p),
+                GeoInterface.y(p),
+                GeoInterface.z(p),
+            ) : unsafe_createpoint(GeoInterface.x(p), GeoInterface.y(p))
+        _addsubgeom!(multipoint, pt, "point")
     end
-    return poly
+    return multipoint
+end
+
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.MultiLineStringTrait,
+    geom,
+) where {T<:IGeometry}
+    is3d = _is3d(geom)
+    multiline = is3d ? createmultilinestring25D() : createmultilinestring()
+    for line in GeoInterface.getgeom(geom)
+        ls = is3d ? unsafe_createlinestring25D() : unsafe_createlinestring()
+        _addpoints!(ls, line, is3d)
+        _addsubgeom!(multiline, ls, "linestring")
+    end
+    return multiline
+end
+
+function GeoInterface.convert(
+    ::Type{T},
+    ::GeoInterface.MultiPolygonTrait,
+    geom,
+) where {T<:IGeometry}
+    is3d = _is3d(geom)
+    multipoly = is3d ? createmultipolygon25D() : createmultipolygon()
+    for poly in GeoInterface.getgeom(geom)
+        p = is3d ? unsafe_createpolygon25D() : unsafe_createpolygon()
+        _addrings!(p, poly, is3d)
+        _addsubgeom!(multipoly, p, "polygon")
+    end
+    return multipoly
 end

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -446,28 +446,28 @@ end
 # `GeoInterface.coordinates` fallback materializes for every ring and
 # sub-geometry.
 
-# The Z coordinate lives on the points, so the first one settles whether the
-# geometry is 3D. GeoInterface leaves `ncoord` optional on container geometries.
-function _is3d(geom)
-    for p in GeoInterface.getpoint(geom)
-        return GeoInterface.is3d(p)
+# Z and M flags of `geom`, read from the container rather than its points.
+_dims(geom) = (GeoInterface.is3d(geom), GeoInterface.ismeasured(geom))
+
+# Appends the point `p` to `geom`, an OGR point, line string or linear ring.
+function _addpoint!(geom, p, is3d::Bool, ismeasured::Bool)
+    x, y = GeoInterface.x(p), GeoInterface.y(p)
+    if is3d && ismeasured
+        addpoint!(geom, x, y, GeoInterface.z(p), GeoInterface.m(p))
+    elseif is3d
+        addpoint!(geom, x, y, GeoInterface.z(p))
+    elseif ismeasured
+        addpointm!(geom, x, y, GeoInterface.m(p))
+    else
+        addpoint!(geom, x, y)
     end
-    return false
+    return geom
 end
 
 # Appends every point of `geom` to `curve`, an OGR line string or linear ring.
-function _addpoints!(curve, geom, is3d::Bool)
+function _addpoints!(curve, geom, is3d::Bool, ismeasured::Bool)
     for p in GeoInterface.getpoint(geom)
-        if is3d
-            addpoint!(
-                curve,
-                GeoInterface.x(p),
-                GeoInterface.y(p),
-                GeoInterface.z(p),
-            )
-        else
-            addpoint!(curve, GeoInterface.x(p), GeoInterface.y(p))
-        end
+        _addpoint!(curve, p, is3d, ismeasured)
     end
     return curve
 end
@@ -481,10 +481,10 @@ function _addsubgeom!(parent, subgeom, what::AbstractString)
 end
 
 # Appends every ring of `geom` to `polygon`.
-function _addrings!(polygon, geom, is3d::Bool)
+function _addrings!(polygon, geom, is3d::Bool, ismeasured::Bool)
     for ring in GeoInterface.getring(geom)
         lr = unsafe_createlinearring()
-        _addpoints!(lr, ring, is3d)
+        _addpoints!(lr, ring, is3d, ismeasured)
         _addsubgeom!(polygon, lr, "linearring")
     end
     return polygon
@@ -495,15 +495,8 @@ function GeoInterface.convert(
     ::GeoInterface.PointTrait,
     geom,
 ) where {T<:IGeometry}
-    return if GeoInterface.is3d(geom)
-        createpoint(
-            GeoInterface.x(geom),
-            GeoInterface.y(geom),
-            GeoInterface.z(geom),
-        )
-    else
-        createpoint(GeoInterface.x(geom), GeoInterface.y(geom))
-    end
+    is3d, ismeasured = _dims(geom)
+    return _addpoint!(_createpoint(is3d, ismeasured), geom, is3d, ismeasured)
 end
 
 function GeoInterface.convert(
@@ -511,19 +504,19 @@ function GeoInterface.convert(
     ::GeoInterface.LineStringTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = _is3d(geom)
-    line = is3d ? createlinestring25D() : createlinestring()
-    return _addpoints!(line, geom, is3d)
+    is3d, ismeasured = _dims(geom)
+    line = _createlinestring(is3d, ismeasured)
+    return _addpoints!(line, geom, is3d, ismeasured)
 end
 
 # `wkbLinearRing` carries no dimensional variants, so the ring starts flat and
-# `addpoint!` lifts it to 3D on the first point.
+# the first point lifts it to the right Z/M layout.
 function GeoInterface.convert(
     ::Type{T},
     ::GeoInterface.LinearRingTrait,
     geom,
 ) where {T<:IGeometry}
-    return _addpoints!(createlinearring(), geom, _is3d(geom))
+    return _addpoints!(createlinearring(), geom, _dims(geom)...)
 end
 
 function GeoInterface.convert(
@@ -531,9 +524,9 @@ function GeoInterface.convert(
     ::GeoInterface.PolygonTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = _is3d(geom)
-    poly = is3d ? createpolygon25D() : createpolygon()
-    return _addrings!(poly, geom, is3d)
+    is3d, ismeasured = _dims(geom)
+    poly = _createpolygon(is3d, ismeasured)
+    return _addrings!(poly, geom, is3d, ismeasured)
 end
 
 function GeoInterface.convert(
@@ -541,16 +534,11 @@ function GeoInterface.convert(
     ::GeoInterface.MultiPointTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = _is3d(geom)
-    multipoint = is3d ? createmultipoint25D() : createmultipoint()
+    is3d, ismeasured = _dims(geom)
+    multipoint = _createmultipoint(is3d, ismeasured)
     for p in GeoInterface.getgeom(geom)
-        pt =
-            is3d ?
-            unsafe_createpoint(
-                GeoInterface.x(p),
-                GeoInterface.y(p),
-                GeoInterface.z(p),
-            ) : unsafe_createpoint(GeoInterface.x(p), GeoInterface.y(p))
+        pt = _unsafe_createpoint(is3d, ismeasured)
+        _addpoint!(pt, p, is3d, ismeasured)
         _addsubgeom!(multipoint, pt, "point")
     end
     return multipoint
@@ -561,11 +549,11 @@ function GeoInterface.convert(
     ::GeoInterface.MultiLineStringTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = _is3d(geom)
-    multiline = is3d ? createmultilinestring25D() : createmultilinestring()
+    is3d, ismeasured = _dims(geom)
+    multiline = _createmultilinestring(is3d, ismeasured)
     for line in GeoInterface.getgeom(geom)
-        ls = is3d ? unsafe_createlinestring25D() : unsafe_createlinestring()
-        _addpoints!(ls, line, is3d)
+        ls = _unsafe_createlinestring(is3d, ismeasured)
+        _addpoints!(ls, line, is3d, ismeasured)
         _addsubgeom!(multiline, ls, "linestring")
     end
     return multiline
@@ -576,11 +564,11 @@ function GeoInterface.convert(
     ::GeoInterface.MultiPolygonTrait,
     geom,
 ) where {T<:IGeometry}
-    is3d = _is3d(geom)
-    multipoly = is3d ? createmultipolygon25D() : createmultipolygon()
+    is3d, ismeasured = _dims(geom)
+    multipoly = _createmultipolygon(is3d, ismeasured)
     for poly in GeoInterface.getgeom(geom)
-        p = is3d ? unsafe_createpolygon25D() : unsafe_createpolygon()
-        _addrings!(p, poly, is3d)
+        p = _unsafe_createpolygon(is3d, ismeasured)
+        _addrings!(p, poly, is3d, ismeasured)
         _addsubgeom!(multipoly, p, "polygon")
     end
     return multipoly

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1284,16 +1284,30 @@ end
 """
     addpoint!(geom::AbstractGeometry, x, y)
     addpoint!(geom::AbstractGeometry, x, y, z)
+    addpoint!(geom::AbstractGeometry, x, y, z, m)
 
-Add a point to a geometry (line string or point).
+Add a point to a geometry (line string or point). Use [`addpointm!`](@ref) for
+a point with an m coordinate but no z coordinate.
 
 ### Parameters
 * `geom`: the geometry to add a point to.
 * `x`: x coordinate of point to add.
 * `y`: y coordinate of point to add.
 * `z`: z coordinate of point to add.
+* `m`: m coordinate of point to add.
 """
 function addpoint! end
+
+function addpoint!(
+    geom::G,
+    x::Real,
+    y::Real,
+    z::Real,
+    m::Real,
+)::G where {G<:AbstractGeometry}
+    GDAL.ogr_g_addpointzm(geom, x, y, z, m)
+    return geom
+end
 
 function addpoint!(
     geom::G,
@@ -1307,6 +1321,28 @@ end
 
 function addpoint!(geom::G, x::Real, y::Real)::G where {G<:AbstractGeometry}
     GDAL.ogr_g_addpoint_2d(geom, x, y)
+    return geom
+end
+
+"""
+    addpointm!(geom::AbstractGeometry, x, y, m)
+
+Add a point with an m coordinate, but no z coordinate, to a geometry (line
+string or point). Use [`addpoint!`](@ref) for the other coordinate layouts.
+
+### Parameters
+* `geom`: the geometry to add a point to.
+* `x`: x coordinate of point to add.
+* `y`: y coordinate of point to add.
+* `m`: m coordinate of point to add.
+"""
+function addpointm!(
+    geom::G,
+    x::Real,
+    y::Real,
+    m::Real,
+)::G where {G<:AbstractGeometry}
+    GDAL.ogr_g_addpointm(geom, x, y, m)
     return geom
 end
 
@@ -1731,6 +1767,22 @@ for (geom, wkbgeom) in GEOMETRY_CONSTRUCTORS
                 unsafe_creategeom(Val{$wkbvariant}())
         end
         push!(DIMENSIONED_CONSTRUCTORS, createfunc)
+    end
+    # `_createpolygon(is3d, ismeasured)` and friends pick the variant from
+    # flags only known at runtime, as the `GeoInterface.convert` fast paths do.
+    for f in (:create, :unsafe_create)
+        stem = Symbol(f, geom)
+        @eval function $(Symbol(:_, stem))(is3d::Bool, ismeasured::Bool)
+            return if is3d && ismeasured
+                $(Symbol(stem, :ZM))()
+            elseif is3d
+                $(Symbol(stem, "25D"))()
+            elseif ismeasured
+                $(Symbol(stem, :M))()
+            else
+                $stem()
+            end
+        end
     end
 end
 

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -1697,25 +1697,48 @@ Get flag to enable/disable returning non-linear geometries in the C API.
 """
 getnonlineargeomflag()::Bool = Bool(GDAL.ogrgetnonlineargeometriesenabledflag())
 
-# TODO This code doesn't create the wkbgeom variants (25D, M, ZM)
-for (geom, wkbgeom) in (
-    (:geomcollection, wkbGeometryCollection),
-    (:linestring, wkbLineString),
-    (:linearring, wkbLinearRing),
-    (:multilinestring, wkbMultiLineString),
-    (:multipoint, wkbMultiPoint),
-    (:multipolygon, wkbMultiPolygon),
-    (:multipolygon_noholes, wkbMultiPolygon),
-    (:point, wkbPoint),
-    (:polygon, wkbPolygon),
+# Constructor stem and the OGR type it builds. Each stem also gains a
+# constructor per dimensional variant, e.g. `createpolygon25D`; `linearring`
+# is defined separately below because OGR gives it no 25D/M/ZM forms.
+const GEOMETRY_CONSTRUCTORS = (
+    (:geomcollection, :wkbGeometryCollection),
+    (:linestring, :wkbLineString),
+    (:multilinestring, :wkbMultiLineString),
+    (:multipoint, :wkbMultiPoint),
+    (:multipolygon, :wkbMultiPolygon),
+    (:multipolygon_noholes, :wkbMultiPolygon),
+    (:point, :wkbPoint),
+    (:polygon, :wkbPolygon),
 )
+
+# The generated dimensional constructors. context.jl gives each of them the
+# scoped `do`-block form.
+const DIMENSIONED_CONSTRUCTORS = Symbol[]
+
+for (geom, wkbgeom) in GEOMETRY_CONSTRUCTORS
     @eval begin
-        $(Symbol("create$geom"))() = creategeom(Val{$wkbgeom}())
-        $(Symbol("unsafe_create$geom"))() = unsafe_creategeom(Val{$wkbgeom}())
-        $(Symbol("create$geom"))(val::Val) = creategeom(val)
-        $(Symbol("unsafe_create$geom"))(val::Val) = unsafe_creategeom(val)
+        $(Symbol(:create, geom))() = creategeom(Val{$wkbgeom}())
+        $(Symbol(:unsafe_create, geom))() = unsafe_creategeom(Val{$wkbgeom}())
+        $(Symbol(:create, geom))(val::Val) = creategeom(val)
+        $(Symbol(:unsafe_create, geom))(val::Val) = unsafe_creategeom(val)
+    end
+    for suffix in ("25D", "M", "ZM")
+        createfunc = Symbol(:create, geom, suffix)
+        wkbvariant = Symbol(wkbgeom, suffix)
+        @eval begin
+            $createfunc() = creategeom(Val{$wkbvariant}())
+            $(Symbol(:unsafe_, createfunc))() =
+                unsafe_creategeom(Val{$wkbvariant}())
+        end
+        push!(DIMENSIONED_CONSTRUCTORS, createfunc)
     end
 end
+
+# `wkbLinearRing` has no dimensional variants, so this stem stands alone.
+createlinearring() = creategeom(Val{wkbLinearRing}())
+unsafe_createlinearring() = unsafe_creategeom(Val{wkbLinearRing}())
+createlinearring(val::Val) = creategeom(val)
+unsafe_createlinearring(val::Val) = unsafe_creategeom(val)
 
 let V = Vector{<:Real}
     for (args, typedargs, typesuffix) in (

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1001,23 +1001,43 @@ import JLD2
             @test !GI.ismeasured(point)
             @test !GI.is3d(point)
         end
+        AG.createpointM() do point
+            AG.addpointm!(point, 1, 2, 3)
+            @test GI.ismeasured(point)
+            @test !GI.is3d(point)
+            @test GI.m(point) == 3
+            @test GI.getcoord(point, 3) == 3
+            @test_throws ArgumentError GI.z(point)
+            @test AG.toISOWKT(point) == "POINT M (1 2 3)"
+        end
+        AG.createpointZM() do point
+            AG.addpoint!(point, 1, 2, 3, 4)
+            @test GI.ismeasured(point)
+            @test GI.is3d(point)
+            @test GI.z(point) == 3
+            @test GI.m(point) == 4
+            @test GI.getcoord(point, 4) == 4
+            @test AG.toISOWKT(point) == "POINT ZM (1 2 3 4)"
+        end
     end
 
     @testset "GeoInterface conversion" begin
         struct MyPoint end
         struct MyLine end
 
-        GI.isgeometry(::MyPoint) = true
+        GI.isgeometry(::Type{MyPoint}) = true
         GI.geomtrait(::MyPoint) = GI.PointTrait()
         GI.ncoord(::GI.PointTrait, geom::MyPoint) = 2
         GI.getcoord(::GI.PointTrait, geom::MyPoint, i) = [1.0, 2.0][i]
 
-        GI.isgeometry(::MyLine) = true
+        GI.isgeometry(::Type{MyLine}) = true
         GI.geomtrait(::MyLine) = GI.LineStringTrait()
+        GI.ncoord(::GI.LineStringTrait, geom::MyLine) = 2
         GI.ngeom(::GI.LineStringTrait, geom::MyLine) = 2
         GI.getgeom(::GI.LineStringTrait, geom::MyLine, i) = MyPoint()
 
         geom = MyLine()
+        @test GI.testgeometry(geom)
         ag_geom = GI.convert(AG.IGeometry, geom)
         @test ag_geom isa AG.IGeometry{AG.wkbLineString}
         @test GI.coordinates(ag_geom) ==
@@ -1133,6 +1153,98 @@ import JLD2
             # The generic path routes coordinates through `lookup_method`
             generic = AG.lookup_method[typeof(GI.geomtrait(source))]
             @test AG.toWKT(generic(GI.coordinates(source))) == wkt
+        end
+
+        # The generic path has no notion of M, so these only check the fast
+        # path. Measured-only points need the explicit wrapper; a 4-tuple is
+        # ZM by GeoInterface's default coordinate names.
+        pm(x, y, m) = GI.Point{false,true}((x, y, m))
+        squarem = GI.LinearRing([
+            pm(0.0, 0.0, 1.0),
+            pm(3.0, 0.0, 2.0),
+            pm(3.0, 3.0, 3.0),
+            pm(0.0, 0.0, 1.0),
+        ])
+        squarezm = GI.LinearRing([
+            (0.0, 0.0, 1.0, 5.0),
+            (3.0, 0.0, 1.0, 6.0),
+            (3.0, 3.0, 1.0, 7.0),
+            (0.0, 0.0, 1.0, 5.0),
+        ])
+        for (source, isowkt, wkbtype) in (
+            (pm(1.0, 2.0, 3.0), "POINT M (1 2 3)", AG.wkbPointM),
+            (
+                GI.Point((1.0, 2.0, 3.0, 4.0)),
+                "POINT ZM (1 2 3 4)",
+                AG.wkbPointZM,
+            ),
+            (
+                GI.LineString([pm(0.0, 0.0, 1.0), pm(1.0, 1.0, 2.0)]),
+                "LINESTRING M (0 0 1,1 1 2)",
+                AG.wkbLineStringM,
+            ),
+            (
+                GI.LineString([(0.0, 0.0, 1.0, 5.0), (1.0, 1.0, 2.0, 6.0)]),
+                "LINESTRING ZM (0 0 1 5,1 1 2 6)",
+                AG.wkbLineStringZM,
+            ),
+            (
+                squarem,
+                "LINEARRING M (0 0 1,3 0 2,3 3 3,0 0 1)",
+                AG.wkbLineString,
+            ),
+            (
+                squarezm,
+                "LINEARRING ZM (0 0 1 5,3 0 1 6,3 3 1 7,0 0 1 5)",
+                AG.wkbLineString,
+            ),
+            (
+                GI.MultiPoint([pm(0.0, 0.0, 5.0), pm(1.0, 1.0, 6.0)]),
+                "MULTIPOINT M ((0 0 5),(1 1 6))",
+                AG.wkbMultiPointM,
+            ),
+            (
+                GI.MultiPoint([(0.0, 0.0, 5.0, 7.0), (1.0, 1.0, 6.0, 8.0)]),
+                "MULTIPOINT ZM ((0 0 5 7),(1 1 6 8))",
+                AG.wkbMultiPointZM,
+            ),
+            (
+                GI.MultiLineString([[pm(0.0, 0.0, 1.0), pm(1.0, 1.0, 2.0)]]),
+                "MULTILINESTRING M ((0 0 1,1 1 2))",
+                AG.wkbMultiLineStringM,
+            ),
+            (
+                GI.MultiLineString([[
+                    (0.0, 0.0, 1.0, 5.0),
+                    (1.0, 1.0, 2.0, 6.0),
+                ]]),
+                "MULTILINESTRING ZM ((0 0 1 5,1 1 2 6))",
+                AG.wkbMultiLineStringZM,
+            ),
+            (
+                GI.Polygon([squarem]),
+                "POLYGON M ((0 0 1,3 0 2,3 3 3,0 0 1))",
+                AG.wkbPolygonM,
+            ),
+            (
+                GI.Polygon([squarezm]),
+                "POLYGON ZM ((0 0 1 5,3 0 1 6,3 3 1 7,0 0 1 5))",
+                AG.wkbPolygonZM,
+            ),
+            (
+                GI.MultiPolygon([GI.Polygon([squarem])]),
+                "MULTIPOLYGON M (((0 0 1,3 0 2,3 3 3,0 0 1)))",
+                AG.wkbMultiPolygonM,
+            ),
+            (
+                GI.MultiPolygon([GI.Polygon([squarezm])]),
+                "MULTIPOLYGON ZM (((0 0 1 5,3 0 1 6,3 3 1 7,0 0 1 5)))",
+                AG.wkbMultiPolygonZM,
+            ),
+        )
+            geom = GI.convert(AG.IGeometry, source)
+            @test geom isa AG.IGeometry{wkbtype}
+            @test AG.toISOWKT(geom) == isowkt
         end
     end
 

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1030,6 +1030,59 @@ import JLD2
               [[1, 2], [1, 2]]
     end
 
+    @testset "Dimensional geometry constructors" begin
+        for (geom, wkbgeom) in AG.GEOMETRY_CONSTRUCTORS,
+            suffix in ("25D", "M", "ZM")
+
+            create = getfield(AG, Symbol(:create, geom, suffix))
+            wkbtype = getfield(AG, Symbol(wkbgeom, suffix))
+            @test AG.getgeomtype(create()) == wkbtype
+            create() do g
+                @test AG.getgeomtype(g) == wkbtype
+            end
+        end
+        # OGR defines no dimensional variants of wkbLinearRing
+        @test !isdefined(AG, :createlinearring25D)
+        @test AG.getgeomtype(AG.createlinearring()) == AG.wkbLineString
+    end
+
+    @testset "GeoInterface polygon conversion" begin
+        poly = GI.Polygon([
+            GI.LinearRing([
+                (0.0, 0.0),
+                (3.0, 0.0),
+                (3.0, 3.0),
+                (0.0, 3.0),
+                (0.0, 0.0),
+            ]),
+            GI.LinearRing([
+                (1.0, 1.0),
+                (2.0, 1.0),
+                (2.0, 2.0),
+                (1.0, 2.0),
+                (1.0, 1.0),
+            ]),
+        ])
+        ag_poly = GI.convert(AG.IGeometry, poly)
+        @test ag_poly isa AG.IGeometry{AG.wkbPolygon}
+        @test AG.toWKT(ag_poly) ==
+              "POLYGON ((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))"
+        @test AG.toWKB(ag_poly) ==
+              AG.toWKB(AG.createpolygon(GI.coordinates(poly)))
+
+        poly3d = GI.Polygon([
+            GI.LinearRing([
+                (0.0, 0.0, 1.0),
+                (3.0, 0.0, 1.0),
+                (3.0, 3.0, 1.0),
+                (0.0, 0.0, 1.0),
+            ]),
+        ])
+        ag_poly3d = GI.convert(AG.IGeometry, poly3d)
+        @test ag_poly3d isa AG.IGeometry{AG.wkbPolygon25D}
+        @test AG.toWKT(ag_poly3d) == "POLYGON ((0 0 1,3 0 1,3 3 1,0 0 1))"
+    end
+
     @testset "JLD2 serialization" begin
         filepath = joinpath(tempdir(), "test_geometry.jld2")
         geom = AG.fromWKT(

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -1046,41 +1046,94 @@ import JLD2
         @test AG.getgeomtype(AG.createlinearring()) == AG.wkbLineString
     end
 
-    @testset "GeoInterface polygon conversion" begin
-        poly = GI.Polygon([
-            GI.LinearRing([
-                (0.0, 0.0),
-                (3.0, 0.0),
-                (3.0, 3.0),
-                (0.0, 3.0),
-                (0.0, 0.0),
-            ]),
-            GI.LinearRing([
-                (1.0, 1.0),
-                (2.0, 1.0),
-                (2.0, 2.0),
-                (1.0, 2.0),
-                (1.0, 1.0),
-            ]),
+    @testset "GeoInterface conversion fast paths" begin
+        square(o) = GI.LinearRing([
+            (o + 0.0, o + 0.0),
+            (o + 3.0, o + 0.0),
+            (o + 3.0, o + 3.0),
+            (o + 0.0, o + 0.0),
         ])
-        ag_poly = GI.convert(AG.IGeometry, poly)
-        @test ag_poly isa AG.IGeometry{AG.wkbPolygon}
-        @test AG.toWKT(ag_poly) ==
-              "POLYGON ((0 0,3 0,3 3,0 3,0 0),(1 1,2 1,2 2,1 2,1 1))"
-        @test AG.toWKB(ag_poly) ==
-              AG.toWKB(AG.createpolygon(GI.coordinates(poly)))
-
-        poly3d = GI.Polygon([
-            GI.LinearRing([
-                (0.0, 0.0, 1.0),
-                (3.0, 0.0, 1.0),
-                (3.0, 3.0, 1.0),
-                (0.0, 0.0, 1.0),
-            ]),
+        square3d = GI.LinearRing([
+            (0.0, 0.0, 1.0),
+            (3.0, 0.0, 1.0),
+            (3.0, 3.0, 1.0),
+            (0.0, 0.0, 1.0),
         ])
-        ag_poly3d = GI.convert(AG.IGeometry, poly3d)
-        @test ag_poly3d isa AG.IGeometry{AG.wkbPolygon25D}
-        @test AG.toWKT(ag_poly3d) == "POLYGON ((0 0 1,3 0 1,3 3 1,0 0 1))"
+        hole = GI.LinearRing([(1.0, 1.0), (2.0, 1.0), (2.0, 2.0), (1.0, 1.0)])
+        for (source, wkt, wkbtype) in (
+            (GI.Point((1.0, 2.0)), "POINT (1 2)", AG.wkbPoint),
+            (GI.Point((1.0, 2.0, 3.0)), "POINT (1 2 3)", AG.wkbPoint25D),
+            (
+                GI.LineString([(0.0, 0.0), (1.0, 1.0), (2.0, 0.0)]),
+                "LINESTRING (0 0,1 1,2 0)",
+                AG.wkbLineString,
+            ),
+            (
+                GI.LineString([(0.0, 0.0, 1.0), (1.0, 1.0, 2.0)]),
+                "LINESTRING (0 0 1,1 1 2)",
+                AG.wkbLineString25D,
+            ),
+            (square(0), "LINEARRING (0 0,3 0,3 3,0 0)", AG.wkbLineString),
+            (
+                square3d,
+                "LINEARRING (0 0 1,3 0 1,3 3 1,0 0 1)",
+                AG.wkbLineString,
+            ),
+            (
+                GI.MultiPoint([(0.0, 0.0), (1.0, 1.0)]),
+                "MULTIPOINT (0 0,1 1)",
+                AG.wkbMultiPoint,
+            ),
+            (
+                GI.MultiPoint([(0.0, 0.0, 5.0), (1.0, 1.0, 6.0)]),
+                "MULTIPOINT (0 0 5,1 1 6)",
+                AG.wkbMultiPoint25D,
+            ),
+            (
+                GI.MultiLineString([
+                    [(0.0, 0.0), (1.0, 1.0)],
+                    [(2.0, 2.0), (3.0, 3.0)],
+                ]),
+                "MULTILINESTRING ((0 0,1 1),(2 2,3 3))",
+                AG.wkbMultiLineString,
+            ),
+            (
+                GI.MultiLineString([[(0.0, 0.0, 1.0), (1.0, 1.0, 2.0)]]),
+                "MULTILINESTRING ((0 0 1,1 1 2))",
+                AG.wkbMultiLineString25D,
+            ),
+            (
+                GI.Polygon([square(0), hole]),
+                "POLYGON ((0 0,3 0,3 3,0 0),(1 1,2 1,2 2,1 1))",
+                AG.wkbPolygon,
+            ),
+            (
+                GI.Polygon([square3d]),
+                "POLYGON ((0 0 1,3 0 1,3 3 1,0 0 1))",
+                AG.wkbPolygon25D,
+            ),
+            (
+                GI.MultiPolygon([
+                    GI.Polygon([square(0)]),
+                    GI.Polygon([square(10)]),
+                ]),
+                "MULTIPOLYGON (((0 0,3 0,3 3,0 0))," *
+                "((10 10,13 10,13 13,10 10)))",
+                AG.wkbMultiPolygon,
+            ),
+            (
+                GI.MultiPolygon([GI.Polygon([square3d])]),
+                "MULTIPOLYGON (((0 0 1,3 0 1,3 3 1,0 0 1)))",
+                AG.wkbMultiPolygon25D,
+            ),
+        )
+            geom = GI.convert(AG.IGeometry, source)
+            @test geom isa AG.IGeometry{wkbtype}
+            @test AG.toWKT(geom) == wkt
+            # The generic path routes coordinates through `lookup_method`
+            generic = AG.lookup_method[typeof(GI.geomtrait(source))]
+            @test AG.toWKT(generic(GI.coordinates(source))) == wkt
+        end
     end
 
     @testset "JLD2 serialization" begin


### PR DESCRIPTION
Two changes to geometry construction.

## Dimensional constructors

Every `create*`/`unsafe_create*` stem gains a constructor per dimensional variant, e.g. `createpolygon25D` and `createmultipointZM`: 24 new functions, each with the scoped `do`-block form. This retires the TODO in `src/ogr/geometry.jl`. `linearring` stands alone, because OGR defines no `25D`/`M`/`ZM` forms of `wkbLinearRing`.

Measured points get their own primitives: `addpoint!(geom, x, y, z, m)` wraps `OGR_G_AddPointZM` and `addpointm!(geom, x, y, m)` wraps `OGR_G_AddPointM`.

## `GeoInterface.convert` fast paths

`GeoInterface.convert(IGeometry, geom)` streams points straight into the OGR geometry for `Point`, `LineString`, `LinearRing`, `MultiPoint`, `MultiLineString`, `Polygon` and `MultiPolygon`. `GeometryCollection` is left to #430.

Each path reads `GeoInterface.is3d` and `GeoInterface.ismeasured` from the container and builds the matching variant, so the static type follows the data: a 3D line string converts to `IGeometry{wkbLineString25D}`, a measured one to `IGeometry{wkbLineStringM}`.

Timings on a 2000-point ring, minimum of 50 runs:

| Input | Fast path | Generic path | Speedup |
|---|---|---|---|
| `LineString` | 0.025 ms | 0.111 ms | 4.5× |
| `Polygon` | 0.025 ms | 0.110 ms | 4.3× |
| `MultiLineString` (3 parts) | 0.078 ms | 0.343 ms | 4.4× |
| `MultiPolygon` (3 parts) | 0.076 ms | 0.365 ms | 4.8× |

## Tests

`test_geometry.jl` goes from 261 to 394 passing tests: all 24 constructors in plain and `do`-block form, and every fast path in each of the 2D, Z, M and ZM layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLc2tuHZhxgkzBtpxTM9AP
