### PR TITLE
Add raster sieve filtering

### DIFF
--- a/src/raster/rasterband.jl
+++ b/src/raster/rasterband.jl
@@ -296,6 +296,62 @@ function copywholeraster!(
 end
 
 """
+    sievefilter!(source::AbstractRasterBand, destination::AbstractRasterBand,
+        size_threshold::Integer; mask, connectedness, progressfunc)
+    sievefilter!(band::AbstractRasterBand, size_threshold::Integer; kwargs...)
+
+Remove raster polygons smaller than `size_threshold` pixels by replacing them
+with the value of their largest neighbouring polygon.
+
+The source and destination bands must have the same dimensions. Passing a
+`mask` excludes zero-valued pixels from polygons; those pixels retain their
+source values. The two-argument form updates `band` in place.
+
+### Parameters
+* `source`: source raster band.
+* `destination`: destination raster band.
+* `size_threshold`: polygons smaller than this number of pixels are removed.
+
+### Keyword Arguments
+* `mask`: optional mask band, or `nothing` to process every pixel.
+* `connectedness`: `4` (the default) or `8` for polygon adjacency.
+* `progressfunc`: a function `(::Float64, ::String)::Bool` used to report
+  progress.
+"""
+function sievefilter!(
+    source::AbstractRasterBand,
+    destination::T,
+    size_threshold::Integer;
+    mask::Union{AbstractRasterBand,Nothing} = nothing,
+    connectedness::Integer = 4,
+    progressfunc::Function = _dummyprogress,
+)::T where {T<:AbstractRasterBand}
+    connectedness in (4, 8) ||
+        throw(ArgumentError("connectedness must be either 4 or 8"))
+
+    result = GDAL.gdalsievefilter(
+        source,
+        isnothing(mask) ? C_NULL : mask,
+        destination,
+        size_threshold,
+        connectedness,
+        C_NULL,
+        @cfunction(_progresscallback, Cint, (Cdouble, Cstring, Ptr{Cvoid})),
+        progressfunc,
+    )
+    @cplerr result "Failed to sieve raster band"
+    return destination
+end
+
+function sievefilter!(
+    band::T,
+    size_threshold::Integer;
+    kwargs...,
+)::T where {T<:AbstractRasterBand}
+    return sievefilter!(band, band, size_threshold; kwargs...)
+end
+
+"""
     noverview(band::AbstractRasterBand)
 
 Return the number of overview layers available, zero if none.

--- a/test/test_rasterband.jl
+++ b/test/test_rasterband.jl
@@ -151,3 +151,81 @@ import GeoFormatTypes as GFT
         end
     end
 end
+
+@testset "Sieve filter" begin
+    AG.create(
+        AG.getdriver("MEM"),
+        width = 4,
+        height = 4,
+        nbands = 3,
+        dtype = Int32,
+    ) do dataset
+        source = AG.getband(dataset, 1)
+        destination = AG.getband(dataset, 2)
+        mask = AG.getband(dataset, 3)
+
+        input = Int32[
+            1 1 1 1
+            1 2 1 1
+            1 1 3 3
+            1 1 1 1
+        ]
+        AG.write!(source, input)
+        progress_called = Ref(false)
+        progressfunc = function (progress, message = "")
+            progress_called[] = true
+            return true
+        end
+
+        @test AG.sievefilter!(
+            source,
+            destination,
+            2;
+            progressfunc,
+        ) === destination
+        @test AG.read(destination) == Int32[
+            1 1 1 1
+            1 1 1 1
+            1 1 3 3
+            1 1 1 1
+        ]
+        @test progress_called[]
+
+        diagonal = Int32[
+            1 1 1 1
+            1 2 1 1
+            1 1 2 1
+            1 1 1 1
+        ]
+        AG.write!(source, diagonal)
+        AG.sievefilter!(source, destination, 2)
+        @test AG.read(destination) == ones(Int32, 4, 4)
+
+        AG.sievefilter!(source, destination, 2; connectedness = 8)
+        @test AG.read(destination) == diagonal
+
+        AG.write!(mask, ones(Int32, 4, 4))
+        masked = copy(input)
+        masked[2, 2] = 0
+        AG.write!(mask, Int32.(masked .!= 0))
+        AG.fillraster!(destination, 9)
+        AG.sievefilter!(source, destination, 2; mask)
+        @test AG.read(destination) == Int32[
+            1 1 1 1
+            1 2 1 1
+            1 1 1 1
+            1 1 1 1
+        ]
+
+        AG.write!(source, input)
+        @test AG.sievefilter!(source, 2) === source
+        @test AG.read(source)[2, 2] == 1
+
+        @test_throws ArgumentError AG.sievefilter!(
+            source,
+            destination,
+            2;
+            connectedness = 6,
+        )
+    end
+end


### PR DESCRIPTION
Adds a high-level sievefilter! wrapper with mask and connectivity support.

Closes #431.