### PR TITLE
Implement copy and deepcopy for geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ArchGDAL added `subdatasets` to list the filenames of a dataset's subdatasets. [#489](https://github.com/yeesian/ArchGDAL.jl/pull/489)
+- `Base.copy` and `Base.deepcopy` clone geometries and re-prepare prepared geometries, instead of producing a wrapper that aliases the original's GDAL handle without a finalizer. [#506](https://github.com/yeesian/ArchGDAL.jl/pull/506)
 
 ### Fixed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JuliaFormatter formatted the Julia source and tests. [#495](https://github.com/yeesian/ArchGDAL.jl/pull/495), [#502](https://github.com/yeesian/ArchGDAL.jl/pull/502)
+- `PreparedGeometry` and `IPreparedGeometry` gained a `basegeom` field holding the geometry they were prepared from, since GDAL exposes no way to recover it from an `OGRPreparedGeometryH`. [#506](https://github.com/yeesian/ArchGDAL.jl/pull/506)
 
 ## [0.10.12] - 2026-08-13
 

--- a/docs/src/geometries.md
+++ b/docs/src/geometries.md
@@ -116,6 +116,7 @@ The following predicates return a `Bool`.
 The following methods do not modify `geom`.
 
 * [`ArchGDAL.clone(geom)`](@ref): a copy of the geometry with the original spatial reference system.
+* `copy(geom)` and `deepcopy(geom)`: like `ArchGDAL.clone`, but type-preserving. `ArchGDAL.clone` always returns an `IGeometry`, whereas these return the same wrapper type as `geom`, so copying a `Geometry` gives back a `Geometry` you are responsible for destroying. Both give the copy its own GDAL handle, so a copy stays valid after the original is destroyed.
 * [`ArchGDAL.forceto(geom, targettype)`](@ref): force the provided geometry to the specified geometry type.
 * [`ArchGDAL.simplify(geom, tol)`](@ref): Compute a simplified geometry.
 * [`ArchGDAL.simplifypreservetopology(geom, tol)`](@ref): Simplify the geometry while preserving topology.

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -111,11 +111,52 @@ function clone(geom::AbstractGeometry{T}) where {T}
     end
 end
 
-Base.copy(geom::AbstractGeometry) = clone(geom)
+# Clone `geom` into a `W{T}` wrapper, preserving the geometry type parameter.
+# `clone` and `unsafe_clone` collapse NULL geometries to `wkbUnknown`, which
+# `Base.deepcopy` rejects: it asserts that `deepcopy_internal` returns a value
+# of the same type as its argument.
+function _clonegeom(::Type{W}, geom::AbstractGeometry{T}) where {W,T}
+    return W{T}(
+        geom.ptr == C_NULL ? GDAL.OGRGeometryH(C_NULL) : GDAL.ogr_g_clone(geom),
+    )
+end
 
+"""
+    copy(geom::AbstractGeometry)
+
+Returns a copy of the geometry with the original spatial reference system.
+
+The copy owns a separate GDAL handle, so mutating it leaves `geom` untouched.
+The result has the same Julia type as `geom`: copying a `Geometry` yields a
+`Geometry`, which the caller is responsible for destroying.
+
+Copying an `AbstractPreparedGeometry` re-prepares a copy of the geometry it was
+built from, since GDAL exposes no way to clone a prepared geometry directly.
+"""
+Base.copy(geom::IGeometry) = _clonegeom(IGeometry, geom)
+
+Base.copy(geom::Geometry) = _clonegeom(Geometry, geom)
+
+function Base.copy(geom::IPreparedGeometry)
+    return preparegeom(_clonegeom(IGeometry, geom.basegeom))
+end
+
+# The copy owns its base geometry either way: it is an internal detail the
+# caller never sees, so `destroy`ing the returned `PreparedGeometry` must not
+# leak it.
+function Base.copy(geom::PreparedGeometry)
+    return unsafe_preparegeom(_clonegeom(IGeometry, geom.basegeom))
+end
+
+# Without this, `deepcopy` falls back to `jl_new_struct_uninit`, which copies
+# the `ptr` field verbatim (it is a bitstype) and bypasses the inner
+# constructor. The result would alias the original's GDAL handle *and* carry no
+# finalizer, leaving a dangling pointer once the original is collected.
 function Base.deepcopy_internal(geom::AbstractGeometry, stackdict::IdDict)
     haskey(stackdict, geom) && return stackdict[geom]
-    geomcopy = clone(geom)
+    # `Base.copy` qualified: ArchGDAL defines its own `copy` for datasets and
+    # feature layers, which shadows `Base.copy` inside the module.
+    geomcopy = Base.copy(geom)
     stackdict[geom] = geomcopy
     return geomcopy
 end
@@ -176,13 +217,17 @@ has_preparedgeom_support() = Bool(GDAL.ogrhaspreparedgeometrysupport())
 
 Create an prepared geometry of a geometry. This can speed up operations which interact
 with the geometry multiple times, by storing caches of calculated geometry information.
+
+The prepared geometry holds a reference to `geom`. GDAL builds its own GEOS copy,
+so this is only to keep the source available for `copy` and `deepcopy`, which
+re-prepare from it.
 """
 function preparegeom(geom::AbstractGeometry{T}) where {T}
-    return IPreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom))
+    return IPreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom), geom)
 end
 
 function unsafe_preparegeom(geom::AbstractGeometry{T}) where {T}
-    return PreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom))
+    return PreparedGeometry{T}(GDAL.ogrcreatepreparedgeometry(geom), geom)
 end
 
 """

--- a/src/ogr/geometry.jl
+++ b/src/ogr/geometry.jl
@@ -111,6 +111,15 @@ function clone(geom::AbstractGeometry{T}) where {T}
     end
 end
 
+Base.copy(geom::AbstractGeometry) = clone(geom)
+
+function Base.deepcopy_internal(geom::AbstractGeometry, stackdict::IdDict)
+    haskey(stackdict, geom) && return stackdict[geom]
+    geomcopy = clone(geom)
+    stackdict[geom] = geomcopy
+    return geomcopy
+end
+
 function unsafe_clone(geom::AbstractGeometry{T}) where {T}
     if geom.ptr == C_NULL
         return Geometry{wkbUnknown}()

--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,9 @@ abstract type AbstractGeometry{T} end
 # needs to have a `ptr::GDAL.OGRGeometryH` attribute
 
 abstract type AbstractPreparedGeometry{T} <: AbstractGeometry{T} end
-# needs to have a `ptr::GDAL.OGRPreparedGeometryH` attribute
+# needs to have a `ptr::GDAL.OGRPreparedGeometryH` attribute, and a
+# `basegeom::AbstractGeometry{T}` attribute holding the geometry it was
+# prepared from (GDAL exposes no way to recover it from the handle).
 
 abstract type AbstractSpatialRef end
 # needs to have a `ptr::GDAL.OGRSpatialReferenceH` attribute
@@ -274,13 +276,18 @@ _geomtype(::IGeometry{T}) where {T} = T
 
 mutable struct PreparedGeometry{T} <: AbstractPreparedGeometry{T}
     ptr::GDAL.OGRPreparedGeometryH
+    basegeom::AbstractGeometry{T}
 end
 
 mutable struct IPreparedGeometry{T} <: AbstractPreparedGeometry{T}
     ptr::GDAL.OGRPreparedGeometryH
+    basegeom::AbstractGeometry{T}
 
-    function IPreparedGeometry{T}(ptr::GDAL.OGRPreparedGeometryH) where {T}
-        geom = new{T}(ptr)
+    function IPreparedGeometry{T}(
+        ptr::GDAL.OGRPreparedGeometryH,
+        basegeom::AbstractGeometry{T},
+    ) where {T}
+        geom = new{T}(ptr, basegeom)
         finalizer(destroy, geom)
         return geom
     end

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -998,6 +998,46 @@ import JLD2
         AG.clone(geom) do g
             @test sprint(print, g) == "NULL Geometry"
         end
+
+        # `clone` collapses a NULL geometry to `wkbUnknown`, but `deepcopy`
+        # asserts that its result has the same type as its argument.
+        typednull = AG.IGeometry{AG.wkbPoint}(C_NULL)
+        @test copy(typednull) isa AG.IGeometry{AG.wkbPoint}
+        @test deepcopy(typednull) isa AG.IGeometry{AG.wkbPoint}
+        @test sprint(print, deepcopy(typednull)) == "NULL Geometry"
+    end
+
+    @testset "copy and deepcopy" begin
+        # Without a `deepcopy_internal` method, Julia's fallback copies the
+        # `ptr` field verbatim and skips the inner constructor, so the result
+        # would alias the original handle and carry no finalizer.
+        geom =
+            AG.createpolygon([(0.0, 0.0), (0.0, 4.0), (4.0, 0.0), (0.0, 0.0)])
+        for geomcopy in (copy(geom), deepcopy(geom))
+            @test geomcopy isa AG.IGeometry{AG.wkbPolygon}
+            @test geomcopy.ptr != geom.ptr
+            @test AG.equals(geomcopy, geom)
+        end
+
+        # `copy` is type-preserving: a caller-managed `Geometry` copies to a
+        # `Geometry`, not to an `IGeometry`. `deepcopy` errors otherwise.
+        unsafegeom = AG.unsafe_createpoint(1.0, 2.0)
+        unsafecopy = copy(unsafegeom)
+        unsafedeepcopy = deepcopy(unsafegeom)
+        @test unsafecopy isa AG.Geometry{AG.wkbPoint}
+        @test unsafedeepcopy isa AG.Geometry{AG.wkbPoint}
+        @test unsafecopy.ptr != unsafegeom.ptr
+        @test unsafedeepcopy.ptr != unsafegeom.ptr
+        @test AG.equals(unsafecopy, unsafegeom)
+        AG.destroy.((unsafegeom, unsafecopy, unsafedeepcopy))
+
+        # A copy must survive the original being freed.
+        original = AG.createpoint(3.0, 4.0)
+        survivor = deepcopy(original)
+        AG.destroy(original)
+        @test original.ptr == C_NULL
+        @test survivor.ptr != C_NULL
+        @test AG.toWKT(survivor) == "POINT (3 4)"
     end
 
     @testset "Test coordinate dimensions" begin

--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -843,6 +843,23 @@ import JLD2
             @test sprint(print, geom4) == "Geometry: POINT EMPTY"
         end
 
+        geomcopy = copy(geom3)
+        geomdeepcopy = deepcopy(geom3)
+        @test geomcopy isa AG.IGeometry{AG.wkbGeometryCollection25D}
+        @test geomdeepcopy isa AG.IGeometry{AG.wkbGeometryCollection25D}
+        @test geomcopy.ptr != geom3.ptr
+        @test geomdeepcopy.ptr != geom3.ptr
+        @test AG.equals(geomcopy, geom3)
+        @test AG.equals(geomdeepcopy, geom3)
+
+        repeated = deepcopy([geom3, geom3])
+        @test repeated[1] === repeated[2]
+        @test repeated[1].ptr != geom3.ptr
+
+        AG.removeallgeoms!(geomcopy)
+        @test AG.ngeom(geomcopy) == 0
+        @test AG.ngeom(geom3) == 4
+
         @test AG.toISOWKT(geom3) ==
               "GEOMETRYCOLLECTION Z (" *
               "POINT Z (2 5 8)," *
@@ -976,6 +993,8 @@ import JLD2
         geom = AG.IGeometry()
         @test AG.geomname(geom) === missing
         @test sprint(print, AG.clone(geom)) == "NULL Geometry"
+        @test sprint(print, copy(geom)) == "NULL Geometry"
+        @test sprint(print, deepcopy(geom)) == "NULL Geometry"
         AG.clone(geom) do g
             @test sprint(print, g) == "NULL Geometry"
         end

--- a/test/test_prepared_geometry.jl
+++ b/test/test_prepared_geometry.jl
@@ -25,4 +25,38 @@ import ArchGDAL as AG
     or1 = AG.contains(polygon, point)
     or2 = AG.contains(prep_polygon, point)
     @test or1 === or2
+
+    @testset "copy and deepcopy" begin
+        # GDAL exposes no clone for OGRPreparedGeometryH and no way to recover
+        # the source geometry from the handle, so a prepared geometry keeps a
+        # reference to what it was prepared from and copies re-prepare from it.
+        @test prep_polygon.basegeom === polygon
+
+        for prep_copy in (copy(prep_polygon), deepcopy(prep_polygon))
+            @test prep_copy isa AG.IPreparedGeometry{AG.wkbPolygon}
+            @test prep_copy.ptr != prep_polygon.ptr
+            # the copy owns its base geometry, rather than sharing `polygon`
+            @test prep_copy.basegeom isa AG.IGeometry{AG.wkbPolygon}
+            @test prep_copy.basegeom !== polygon
+            @test prep_copy.basegeom.ptr != polygon.ptr
+            @test AG.equals(prep_copy.basegeom, polygon)
+            @test AG.intersects(prep_copy, point) === ir1
+            @test AG.contains(prep_copy, point) === or1
+        end
+
+        # a copy stays usable after the geometry it was prepared from is gone
+        survivor = deepcopy(prep_polygon)
+        AG.destroy(polygon)
+        @test AG.intersects(survivor, point) === ir1
+
+        # `copy` is type-preserving here too: the caller-managed
+        # `PreparedGeometry` copies to a `PreparedGeometry`
+        unsafe_prep = AG.unsafe_preparegeom(survivor.basegeom)
+        unsafe_copy = copy(unsafe_prep)
+        @test unsafe_copy isa AG.PreparedGeometry{AG.wkbPolygon}
+        @test unsafe_copy.ptr != unsafe_prep.ptr
+        @test AG.intersects(unsafe_copy, point) === ir1
+        AG.destroy(unsafe_copy)
+        AG.destroy(unsafe_prep)
+    end
 end


### PR DESCRIPTION
## Summary

- implement Base.copy for ArchGDAL geometries using clone
- implement the deepcopy hook using the same clone operation
- preserve repeated references when geometries are nested in deeply copied containers
- cover independent handles, mutation isolation, and NULL geometries

Fixes #452.

## Testing

- test_geometry.jl: 273/273 passed
- full suite: 1,978 passed; 3 environment-related errors from SQLite driver initialization and SSL certificate validation